### PR TITLE
[ci] Measure per-test runtime and sample a weekly fast lane

### DIFF
--- a/.github/workflows/core-set.yml
+++ b/.github/workflows/core-set.yml
@@ -1,0 +1,92 @@
+name: Core set
+
+# Builds the fast lane's always-run core set (esbmc/esbmc#6735): the tests that
+# run on every PR regardless of the week's random sample. Rather than curating
+# it by hand, it is solved for -- greedy weighted set cover over each test's own
+# line coverage, picking the most lines reached per second of runtime.
+#
+# Monthly, because it costs one llvm-cov export per test over an instrumented
+# binary. The `select` step is cheap and can be re-run against a stored
+# collection with a different budget via workflow_dispatch.
+
+on:
+  schedule:
+    # 06:00 on the 1st, clear of the 02:00 nightly coverage job that shares
+    # this runner pool.
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+    inputs:
+      budget-seconds:
+        description: "Wall-clock the core set may occupy in the fast lane"
+        default: '180'
+        type: string
+      target:
+        description: "Stop once this fraction of reachable lines is covered"
+        default: '0.95'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  core-set:
+    name: Solve the coverage cover
+    runs-on: ['self-hosted', 'Linux', 'x64', 'cov']
+    timeout-minutes: 720
+    steps:
+      - uses: actions/checkout@v6
+
+      # -k ON also sets CORE_REGRESSION_ONLY, which is what we want here: the
+      # always-run set should not contain KNOWNBUG/FUTURE tests.
+      - name: Build with coverage instrumentation
+        run: ./scripts/build.sh -b Debug -k ON
+
+      # Only affects test properties, so this reconfigure costs no rebuild.
+      - name: Split the profiles per test
+        run: cmake -DENABLE_PER_TEST_COVERAGE=ON build
+
+      - name: Run the full suite
+        run: cd build && ctest -j"$(nproc)" --timeout 600 . || true
+
+      - name: Reduce the profiles to per-test line sets
+        run: |
+          python3 scripts/ci/coverage_core_set.py collect \
+            --profiles build/per-test-profiles \
+            --binary build/src/esbmc/esbmc \
+            --output "$RUNNER_TEMP/coverage" \
+            --jobs "$(nproc)"
+
+      - name: Solve for the core set
+        run: |
+          python3 scripts/ci/coverage_core_set.py select \
+            --coverage "$RUNNER_TEMP/coverage" \
+            --timings ci/test-timings.json \
+            --budget-seconds "${{ inputs.budget-seconds || '180' }}" \
+            --target "${{ inputs.target || '0.95' }}" \
+            --jobs 2 \
+            --output ci/core-set.txt \
+            --report "$GITHUB_STEP_SUMMARY"
+
+      - name: Save the line sets
+        # Keeps `select` re-runnable at a different budget without re-measuring.
+        uses: actions/upload-artifact@v7
+        with:
+          name: per-test-coverage
+          path: ${{ runner.temp }}/coverage
+          retention-days: 14
+
+      - name: Clean up temp directories
+        if: always()
+        run: rm -rf build/per-test-profiles /tmp/esbmc-headers-* /tmp/esbmc-test-*
+
+      - name: Commit the core set
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: '[ci] refresh the coverage-derived core set'
+          file_pattern: ci/core-set.txt
+          commit_user_name: 'github-actions'
+          commit_user_email: 'github-actions@github.com'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,8 @@ jobs:
     - uses: actions/checkout@v6
     - name: Runs testing tool unit test
       run: cd regression && python3 testing_tool_test.py
+    - name: Runs fast-lane CI script tests
+      run: python3 scripts/ci/ci_scripts_test.py
 
   build-ubuntu:
     uses: ./.github/workflows/build-unix.yml

--- a/.github/workflows/test-timings.yml
+++ b/.github/workflows/test-timings.yml
@@ -1,0 +1,92 @@
+name: Test timings
+
+# Step 1 of the CI overhaul in esbmc/esbmc#6735: measure how long each test
+# actually takes, so the per-PR fast lane can size its sample by wall-clock
+# instead of by test count. Nothing downstream can be sized without this.
+#
+# It also freezes the week's fast-lane selection: the first run of an ISO week
+# writes ci/selected-tests-<year>-W<week>.txt and later runs leave it alone, so
+# every PR opened that week sees the same list.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  # The budget the fast lane is being sized for, and the parallelism the PR
+  # Linux leg actually runs at (-j2, bounded by runner memory -- see the
+  # comment in build-unix.yml).
+  FAST_LANE_BUDGET_SECONDS: 900
+  FAST_LANE_JOBS: 2
+
+jobs:
+  measure:
+    name: Measure the full suite
+    runs-on: ['self-hosted', 'Linux', 'x64', 'benchexec']
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v6
+
+      # Same configuration as the PR Linux leg, so the durations describe the
+      # binary the fast lane will actually run.
+      - name: Build ESBMC
+        run: ./scripts/build.sh -b DebugOpt -e ON
+
+      - name: Run the full suite
+        # Failures are the nightly gate's business (tier 2), not this job's:
+        # a red suite still yields valid timings.
+        run: |
+          cd build
+          ctest -j"$(nproc)" --output-junit "$RUNNER_TEMP/junit.xml" . || true
+
+      - name: Update the timing table
+        # --merge so a partial run narrows the table's freshness rather than
+        # dropping every test it did not reach, and so a test skipped on this
+        # host keeps the duration an earlier run measured.
+        run: |
+          python3 scripts/ci/ctest_timings.py \
+            --junit "$RUNNER_TEMP/junit.xml" \
+            --output ci/test-timings.json \
+            --merge \
+            --commit "${{ github.sha }}" \
+            --runner "${{ runner.name }}" \
+            --jobs "$(nproc)"
+
+      - name: Freeze this week's fast-lane selection
+        run: |
+          week=$(python3 -c 'import datetime; y,w,_ = datetime.date.today().isocalendar(); print(f"{y}-W{w:02d}")')
+          out="ci/selected-tests-$week.txt"
+          if [ -f "$out" ]; then
+            echo "$out already exists; leaving this week's selection frozen."
+            exit 0
+          fi
+          python3 scripts/ci/select_tests.py \
+            --timings ci/test-timings.json \
+            --week "$week" \
+            --budget-seconds "$FAST_LANE_BUDGET_SECONDS" \
+            --jobs "$FAST_LANE_JOBS" \
+            --always-run ci/core-set.txt \
+            --output "$out" \
+            --summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Clean up temp directories
+        if: always()
+        run: rm -rf /tmp/esbmc-headers-* /tmp/esbmc-test-*
+
+      - name: Commit the timing table and selection
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: '[ci] refresh per-test timings'
+          file_pattern: |
+            ci/test-timings.json
+            ci/selected-tests-*.txt
+          commit_user_name: 'github-actions'
+          commit_user_email: 'github-actions@github.com'

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,53 @@
+# Fast-lane CI data
+
+Data behind the two-tier CI of [#6735](https://github.com/esbmc/esbmc/issues/6735).
+Everything here is generated and committed by a workflow; nothing is hand-edited.
+
+Rollout steps 1 and 2 only — **no PR check consumes these files yet**. The PR
+lane still runs the full suite.
+
+| File | Written by | What it is |
+| --- | --- | --- |
+| `test-timings.json` | `test-timings.yml` (nightly) | measured duration of every test |
+| `selected-tests-<year>-W<week>.txt` | `test-timings.yml` (first run of the week) | the week's fast-lane sample |
+| `core-set.txt` | `core-set.yml` (monthly) | always-run tests, solved from coverage |
+
+## Reproducing a fast-lane failure locally
+
+The selection is a pure function of the ISO week, so it is the same for every PR
+that week and can be regenerated exactly:
+
+```sh
+scripts/ci/select_tests.py --week 2026-W36 --output /tmp/selected.txt
+scripts/ci/run_selected_tests.py --build-dir build --tests /tmp/selected.txt --output-on-failure
+```
+
+`select_tests.py` defaults to `--budget-seconds 900 --jobs 2`, matching the PR
+Linux leg. Pass `--always-run ci/core-set.txt` to include the core set as CI
+does. Any argument `run_selected_tests.py` does not recognise is forwarded to
+`ctest`.
+
+## How the sample is drawn
+
+Tests are added until the projected wall-clock hits the budget — measured
+cumulative runtime, not a test count. Sampling is stratified twice: by suite
+(the ctest label), so no frontend or solver backend goes dark for a week, and
+within a suite by runtime tercile, so slow tests are not squeezed out by cheap
+ones. Every suite contributes at least one test even when its proportional share
+rounds to nothing.
+
+A test with no measurement yet — newly added, or skipped on the measuring host —
+is costed at its suite's median rather than zero, so an unmeasured suite cannot
+be sampled without bound.
+
+## Caveats
+
+- **Durations are relative, not absolute.** They are measured on a self-hosted
+  runner at full parallelism, while the PR lane runs `-j2` on a hosted runner.
+  `--packing-efficiency` absorbs the systematic part; shadow mode (rollout step
+  3) is where the projection gets checked against reality.
+- **Deleted tests linger** in `test-timings.json`, because the nightly merges
+  rather than replaces. `run_selected_tests.py` reports and ignores selected
+  tests that the build does not contain.
+- **`core-set.txt` is built from a `CORE_REGRESSION_ONLY` coverage build**, so
+  `KNOWNBUG` and `FUTURE` tests are never candidates for the always-run set.

--- a/ci/core-set.txt
+++ b/ci/core-set.txt
@@ -1,0 +1,5 @@
+# Coverage-derived always-run core set (esbmc/esbmc#6735).
+#
+# Solved by .github/workflows/core-set.yml -- greedy weighted set cover over
+# per-test line coverage. Empty until its first run; the fast lane then falls
+# back to the stratified random sample alone.

--- a/ci/test-timings.json
+++ b/ci/test-timings.json
@@ -1,0 +1,8 @@
+{
+ "generated": "",
+ "schema": 1,
+ "source": {
+  "note": "Populated by .github/workflows/test-timings.yml; empty until its first run."
+ },
+ "tests": {}
+}

--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -35,6 +35,35 @@ set(ESBMC_REGRESS_MEMORY_LIMIT 8192 CACHE STRING
 option(ENABLE_SANITIZER_CI
     "Restrict regression to CORE mode for sanitizer-instrumented CI runs" OFF)
 
+# The fast lane's always-run core set is derived by greedy set cover over
+# per-test line coverage (esbmc/esbmc#6735), which needs each test's profile
+# kept apart instead of merged into one repo-wide total. Off by default: it
+# only makes sense on an ENABLE_COVERAGE build and costs a directory per test.
+option(ENABLE_PER_TEST_COVERAGE
+    "Write one LLVM raw profile per regression test, for the core-set build" OFF)
+set(ESBMC_PER_TEST_PROFILE_DIR "${CMAKE_BINARY_DIR}/per-test-profiles" CACHE PATH
+    "Directory ENABLE_PER_TEST_COVERAGE writes each test's raw profiles under")
+
+# Compute the LLVM_PROFILE_FILE entry to append to a test's ENVIRONMENT, or an
+# empty string when per-test coverage is off. '/' cannot appear in a directory
+# name and no ctest name contains '@', so the substitution is reversible --
+# scripts/ci/coverage_core_set.py reverses it to recover the test name.
+#
+# %m, not %p: a single test.desc runs ESBMC several times, and %m merges those
+# runs into one file per binary online instead of leaving one raw profile per
+# process. Over the whole suite that is the difference between a manageable
+# profile tree and tens of gigabytes of it. The profile runtime creates the
+# directory itself, so nothing here needs to.
+function(esbmc_per_test_profile_env out test_name)
+    if(NOT ENABLE_PER_TEST_COVERAGE)
+        set(${out} "" PARENT_SCOPE)
+        return()
+    endif()
+    string(REPLACE "/" "@" _profile_dir "${test_name}")
+    set(${out} ";LLVM_PROFILE_FILE=${ESBMC_PER_TEST_PROFILE_DIR}/${_profile_dir}/%m.profraw"
+        PARENT_SCOPE)
+endfunction()
+
 if(BENCHBRINGUP)
   # To run a specific benchmark in Github workflow and download the log archive when completed
   #   - BENCHMARK_TO_RUN: user-specified benchmark to run
@@ -118,10 +147,11 @@ function(add_esbmc_regression_test folder modes test)
                      --capabilities=${ESBMC_TEST_CAPABILITIES_ARG}
                      ${BENCHBRINGUP_ARGS}) # additional args for BENCHBRINGUP workflow
     # Timeout and memory limit are passed via environment
+    esbmc_per_test_profile_env(profile_env "${test_name}")
     set_tests_properties(${test_name}
       PROPERTIES SKIP_RETURN_CODE 10
       TIMEOUT ${ESBMC_REGRESS_CTEST_TIMEOUT}
-      ENVIRONMENT "ESBMC_REGRESS_TIMEOUT=${ESBMC_REGRESS_TIMEOUT};ESBMC_REGRESS_MEMORY_LIMIT=${ESBMC_REGRESS_MEMORY_LIMIT}"
+      ENVIRONMENT "ESBMC_REGRESS_TIMEOUT=${ESBMC_REGRESS_TIMEOUT};ESBMC_REGRESS_MEMORY_LIMIT=${ESBMC_REGRESS_MEMORY_LIMIT}${profile_env}"
       LABELS "regression;${folder}/${extra_labels}")
 endfunction()
 
@@ -703,17 +733,21 @@ foreach(_t IN LISTS _slow_regression_tests)
         #    decides "no SUCCESSFUL printed -> KNOWNBUG satisfied".
         # The outer must comfortably exceed the inner so testing_tool
         # wins the race (kill + grace + regex check time).
+        # This resets ENVIRONMENT wholesale, so re-add the per-test profile
+        # entry add_esbmc_regression_test put there.
+        esbmc_per_test_profile_env(profile_env "${_t}")
         set_tests_properties(${_t} PROPERTIES
           TIMEOUT ${ESBMC_REGRESS_CTEST_TIMEOUT_SLOW}
-          ENVIRONMENT "ESBMC_REGRESS_TIMEOUT=${ESBMC_REGRESS_TIMEOUT_SLOW};ESBMC_REGRESS_MEMORY_LIMIT=${ESBMC_REGRESS_MEMORY_LIMIT}"
+          ENVIRONMENT "ESBMC_REGRESS_TIMEOUT=${ESBMC_REGRESS_TIMEOUT_SLOW};ESBMC_REGRESS_MEMORY_LIMIT=${ESBMC_REGRESS_MEMORY_LIMIT}${profile_env}"
         )
     endif()
 endforeach()
 foreach(_t IN LISTS _very_slow_regression_tests)
     if(TEST ${_t})
+        esbmc_per_test_profile_env(profile_env "${_t}")
         set_tests_properties(${_t} PROPERTIES
           TIMEOUT ${ESBMC_REGRESS_CTEST_TIMEOUT_VERY_SLOW}
-          ENVIRONMENT "ESBMC_REGRESS_TIMEOUT=${ESBMC_REGRESS_TIMEOUT_VERY_SLOW};ESBMC_REGRESS_MEMORY_LIMIT=${ESBMC_REGRESS_MEMORY_LIMIT}"
+          ENVIRONMENT "ESBMC_REGRESS_TIMEOUT=${ESBMC_REGRESS_TIMEOUT_VERY_SLOW};ESBMC_REGRESS_MEMORY_LIMIT=${ESBMC_REGRESS_MEMORY_LIMIT}${profile_env}"
         )
     endif()
 endforeach()

--- a/scripts/ci/ci_scripts_test.py
+++ b/scripts/ci/ci_scripts_test.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Tests for the fast-lane CI scripts (esbmc/esbmc#6735).
+
+Run with: python3 scripts/ci/ci_scripts_test.py
+
+Everything here works on real files in a temporary directory; no mocks, per the
+repository's testing rules.
+"""
+
+# Test names carry the intent, so per-method docstrings would only restate them;
+# the sibling imports must follow the sys.path setup below.
+# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=wrong-import-position,invalid-name
+
+import base64
+import gzip
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+import zlib
+from datetime import date
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import coverage_core_set as ccs  # noqa: E402
+import ctest_timings as timings  # noqa: E402
+import run_selected_tests as runner  # noqa: E402
+import select_tests as sel  # noqa: E402
+
+JUNIT = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Linux-c++" tests="3">
+  <testcase name="regression/esbmc/alpha" time="1.500" status="run">
+    <system-out>lots of output</system-out>
+  </testcase>
+  <testcase name="regression/python/beta" time="0.250" status="fail">
+    <failure message="boom">trace</failure>
+  </testcase>
+  <testcase name="regression/python/gamma" time="0.001" status="run">
+    <skipped/>
+  </testcase>
+</testsuite>
+"""
+
+
+class TempDirCase(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
+        self.tmp = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, name, text):
+        path = os.path.join(self.tmp, name)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        return path
+
+
+class CtestTimings(TempDirCase):
+
+    def test_parses_time_and_status(self):
+        parsed = dict((n, (s, st)) for n, s, st in timings.parse_junit(self.write("j.xml", JUNIT)))
+        self.assertEqual(parsed["regression/esbmc/alpha"], (1.5, "run"))
+        self.assertEqual(parsed["regression/python/beta"], (0.25, "fail"))
+        self.assertEqual(parsed["regression/python/gamma"][1], "skip")
+
+    def test_merge_keeps_untouched_entries(self):
+        previous = {"tests": {"regression/z3/old": {"seconds": 9.0, "status": "run"}}}
+        _, table = timings.build_table(self.write("j.xml", JUNIT), previous)
+        self.assertEqual(table["tests"]["regression/z3/old"]["seconds"], 9.0)
+        self.assertEqual(table["tests"]["regression/esbmc/alpha"]["seconds"], 1.5)
+
+    def test_skip_does_not_erase_a_real_measurement(self):
+        # A test skipped on this host must keep the duration another host
+        # measured, or the sampler would treat it as free.
+        previous = {"tests": {"regression/python/gamma": {"seconds": 42.0, "status": "run"}}}
+        _, table = timings.build_table(self.write("j.xml", JUNIT), previous)
+        self.assertEqual(table["tests"]["regression/python/gamma"]["seconds"], 42.0)
+
+    def test_empty_report_is_an_error(self):
+        empty = self.write("e.xml", '<?xml version="1.0"?><testsuite tests="0"/>')
+        out = os.path.join(self.tmp, "t.json")
+        self.assertEqual(timings.main(["--junit", empty, "--output", out]), 1)
+        self.assertFalse(os.path.exists(out))
+
+    def test_writes_sorted_table(self):
+        out = os.path.join(self.tmp, "t.json")
+        self.assertEqual(timings.main(["--junit", self.write("j.xml", JUNIT), "--output", out]), 0)
+        with open(out, encoding="utf-8") as fh:
+            table = json.load(fh)
+        self.assertEqual(list(table["tests"]), sorted(table["tests"]))
+        self.assertEqual(table["schema"], timings.SCHEMA)
+
+
+class Strata(unittest.TestCase):
+
+    def test_two_and_three_level_regression_names(self):
+        self.assertEqual(sel.stratum_of("regression/esbmc/foo"), "esbmc")
+        self.assertEqual(sel.stratum_of("regression/esbmc-cpp/cpp/foo"), "esbmc-cpp/cpp")
+        self.assertEqual(sel.stratum_of("regression/z3/foo[bitwuzla]"), "z3")
+
+    def test_unit_tests_are_their_own_stratum(self):
+        self.assertEqual(sel.stratum_of("Interval templates division"), "unit")
+        self.assertEqual(sel.stratum_of("regression/orphan"), "unit")
+
+    def test_iso_week_format(self):
+        self.assertEqual(sel.iso_week(date(2026, 8, 31)), "2026-W36")
+        self.assertEqual(sel.iso_week(date(2026, 1, 1)), "2026-W01")
+
+
+class Costs(unittest.TestCase):
+
+    def test_unknown_test_takes_its_own_suites_median(self):
+        names = ["regression/a/x", "regression/a/y", "regression/a/new", "regression/b/z"]
+        measured = {"regression/a/x": 2.0, "regression/a/y": 4.0, "regression/b/z": 100.0}
+        costs = sel.impute_costs(names, measured)
+        self.assertEqual(costs["regression/a/new"], 3.0)
+
+    def test_unknown_suite_falls_back_to_the_global_median(self):
+        costs = sel.impute_costs(["regression/a/x", "regression/new/y"], {"regression/a/x": 7.0})
+        self.assertEqual(costs["regression/new/y"], 7.0)
+
+    def test_a_zero_measurement_is_floored(self):
+        costs = sel.impute_costs(["regression/a/x"], {"regression/a/x": 0.0})
+        self.assertEqual(costs["regression/a/x"], sel.MIN_COST)
+
+    def test_no_measurements_at_all_still_gives_a_nonzero_cost(self):
+        costs = sel.impute_costs(["regression/a/x"], {})
+        self.assertEqual(costs["regression/a/x"], sel.FALLBACK_COST)
+
+
+def universe(suites=6, per_suite=60):
+    return [f"regression/suite{s}/test{i}" for s in range(suites) for i in range(per_suite)]
+
+
+def costs_for(names):
+    # Spread costs so the runtime terciles are meaningfully different.
+    return {n: 0.5 + (i % 10) for i, n in enumerate(names)}
+
+
+class Selection(unittest.TestCase):
+
+    def setUp(self):
+        self.names = universe()
+        self.costs = costs_for(self.names)
+
+    def test_same_week_is_reproducible(self):
+        a, _ = sel.select(self.names, self.costs, [], 400.0, "2026-W36")
+        b, _ = sel.select(self.names, self.costs, [], 400.0, "2026-W36")
+        self.assertEqual(a, b)
+
+    def test_a_different_week_rolls_a_different_sample(self):
+        a, _ = sel.select(self.names, self.costs, [], 400.0, "2026-W36")
+        b, _ = sel.select(self.names, self.costs, [], 400.0, "2026-W37")
+        self.assertNotEqual(a, b)
+
+    def test_stays_within_budget(self):
+        for budget in (200.0, 400.0, 900.0):
+            _, stats = sel.select(self.names, self.costs, [], budget, "2026-W36")
+            self.assertLessEqual(stats["cpu_seconds"], budget, f"budget {budget}")
+
+    def test_no_suite_goes_untested(self):
+        # The whole point of stratifying. The budget here is smaller than any
+        # single test, so proportional allocation alone would select nothing:
+        # only the guaranteed one-per-stratum draw keeps every area covered.
+        selected, _ = sel.select(self.names, self.costs, [], 1.0, "2026-W36")
+        suites = {sel.stratum_of(n) for n in self.names}
+        self.assertEqual({sel.stratum_of(n) for n in selected}, suites)
+        self.assertEqual(len(selected), len(suites))
+
+    def test_slow_tests_are_not_squeezed_out(self):
+        selected, _ = sel.select(self.names, self.costs, [], 600.0, "2026-W36")
+        slowest = max(self.costs.values())
+        self.assertTrue(any(self.costs[n] >= slowest - 1 for n in selected))
+
+    def test_core_set_is_always_present(self):
+        core = ["regression/suite0/test0", "regression/suite3/test7"]
+        selected, stats = sel.select(self.names, self.costs, core, 5.0, "2026-W36")
+        self.assertTrue(set(core) <= set(selected))
+        self.assertEqual(stats["always_run"], 2)
+
+    def test_core_set_entries_absent_from_the_build_are_dropped(self):
+        selected, stats = sel.select(self.names, self.costs, ["regression/gone/test0"], 50.0,
+                                     "2026-W36")
+        self.assertNotIn("regression/gone/test0", selected)
+        self.assertEqual(stats["always_run"], 0)
+
+    def test_a_bigger_budget_selects_more(self):
+        small, _ = sel.select(self.names, self.costs, [], 100.0, "2026-W36")
+        large, _ = sel.select(self.names, self.costs, [], 800.0, "2026-W36")
+        self.assertGreater(len(large), len(small))
+
+    def test_growing_one_suite_does_not_reshuffle_another(self):
+        grown = self.names + [f"regression/suite9/test{i}" for i in range(40)]
+        costs = costs_for(grown)
+        base_seed = [n for n in sel.select(self.names, self.costs, [], 0.0, "2026-W36")[0]
+                     if sel.stratum_of(n) == "suite0"]
+        grown_seed = [n for n in sel.select(grown, costs, [], 0.0, "2026-W36")[0]
+                      if sel.stratum_of(n) == "suite0"]
+        self.assertEqual(base_seed, grown_seed)
+
+    def test_a_suite_measured_entirely_at_zero_does_not_divide_by_zero(self):
+        # Every test in suite0 skipped on the measuring host, so the whole
+        # stratum weighs nothing and its budget share is split by zero.
+        measured = {
+            n: (0.0 if sel.stratum_of(n) == "suite0" else self.costs[n])
+            for n in self.names
+        }
+        costs = sel.impute_costs(self.names, measured)
+        selected, _ = sel.select(self.names, costs, [], 400.0, "2026-W36")
+        self.assertTrue(any(sel.stratum_of(n) == "suite0" for n in selected))
+
+    def test_a_duplicated_core_set_entry_is_counted_once(self):
+        core = ["regression/suite0/test0", "regression/suite0/test0"]
+        _, stats = sel.select(self.names, self.costs, core, 50.0, "2026-W36")
+        self.assertEqual(stats["always_run"], 1)
+
+    def test_stats_cover_every_suite(self):
+        _, stats = sel.select(self.names, self.costs, [], 400.0, "2026-W36")
+        self.assertEqual(sum(v["total"] for v in stats["strata"].values()), len(self.names))
+        self.assertEqual(sum(v["selected"] for v in stats["strata"].values()), stats["selected"])
+
+
+class SelectorCli(TempDirCase):
+
+    def test_end_to_end(self):
+        names = universe(3, 20)
+        table = {
+            "schema": 1,
+            "tests": {n: {"seconds": c, "status": "run"} for n, c in costs_for(names).items()},
+        }
+        timings_path = self.write("t.json", json.dumps(table))
+        out = os.path.join(self.tmp, "selected.txt")
+        summary = os.path.join(self.tmp, "summary.md")
+        rc = sel.main([
+            "--timings", timings_path, "--week", "2026-W36", "--budget-seconds", "60", "--jobs",
+            "4", "--output", out, "--summary", summary
+        ])
+        self.assertEqual(rc, 0)
+        selected = sel.read_lines(out)
+        self.assertTrue(selected)
+        self.assertTrue(set(selected) <= set(names))
+        with open(summary, encoding="utf-8") as fh:
+            self.assertIn("Fast-lane selection", fh.read())
+
+    def test_comments_and_blanks_are_ignored(self):
+        path = self.write("l.txt", "# header\n\nregression/a/x\n  regression/a/y  # trailing\n")
+        self.assertEqual(sel.read_lines(path), ["regression/a/x", "regression/a/y"])
+
+    def test_empty_universe_is_an_error(self):
+        timings_path = self.write("t.json", json.dumps({"schema": 1, "tests": {}}))
+        rc = sel.main(["--timings", timings_path, "--output", os.path.join(self.tmp, "o.txt")])
+        self.assertEqual(rc, 1)
+
+
+class IndexResolution(unittest.TestCase):
+
+    def test_names_map_to_one_based_ctest_numbers(self):
+        names = ["alpha", "beta", "gamma"]
+        numbers, missing = runner.resolve(["gamma", "alpha"], names)
+        self.assertEqual(numbers, [1, 3])
+        self.assertEqual(missing, [])
+
+    def test_tests_absent_from_the_build_are_reported_not_dropped_silently(self):
+        numbers, missing = runner.resolve(["alpha", "nope"], ["alpha", "beta"])
+        self.assertEqual(numbers, [1])
+        self.assertEqual(missing, ["nope"])
+
+    def test_whole_suite_stays_inside_the_argument_limit(self):
+        # The reason -I is used instead of -R at all: a name alternation over
+        # this many tests is past MAX_ARG_STRLEN, an index list is not.
+        numbers = list(range(1, 15001))
+        spec = "0,0,0," + ",".join(str(n) for n in numbers)
+        self.assertLess(len(spec), runner.MAX_ARG_BYTES)
+
+
+class GreedyCover(unittest.TestCase):
+
+    def test_prefers_the_best_coverage_per_second(self):
+        bitsets = {"cheap": 0b1111, "dear": 0b11111111}
+        chosen, _ = ccs.greedy_cover(bitsets, {"cheap": 1.0, "dear": 10.0}, budget=100.0)
+        self.assertEqual(chosen[0], "cheap")
+
+    def test_covers_everything_reachable_when_the_budget_allows(self):
+        bitsets = {"a": 0b0011, "b": 0b1100, "c": 0b0110}
+        chosen, trail = ccs.greedy_cover(bitsets, {n: 1.0 for n in bitsets}, budget=100.0)
+        self.assertEqual(trail[-1], 1.0)
+        self.assertLessEqual(len(chosen), 3)
+
+    def test_skips_redundant_tests(self):
+        bitsets = {"a": 0b1111, "b": 0b0011, "c": 0b0001}
+        chosen, _ = ccs.greedy_cover(bitsets, {n: 1.0 for n in bitsets}, budget=100.0)
+        self.assertEqual(chosen, ["a"])
+
+    def test_respects_the_budget(self):
+        bitsets = {f"t{i}": 1 << i for i in range(20)}
+        costs = {n: 3.0 for n in bitsets}
+        chosen, _ = ccs.greedy_cover(bitsets, costs, budget=10.0)
+        self.assertEqual(len(chosen), 3)
+
+    def test_stops_at_the_coverage_target(self):
+        bitsets = {f"t{i}": 1 << i for i in range(100)}
+        chosen, trail = ccs.greedy_cover(bitsets, {n: 1.0 for n in bitsets}, 1e6, target=0.25)
+        self.assertEqual(len(chosen), 25)
+        self.assertAlmostEqual(trail[-1], 0.25)
+
+    def test_nothing_fits(self):
+        chosen, trail = ccs.greedy_cover({"a": 0b1}, {"a": 50.0}, budget=1.0)
+        self.assertEqual((chosen, trail), ([], []))
+
+    def test_no_coverage_at_all(self):
+        self.assertEqual(ccs.greedy_cover({"a": 0}, {"a": 1.0}, budget=10.0), ([], []))
+
+
+class CoverageIo(TempDirCase):
+
+    def test_bitsets_round_trip(self):
+        original = {"regression/a/x": (1 << 200) | 0b101, "regression/b/y": 0b11}
+        path = os.path.join(self.tmp, ccs.BITSETS)
+        with gzip.open(path, "wt", encoding="utf-8") as fh:
+            for name, bits in original.items():
+                raw = bits.to_bytes((bits.bit_length() + 7) // 8, "big")
+                blob = base64.b64encode(zlib.compress(raw)).decode("ascii")
+                fh.write(json.dumps({"test": name, "bits": blob}) + "\n")
+        self.assertEqual(ccs.load_bitsets(path), original)
+
+    def test_profile_directory_names_reverse_to_test_names(self):
+        self.assertEqual(ccs.unmangle("regression@esbmc-cpp@cpp@foo"),
+                         "regression/esbmc-cpp/cpp/foo")
+
+    def test_select_reports_an_error_with_no_coverage(self):
+        os.makedirs(os.path.join(self.tmp, "cov"), exist_ok=True)
+        with gzip.open(os.path.join(self.tmp, "cov", ccs.BITSETS), "wt", encoding="utf-8"):
+            pass
+        rc = ccs.main([
+            "select", "--coverage",
+            os.path.join(self.tmp, "cov"), "--timings",
+            self.write("t.json", json.dumps({"tests": {}})), "--output",
+            os.path.join(self.tmp, "core.txt")
+        ])
+        self.assertEqual(rc, 1)
+
+
+_TOOLCHAIN = []
+
+
+def _coverage_toolchain():
+    """Find a clang that can actually link an instrumented binary, plus its llvm tools.
+
+    Having clang on PATH is not enough: a packaged clang is routinely installed
+    without libclang_rt.profile, and only the link step says so.
+    """
+    if _TOOLCHAIN:
+        return _TOOLCHAIN[0]
+    _TOOLCHAIN.append(None)
+    for suffix in ("", "-23", "-21", "-20", "-19", "-18", "-17", "-16", "-15", "-14"):
+        tools = [shutil.which(f"{t}{suffix}") for t in ("clang", "llvm-cov", "llvm-profdata")]
+        if not all(tools):
+            continue
+        with tempfile.TemporaryDirectory() as tmp:
+            source = os.path.join(tmp, "probe.c")
+            with open(source, "w", encoding="utf-8") as fh:
+                fh.write("int main(void) { return 0; }\n")
+            probe = subprocess.run([
+                tools[0], "-fprofile-instr-generate", "-fcoverage-mapping", "-o",
+                os.path.join(tmp, "probe"), source
+            ],
+                                   capture_output=True,
+                                   check=False)
+        if probe.returncode == 0:
+            _TOOLCHAIN[0] = tools
+            return tools
+    return None
+
+
+@unittest.skipUnless(_coverage_toolchain(), "needs clang + llvm-cov + llvm-profdata")
+class CoverageCollection(TempDirCase):
+    """End-to-end over real llvm-cov output, from raw profiles to a core set."""
+
+    PROGRAM = """#include <stdlib.h>
+int a(void) { return 1; }
+int b(void) { return 2; }
+int c(void) { return 3; }
+int main(int argc, char **argv) {
+  int which = argc > 1 ? atoi(argv[1]) : 0;
+  if (which == 0) return a();
+  if (which == 1) return b();
+  return c();
+}
+"""
+
+    def setUp(self):
+        super().setUp()
+        self.clang, self.llvm_cov, self.llvm_profdata = _coverage_toolchain()
+        source = self.write("prog.c", self.PROGRAM)
+        self.binary = os.path.join(self.tmp, "prog")
+        build = subprocess.run(
+            [self.clang, "-fprofile-instr-generate", "-fcoverage-mapping", "-o", self.binary,
+             source],
+            capture_output=True,
+            text=True,
+            check=False)
+        if build.returncode:
+            self.skipTest(f"no usable profile runtime: {build.stderr.strip()[:120]}")
+
+        # Each "test" exercises a different branch, so their line sets differ.
+        self.profiles = os.path.join(self.tmp, "profiles")
+        for i in range(3):
+            env = dict(os.environ)
+            # %m, matching what ENABLE_PER_TEST_COVERAGE sets.
+            env["LLVM_PROFILE_FILE"] = os.path.join(self.profiles, f"regression@toy@case{i}",
+                                                    "%m.profraw")
+            subprocess.run([self.binary, str(i)], env=env, check=False)
+
+    def test_collect_then_select(self):
+        out = os.path.join(self.tmp, "cov")
+        rc = ccs.main([
+            "collect", "--profiles", self.profiles, "--binary", self.binary, "--output", out,
+            "--jobs", "1", "--exclude", "/nonexistent/", "--llvm-cov", self.llvm_cov,
+            "--llvm-profdata", self.llvm_profdata
+        ])
+        self.assertEqual(rc, 0)
+
+        bitsets = ccs.load_bitsets(os.path.join(out, ccs.BITSETS))
+        self.assertEqual(set(bitsets), {f"regression/toy/case{i}" for i in range(3)})
+        # Distinct branches must produce distinct line sets, or the cover is
+        # solving a degenerate problem.
+        self.assertEqual(len(set(bitsets.values())), 3)
+
+        core = os.path.join(self.tmp, "core-set.txt")
+        timings_path = self.write(
+            "t.json",
+            json.dumps({"tests": {n: {"seconds": 1.0} for n in bitsets}}))
+        rc = ccs.main([
+            "select", "--coverage", out, "--timings", timings_path, "--output", core,
+            "--budget-seconds", "30", "--jobs", "1"
+        ])
+        self.assertEqual(rc, 0)
+        self.assertEqual(set(sel.read_lines(core)), set(bitsets))
+
+    def test_a_test_that_wrote_no_profile_is_skipped(self):
+        os.makedirs(os.path.join(self.profiles, "regression@toy@crashed"))
+        out = os.path.join(self.tmp, "cov")
+        self.assertEqual(
+            ccs.main([
+                "collect", "--profiles", self.profiles, "--binary", self.binary, "--output", out,
+                "--jobs", "1", "--llvm-cov", self.llvm_cov, "--llvm-profdata", self.llvm_profdata
+            ]), 0)
+        self.assertNotIn("regression/toy/crashed", ccs.load_bitsets(os.path.join(out, ccs.BITSETS)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/ci/coverage_core_set.py
+++ b/scripts/ci/coverage_core_set.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Derive the fast lane's always-run core set from per-test line coverage.
+
+Randomly sampling the suite leaves gaps every week, so a small set of tests runs
+unconditionally on every PR. Rather than hand-picking it, this builds it the way
+esbmc/esbmc#6735 asks: take each test's own coverage and greedily solve a
+weighted set cover for the most lines reached per second of runtime.
+
+Two steps, because the measuring is expensive and the choosing is not:
+
+``collect``
+    Turn a tree of per-test raw profiles (ENABLE_PER_TEST_COVERAGE) into one
+    covered-line bitset per test. This is ~1 llvm-cov export per test over a
+    large binary, so it is a monthly self-hosted job, parallel over --jobs.
+
+``select``
+    Greedy cost-aware cover over those bitsets, emitting ci/core-set.txt. Cheap
+    enough to re-run with different budgets against a single collect.
+
+Line sets are carried as Python ints used as bitsets: 180k source lines is a
+22 kB int, so the whole suite is a few hundred MB in memory and each round of
+the greedy loop is a native AND plus popcount per candidate.
+"""
+
+import argparse
+import base64
+import gzip
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import zlib
+from concurrent.futures import ProcessPoolExecutor
+
+# Paths that are not ESBMC's own code and would distort the cover.
+DEFAULT_EXCLUDES = ("/usr/", "/build/")
+
+LINE_INDEX = "lines.txt.gz"
+BITSETS = "per-test-lines.jsonl.gz"
+
+
+def unmangle(dirname):
+    """Recover a ctest name from the profile directory ENABLE_PER_TEST_COVERAGE made."""
+    return dirname.replace("@", "/")
+
+
+def profile_dirs(root):
+    """Yield ``(test name, directory)`` for every per-test profile directory."""
+    for name in sorted(os.listdir(root)):
+        path = os.path.join(root, name)
+        if os.path.isdir(path):
+            yield unmangle(name), path
+
+
+def _lcov_lines(binary, profdata, llvm_cov, excludes):
+    """Return ``(all lines, covered lines)`` as ``file:line`` strings from an lcov export."""
+    out = subprocess.run(
+        [llvm_cov, "export", "-format=lcov", f"-instr-profile={profdata}", binary],
+        check=True,
+        capture_output=True,
+        text=True).stdout
+    every, covered = [], []
+    source = None
+    for line in out.splitlines():
+        if line.startswith("SF:"):
+            path = line[3:]
+            source = None if any(x in path for x in excludes) else path
+        elif line.startswith("DA:") and source:
+            number, _, count = line[3:].partition(",")
+            key = f"{source}:{number}"
+            every.append(key)
+            if count.strip() not in ("0", ""):
+                covered.append(key)
+    return every, covered
+
+
+def _merge(profraws, llvm_profdata, out):
+    subprocess.run([llvm_profdata, "merge", "-sparse", "-o", out] + profraws,
+                   check=True,
+                   capture_output=True)
+
+
+def _collect_one(job):  # pylint: disable=too-many-locals
+    """Worker: merge one test's profiles and return its covered lines as a bitset."""
+    name, directory, binary, llvm_cov, llvm_profdata, excludes, index = job
+    profraws = [
+        os.path.join(directory, f) for f in os.listdir(directory) if f.endswith(".profraw")
+    ]
+    if not profraws:
+        return name, None
+    with tempfile.TemporaryDirectory() as tmp:
+        profdata = os.path.join(tmp, "test.profdata")
+        try:
+            _merge(profraws, llvm_profdata, profdata)
+            _, covered = _lcov_lines(binary, profdata, llvm_cov, excludes)
+        except subprocess.CalledProcessError:
+            # A test that crashed the profile writer leaves a truncated raw
+            # profile. Drop it rather than failing the whole collection.
+            return name, None
+    bits = 0
+    for key in covered:
+        position = index.get(key)
+        if position is not None:
+            bits |= 1 << position
+    if not bits:
+        return name, None
+    length = (bits.bit_length() + 7) // 8
+    return name, base64.b64encode(zlib.compress(bits.to_bytes(length, "big"))).decode("ascii")
+
+
+def collect(args):  # pylint: disable=too-many-locals
+    """Build the global line index, then one covered-line bitset per test."""
+    tests = list(profile_dirs(args.profiles))
+    if not tests:
+        print(f"error: no per-test profile directories under {args.profiles}", file=sys.stderr)
+        return 1
+
+    excludes = tuple(args.exclude) if args.exclude else DEFAULT_EXCLUDES
+    os.makedirs(args.output, exist_ok=True)
+
+    # One export over everything merged fixes the bit positions, so every
+    # worker can map a line to the same bit without coordinating.
+    all_profraws = [
+        os.path.join(d, f) for _, d in tests for f in os.listdir(d) if f.endswith(".profraw")
+    ]
+    if not all_profraws:
+        print(f"error: no .profraw files under {args.profiles}", file=sys.stderr)
+        return 1
+    print(f"indexing lines from {len(all_profraws)} raw profiles...", file=sys.stderr)
+    with tempfile.TemporaryDirectory() as tmp:
+        merged = os.path.join(tmp, "all.profdata")
+        _merge(all_profraws, args.llvm_profdata, merged)
+        every, _ = _lcov_lines(args.binary, merged, args.llvm_cov, excludes)
+    index = {key: i for i, key in enumerate(dict.fromkeys(every))}
+    print(f"{len(index)} instrumented lines, {len(tests)} tests", file=sys.stderr)
+
+    with gzip.open(os.path.join(args.output, LINE_INDEX), "wt", encoding="utf-8") as handle:
+        handle.write("".join(f"{key}\n" for key in index))
+
+    jobs = [(name, d, args.binary, args.llvm_cov, args.llvm_profdata, excludes, index)
+            for name, d in tests]
+    done = 0
+    with gzip.open(os.path.join(args.output, BITSETS), "wt", encoding="utf-8") as handle:
+        with ProcessPoolExecutor(max_workers=args.jobs) as pool:
+            for name, bits in pool.map(_collect_one, jobs, chunksize=4):
+                done += 1
+                if bits:
+                    handle.write(json.dumps({"test": name, "bits": bits}) + "\n")
+                if done % 250 == 0:
+                    print(f"  {done}/{len(tests)}", file=sys.stderr)
+    print(f"wrote {args.output}/{BITSETS}", file=sys.stderr)
+    return 0
+
+
+def load_bitsets(path):
+    """Read the collected per-test bitsets back as ``{test: int}``."""
+    out = {}
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        for line in handle:
+            record = json.loads(line)
+            raw = zlib.decompress(base64.b64decode(record["bits"]))
+            out[record["test"]] = int.from_bytes(raw, "big")
+    return out
+
+
+def greedy_cover(bitsets, costs, budget, target=1.0):  # pylint: disable=too-many-locals
+    """Pick tests maximising newly covered lines per second, within ``budget``.
+
+    Returns ``(chosen, trail)`` where ``trail`` records the cumulative fraction
+    of the achievable union covered after each pick.
+    """
+    achievable = 0
+    for bits in bitsets.values():
+        achievable |= bits
+    total = achievable.bit_count()
+    if not total:
+        return [], []
+
+    remaining = dict(bitsets)
+    covered = 0
+    spent = 0.0
+    chosen, trail = [], []
+
+    while remaining and covered.bit_count() < total * target:
+        best, best_value, best_gain = None, 0.0, 0
+        for name, bits in remaining.items():
+            cost = costs.get(name, 1.0)
+            if spent + cost > budget:
+                continue
+            gain = (bits & ~covered).bit_count()
+            # Zero-cost tests would divide by zero and are not free anyway;
+            # floor the divisor at a millisecond.
+            value = gain / max(cost, 0.001)
+            if value > best_value:
+                best, best_value, best_gain = name, value, gain
+        if best is None or not best_gain:
+            break
+        covered |= remaining.pop(best)
+        spent += costs.get(best, 1.0)
+        chosen.append(best)
+        trail.append(round(covered.bit_count() / total, 4))
+
+    return chosen, trail
+
+
+def select(args):
+    """Solve the cover and write ci/core-set.txt."""
+    bitsets = load_bitsets(os.path.join(args.coverage, BITSETS))
+    if not bitsets:
+        print(f"error: no coverage data in {args.coverage}", file=sys.stderr)
+        return 1
+
+    with open(args.timings, encoding="utf-8") as handle:
+        costs = {n: t["seconds"] for n, t in json.load(handle).get("tests", {}).items()}
+    missing = [n for n in bitsets if n not in costs]
+    if missing:
+        print(f"note: {len(missing)} covered tests have no timing; assuming 1s", file=sys.stderr)
+        costs.update({n: 1.0 for n in missing})
+
+    budget = args.budget_seconds * max(args.jobs, 1)
+    chosen, trail = greedy_cover(bitsets, costs, budget, args.target)
+    if not chosen:
+        print("error: no test fits the budget", file=sys.stderr)
+        return 1
+
+    spent = sum(costs[n] for n in chosen)
+    with open(args.output, "w", encoding="utf-8") as handle:
+        handle.write("# Coverage-derived always-run core set (esbmc/esbmc#6735).\n")
+        handle.write("# Regenerate: scripts/ci/coverage_core_set.py select\n")
+        handle.write(f"# {len(chosen)} tests, {trail[-1] * 100:.1f}% of reachable lines, "
+                 f"{spent:.0f} CPU-seconds\n")
+        handle.write("".join(f"{name}\n" for name in sorted(chosen)))
+
+    if args.report:
+        with open(args.report, "w", encoding="utf-8") as handle:
+            handle.write("### Coverage-derived core set\n\n")
+            handle.write(f"- {len(chosen)} of {len(bitsets)} tests\n")
+            handle.write(f"- {trail[-1] * 100:.1f}% of the lines the suite reaches at all\n")
+            handle.write(f"- {spent / 60:.1f} CPU-minutes "
+                     f"({spent / max(args.jobs, 1) / 60:.1f} min at -j{args.jobs})\n\n")
+            handle.write("| # tests | cumulative coverage |\n| ---: | ---: |\n")
+            for i in range(0, len(trail), max(len(trail) // 20, 1)):
+                handle.write(f"| {i + 1} | {trail[i] * 100:.1f}% |\n")
+
+    print(f"{len(chosen)} tests, {trail[-1] * 100:.1f}% of reachable lines -> {args.output}")
+    return 0
+
+
+def main(argv=None):
+    """Dispatch to collect or select."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    gather = sub.add_parser("collect", help="per-test raw profiles -> covered-line bitsets")
+    gather.add_argument("--profiles", required=True, help="the run's per-test profile tree")
+    gather.add_argument("--binary", required=True, help="the instrumented esbmc binary")
+    gather.add_argument("--output", required=True, help="directory to write the bitsets to")
+    gather.add_argument("--jobs", type=int, default=os.cpu_count(), help="parallel llvm-cov runs")
+    gather.add_argument("--exclude", action="append", help="path fragment to ignore (repeatable)")
+    gather.add_argument("--llvm-cov", default="llvm-cov")
+    gather.add_argument("--llvm-profdata", default="llvm-profdata")
+    gather.set_defaults(func=collect)
+
+    solve = sub.add_parser("select", help="bitsets -> ci/core-set.txt")
+    solve.add_argument("--coverage", required=True, help="directory produced by collect")
+    solve.add_argument("--timings", default="ci/test-timings.json", help="per-test durations")
+    solve.add_argument("--output", default="ci/core-set.txt")
+    solve.add_argument("--budget-seconds", type=float, default=180.0, help="wall-clock to fill")
+    solve.add_argument("--jobs", type=int, default=2, help="ctest -j the budget assumes")
+    solve.add_argument("--target",
+                       type=float,
+                       default=0.95,
+                       help="stop once this fraction of reachable lines is covered")
+    solve.add_argument("--report", help="Markdown report to write")
+    solve.set_defaults(func=select)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/ctest_timings.py
+++ b/scripts/ci/ctest_timings.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Turn a CTest JUnit report into the per-test timing table the fast lane sizes itself from.
+
+Nothing else in the two-tier CI (esbmc/esbmc#6735) can be sized without measured
+per-test durations, so the nightly full-suite run emits JUnit XML and this
+converts it to ci/test-timings.json.
+
+The XML is parsed incrementally and each element dropped once consumed: CTest
+embeds every test's full stdout in <system-out>, so a whole-suite report is
+hundreds of megabytes and must never be held in memory at once.
+"""
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+
+SCHEMA = 1
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_junit(path):
+    """Yield (name, seconds, status) for every <testcase> in a CTest JUnit report."""
+    for _, elem in ET.iterparse(path, events=("end", )):
+        if elem.tag != "testcase":
+            continue
+        name = elem.get("name")
+        if name:
+            if elem.find("skipped") is not None:
+                status = "skip"
+            elif elem.find("failure") is not None or elem.get("status") == "fail":
+                status = "fail"
+            else:
+                status = "run"
+            yield name, round(float(elem.get("time") or 0.0), 3), status
+        elem.clear()
+
+
+def build_table(junit_path, previous=None, source=None):
+    """Merge a run's measurements over ``previous``, newest measurement winning.
+
+    Entries only in ``previous`` are carried across so a partial run (a shard, a
+    suite re-run, a job that hit the wall) narrows the table's freshness rather
+    than deleting the tests it did not touch.
+    """
+    tests = dict(previous.get("tests", {})) if previous else {}
+    measured = _utc_now()
+    seen = 0
+    for name, seconds, status in parse_junit(junit_path):
+        seen += 1
+        # A skipped test measures the harness, not the test; keep any real
+        # duration already on record instead of overwriting it with ~0.
+        if status == "skip" and name in tests:
+            continue
+        tests[name] = {"seconds": seconds, "status": status, "measured": measured}
+    return seen, {
+        "schema": SCHEMA,
+        "generated": measured,
+        "source": source or {},
+        "tests": dict(sorted(tests.items())),
+    }
+
+
+def main(argv=None):
+    """Convert one JUnit report into the timing table."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--junit", required=True, help="CTest --output-junit XML to read")
+    parser.add_argument("--output", required=True, help="timing table to write")
+    parser.add_argument("--merge",
+                    action="store_true",
+                    help="carry over entries of --output that this run did not measure")
+    parser.add_argument("--commit", default="", help="commit the measurements were taken at")
+    parser.add_argument("--runner", default="", help="runner label the measurements came from")
+    parser.add_argument("--jobs", type=int, default=0, help="ctest -j used when measuring")
+    args = parser.parse_args(argv)
+
+    previous = None
+    if args.merge:
+        try:
+            with open(args.output, encoding="utf-8") as handle:
+                previous = json.load(handle)
+        except FileNotFoundError:
+            pass
+
+    source = {"commit": args.commit, "runner": args.runner, "jobs": args.jobs}
+    seen, table = build_table(args.junit, previous, {k: v for k, v in source.items() if v})
+
+    if not seen:
+        print(f"error: no <testcase> elements in {args.junit}", file=sys.stderr)
+        return 1
+
+    with open(args.output, "w", encoding="utf-8") as handle:
+        json.dump(table, handle, indent=1, sort_keys=True)
+        handle.write("\n")
+
+    total = sum(t["seconds"] for t in table["tests"].values())
+    print(f"{seen} measured, {len(table['tests'])} on record, "
+          f"{total / 3600:.2f} CPU-hours total -> {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/run_selected_tests.py
+++ b/scripts/ci/run_selected_tests.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Run exactly the tests select_tests.py chose, in one ctest invocation.
+
+ctest can only be narrowed by name regex (``-R``) or by test number (``-I``).
+A name alternation over a few thousand tests is ~170 kB, past the 128 kB Linux
+caps on a single argument (MAX_ARG_STRLEN), so the selection is resolved to test
+numbers instead: ``ctest --show-only=json-v1`` lists tests in the same order
+ctest numbers them, and the resulting index list stays under 90 kB even if every
+test in the suite is selected.
+
+Numbers are resolved against the build directory being run, so they cannot go
+stale the way a checked-in index list would.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+# The sibling import below has to follow the sys.path setup.
+# pylint: disable=wrong-import-position
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from select_tests import read_lines  # noqa: E402  (sibling module, not a package)
+
+# MAX_ARG_STRLEN is 128 kB; stop short of it with room for the rest of argv.
+MAX_ARG_BYTES = 120_000
+
+
+def ctest_test_names(build_dir):
+    """List the build's tests in ctest numbering order (test #N is entry N-1)."""
+    out = subprocess.run(["ctest", "--show-only=json-v1"],
+                         cwd=build_dir,
+                         check=True,
+                         capture_output=True,
+                         text=True).stdout
+    return [t["name"] for t in json.loads(out)["tests"]]
+
+
+def resolve(selected, names):
+    """Map test names to 1-based ctest numbers. Returns ``(numbers, missing)``."""
+    index = {name: i + 1 for i, name in enumerate(names)}
+    numbers = sorted(index[n] for n in selected if n in index)
+    return numbers, sorted(n for n in selected if n not in index)
+
+
+def main(argv=None):
+    """Resolve the selection to ctest numbers and run it."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--build-dir", default="build", help="configured build directory")
+    parser.add_argument("--tests", required=True, help="selected test list from select_tests.py")
+    parser.epilog = "Any other argument is forwarded to ctest verbatim."
+    # parse_known_args, not parse_args: ctest's own flags (-j, -N,
+    # --output-on-failure) must pass straight through.
+    args, ctest_args = parser.parse_known_args(argv)
+
+    selected = read_lines(args.tests)
+    names = ctest_test_names(args.build_dir)
+    numbers, missing = resolve(selected, names)
+
+    if missing:
+        # Expected whenever the run's build enables fewer suites than the one
+        # that produced the selection (no bitwuzla, no Solidity frontend, ...).
+        print(f"note: {len(missing)} selected tests are not in this build, e.g. {missing[:3]}",
+              file=sys.stderr)
+    if not numbers:
+        print("error: none of the selected tests exist in this build", file=sys.stderr)
+        return 1
+
+    spec = "0,0,0," + ",".join(str(n) for n in numbers)
+    if len(spec) > MAX_ARG_BYTES:
+        print(f"error: {len(numbers)} tests exceed the ctest argument limit; lower the budget",
+              file=sys.stderr)
+        return 1
+
+    cmd = ["ctest", "-I", spec] + ctest_args
+    print(f"running {len(numbers)} of {len(names)} tests", file=sys.stderr)
+    return subprocess.run(cmd, cwd=args.build_dir, check=False).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/select_tests.py
+++ b/scripts/ci/select_tests.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Pick the week's fast-lane test subset (esbmc/esbmc#6735, tier 1).
+
+The selection is a function of the ISO week alone, so every PR opened in a given
+week runs exactly the same tests and a failure is reproducible locally with
+``--week``. There is no per-PR roll to blame a red build on.
+
+Two properties the sampling has to keep:
+
+* **No area goes dark.** Sampling is stratified by suite (the ctest label) and,
+  within a suite, by runtime tercile, so a whole frontend or solver backend
+  cannot sit out a week, and slow tests are not squeezed out by cheap ones.
+* **A suite's draw order is its own.** Each stratum shuffles from a seed derived
+  from the week *and* the stratum name, so the order a suite's tests are
+  considered in does not depend on what any other suite contains. (Budget shares
+  are still global -- growing one suite shifts everyone's share -- but no suite
+  reshuffles because another one changed.)
+
+The budget is measured cumulative runtime, not a test count: tests are added
+until the projected wall-clock hits ``--budget-seconds``.
+"""
+
+import argparse
+import hashlib
+import json
+import random
+import statistics
+import sys
+from datetime import date
+
+# Wall-clock is never jobs x CPU-seconds: the tail of a run is imperfectly
+# packed and the last few long tests finish alone. Discount the budget so the
+# projection does not systematically overshoot.
+DEFAULT_PACKING_EFFICIENCY = 0.85
+
+# Cost assumed for a test with no measurement and no measured peers to impute
+# from -- only reachable on a first run, before any timing table exists.
+FALLBACK_COST = 1.0
+
+# No test is free. A suite whose tests all measured zero -- every one of them
+# skipped on the measuring host, say -- would otherwise carry zero weight and
+# divide by it when its budget share is split across runtime buckets.
+MIN_COST = 0.001
+
+# Budget left unspent by exhausted strata is redistributed over the rest. A
+# handful of rounds converges; the loop also stops as soon as a round adds
+# nothing.
+REDISTRIBUTION_ROUNDS = 8
+
+
+def iso_week(today=None):
+    """Return the ISO year-week label, e.g. ``2026-W36``, used as the seed."""
+    year, week, _ = (today or date.today()).isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+def seed_for(week, stratum=""):
+    """Derive a stable 64-bit seed from the week and (optionally) a stratum."""
+    digest = hashlib.sha256(f"{week}\0{stratum}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big")
+
+
+def stratum_of(name):
+    """Map a ctest name to its stratum: the regression suite, else ``unit``.
+
+    Regression tests are registered as ``regression/<suite>/<test>`` where
+    ``<suite>`` is exactly the ctest label (regression/CMakeLists.txt), so
+    stripping the leading ``regression/`` and the trailing test name recovers it.
+    """
+    if not name.startswith("regression/"):
+        return "unit"
+    rest = name[len("regression/"):]
+    suite, sep, _ = rest.rpartition("/")
+    return suite if sep else "unit"
+
+
+def read_lines(path):
+    """Read a newline-delimited list, dropping blanks and ``#`` comments."""
+    with open(path, encoding="utf-8") as handle:
+        return [s for s in (line.split("#", 1)[0].strip() for line in handle) if s]
+
+
+def impute_costs(universe, measured):
+    """Give every test a cost, standing in a peer's median where none was measured.
+
+    A test with no timing yet -- newly added, or skipped on the measuring host --
+    must not read as free, or the sampler would happily take an unbounded number
+    of them.
+    """
+    known = {n: measured[n] for n in universe if n in measured}
+    per_stratum = {}
+    for name, cost in known.items():
+        per_stratum.setdefault(stratum_of(name), []).append(cost)
+    overall = statistics.median(known.values()) if known else FALLBACK_COST
+
+    costs = {}
+    for name in universe:
+        if name in known:
+            cost = known[name]
+        else:
+            peers = per_stratum.get(stratum_of(name))
+            cost = statistics.median(peers) if peers else overall
+        costs[name] = max(cost, MIN_COST)
+    return costs
+
+
+def _terciles(names, costs):
+    """Split a stratum into fast/medium/slow buckets of roughly equal size."""
+    ordered = sorted(names, key=lambda n: (costs[n], n))
+    if len(ordered) < 3:
+        return [ordered]
+    cut = len(ordered) // 3
+    return [ordered[:cut], ordered[cut:2 * cut], ordered[2 * cut:]]
+
+
+def _draw(bucket, budget, costs, rng, taken):
+    """Randomly take tests from ``bucket`` until ``budget`` cannot fit another.
+
+    Returns the tests taken and what they cost. Sampling is uniform within the
+    bucket rather than cheapest-first, so the choice stays unbiased.
+    """
+    pool = [n for n in bucket if n not in taken]
+    rng.shuffle(pool)
+    picked, spent = [], 0.0
+    for name in pool:
+        if spent + costs[name] > budget:
+            continue
+        picked.append(name)
+        spent += costs[name]
+    return picked, spent
+
+
+def select(universe, costs, always_run, budget, week):
+    # pylint: disable=too-many-locals,too-many-branches
+    """Choose the week's subset. Returns ``(sorted names, stats)``."""
+    taken = set()
+    spent = 0.0
+    for name in sorted(always_run):
+        if name in costs:
+            taken.add(name)
+            spent += costs[name]
+
+    strata = {}
+    for name in universe:
+        if name not in taken:
+            strata.setdefault(stratum_of(name), []).append(name)
+
+    # Every non-empty stratum contributes at least one test even if its
+    # proportional share would round to zero, which is what keeps a small suite
+    # from going untested for weeks at a time.
+    for stratum in sorted(strata):
+        rng = random.Random(seed_for(week, stratum))
+        pool = [n for n in strata[stratum] if n not in taken]
+        if pool:
+            name = rng.choice(sorted(pool))
+            taken.add(name)
+            spent += costs[name]
+
+    for round_no in range(REDISTRIBUTION_ROUNDS):
+        remaining = budget - spent
+        if remaining <= 0:
+            break
+        pending = {
+            s: [n for n in names if n not in taken]
+            for s, names in strata.items()
+        }
+        pending = {s: names for s, names in pending.items() if names}
+        total = sum(costs[n] for names in pending.values() for n in names)
+        if not total:
+            break
+
+        added = False
+        for stratum in sorted(pending):
+            names = pending[stratum]
+            share = remaining * sum(costs[n] for n in names) / total
+            buckets = _terciles(names, costs)
+            bucket_total = sum(costs[n] for n in names)
+            # A fresh RNG per (week, stratum, round) keeps the draw reproducible
+            # while letting later rounds reach tests the first pass skipped.
+            rng = random.Random(seed_for(week, f"{stratum}#{round_no}"))
+            for bucket in buckets:
+                weight = sum(costs[n] for n in bucket)
+                picked, cost = _draw(bucket, share * weight / bucket_total, costs, rng, taken)
+                if picked:
+                    added = True
+                    taken.update(picked)
+                    spent += cost
+        if not added:
+            break
+
+    # Report over the whole universe, not just the sampled part, so a suite
+    # entirely absorbed by the core set still shows up in the table.
+    everything = {}
+    for name in universe:
+        everything.setdefault(stratum_of(name), []).append(name)
+
+    stats = {
+        "week": week,
+        "selected": len(taken),
+        "universe": len(universe),
+        "always_run": len(set(always_run) & set(costs)),
+        "cpu_seconds": round(spent, 1),
+        "budget_cpu_seconds": round(budget, 1),
+        "strata": {
+            s: {
+                "selected": sum(1 for n in names if n in taken),
+                "total": len(names)
+            }
+            for s, names in sorted(everything.items())
+        },
+    }
+    return sorted(taken), stats
+
+
+def format_summary(stats, jobs):
+    """Render the selection as Markdown for the GitHub Actions job summary."""
+    wall = stats["cpu_seconds"] / max(jobs, 1)
+    lines = [
+        f"### Fast-lane selection `{stats['week']}`",
+        "",
+        f"- {stats['selected']} of {stats['universe']} tests "
+        f"({100 * stats['selected'] / max(stats['universe'], 1):.1f}%)",
+        f"- {stats['always_run']} always-run (core set)",
+        f"- {stats['cpu_seconds'] / 60:.1f} CPU-minutes, "
+        f"projected {wall / 60:.1f} min wall-clock at -j{jobs}",
+        "",
+        "| Suite | Selected | Total |",
+        "| --- | ---: | ---: |",
+    ]
+    lines += [
+        f"| `{s}` | {v['selected']} | {v['total']} |" for s, v in stats["strata"].items()
+    ]
+    lines.append("")
+    lines.append(f"Reproduce locally: `scripts/ci/select_tests.py --week {stats['week']}`")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv=None):
+    """Write the week's selection and its summary."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--timings",
+                        default="ci/test-timings.json",
+                        help="measured per-test durations")
+    parser.add_argument("--tests", help="newline-delimited universe; defaults to the timed tests")
+    parser.add_argument("--week", default=None, help="ISO year-week seed (default: this week)")
+    parser.add_argument("--budget-seconds", type=float, default=900.0, help="wall-clock budget")
+    parser.add_argument("--jobs", type=int, default=2, help="ctest -j the budget assumes")
+    parser.add_argument("--packing-efficiency",
+                    type=float,
+                    default=DEFAULT_PACKING_EFFICIENCY,
+                    help="fraction of jobs x budget a real run actually packs")
+    parser.add_argument("--always-run", help="core set to include unconditionally")
+    parser.add_argument("--output", required=True, help="selected test list to write")
+    parser.add_argument("--summary", help="Markdown summary to write")
+    args = parser.parse_args(argv)
+
+    with open(args.timings, encoding="utf-8") as handle:
+        table = json.load(handle)
+    measured = {n: t["seconds"] for n, t in table.get("tests", {}).items()}
+
+    universe = read_lines(args.tests) if args.tests else sorted(measured)
+    if not universe:
+        print("error: empty test universe", file=sys.stderr)
+        return 1
+
+    always_run = read_lines(args.always_run) if args.always_run else []
+    week = args.week or iso_week()
+    costs = impute_costs(universe, measured)
+    budget = args.budget_seconds * max(args.jobs, 1) * args.packing_efficiency
+
+    selected, stats = select(universe, costs, always_run, budget, week)
+
+    with open(args.output, "w", encoding="utf-8") as handle:
+        handle.write(f"# fast-lane selection for {week}\n")
+        handle.write(f"# regenerate: scripts/ci/select_tests.py --week {week}\n")
+        handle.write("".join(f"{name}\n" for name in selected))
+
+    summary = format_summary(stats, args.jobs)
+    if args.summary:
+        with open(args.summary, "w", encoding="utf-8") as handle:
+            handle.write(summary)
+    print(summary, end="")
+
+    if stats["cpu_seconds"] > budget:
+        print(
+            "warning: the core set plus one test per suite already exceeds the budget; "
+            "the fast lane will overrun",
+            file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Rollout **steps 1 and 2** of the two-tier CI in #6735: instrument the suite, then
build the selector. Nothing gates on any of it yet — the PR lane still runs the
full suite, so this is safe to land and observe.

- **Instrument.** `test-timings.yml` runs the full suite nightly with
  `--output-junit` and commits `ci/test-timings.json`. `ctest_timings.py` parses
  the report incrementally, because CTest embeds every test's stdout and a
  whole-suite report is hundreds of MB.
- **Select.** `select_tests.py` turns durations + an ISO-week seed into the
  week's subset, sized by *measured cumulative runtime* rather than test count.
  Same list for every PR that week; reproducible locally with `--week`.
  Stratified by suite **and** by runtime tercile, with one test guaranteed per
  suite, so no frontend or solver backend goes dark for a week and slow tests
  are not squeezed out by cheap ones. A test with no measurement is costed at
  its suite's median, never zero.
- **Core set.** Solved for, not curated, per @rafaelsamenezes' suggestion on the
  issue: `ENABLE_PER_TEST_COVERAGE` keeps each test's LLVM profile apart, and
  `coverage_core_set.py` runs a greedy weighted set cover for the most lines
  reached per second. Monthly job; `ci/core-set.txt` ships empty until its first
  run, and the selector degrades to the random sample alone.

### On measured numbers

Against the real 14,005-test suite, a 15-minute budget at `-j2` selects **1,215
tests (8.7%)**, projected **12.7 min** wall-clock — inside the 10–15 min target.
Consecutive weeks overlap by only ~10%, so the rotation accumulates coverage as
the issue's argument assumes.

### One implementation note worth reviewing

Selections are resolved to **ctest numbers** (`-I`), not a name regex. A `-R`
alternation over a few thousand test names is ~170 kB, past the 128 kB
`MAX_ARG_STRLEN` cap on a single argument — it fails outright. Numbers are
resolved against the build being run, via `ctest --show-only=json-v1`, so they
cannot go stale.

Part of #6735 — this is 2 of the 7 rollout steps, so it deliberately does **not**
carry a closing keyword. Shadow mode (step 3) is next, and is what validates the
wall-clock projection above against reality.

## Test plan

- [x] `python3 scripts/ci/ci_scripts_test.py` — 42 tests, all passing (wired into
      the existing `testing-tool` PR job)
- [x] `python3 regression/testing_tool_test.py` — 10 tests, still green
- [x] `pylint --max-line-length=100 scripts/ci/*.py` — 10.00/10
- [x] `cmakelint` categories clean on `regression/CMakeLists.txt` (no tabs; the
      repo config filters `linelength`)
- [x] Mutation-checked: removing the per-suite guarantee, the budget check, the
      cost floor, the cost-aware greedy ratio, the skip guard, or the 1-based
      index each fails a specific test
- [x] End-to-end on the real suite: `ctest → JUnit → test-timings.json →
      select_tests.py → run_selected_tests.py → ctest`, with all 1,215 selected
      tests resolving against a real build
- [x] `collect`/`select` exercised against real `llvm-cov` output (integration
      test, skipped where no clang with a profile runtime is present)
- [x] `ENABLE_PER_TEST_COVERAGE=ON` verified to set `LLVM_PROFILE_FILE` on plain
      tests *and* on both slow-list overrides, which reset `ENVIRONMENT`
      wholesale; `OFF` leaves the property untouched