### PR TITLE
[goto-programs] Stop --loop-invariant-check dropping post-loop claims

### DIFF
--- a/regression/loop-invariants/github_7478/main.c
+++ b/regression/loop-invariants/github_7478/main.c
@@ -1,0 +1,16 @@
+/* Regression: GitHub #7478 -- a loop guard with a side effect is lowered to
+ * instructions that sit between the loop head and the guard's IF.  Havoc'ing
+ * after them left the IF testing a pre-havoc temporary, so the loop-exit edge
+ * was infeasible and every claim after the loop was dropped unsolved. */
+#include <assert.h>
+
+int main()
+{
+  int cnt = 4;
+  __ESBMC_loop_invariant(cnt >= 0);
+  while (cnt--)
+  {
+  }
+  assert(cnt == -1);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478/test.desc
+++ b/regression/loop-invariants/github_7478/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+PASSED\s+\[main\.assertion\.3\]\s+line\s+14\s+assertion cnt == -1$
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7478_array_ptr_fail/main.c
+++ b/regression/loop-invariants/github_7478_array_ptr_fail/main.c
@@ -1,0 +1,27 @@
+/* Regression: GitHub #7478 -- an array element reached through a pointer.
+ * `modifies_pointer_array` reports this shape but only goto_k_induction reads
+ * it, so the invariant schema has to recognise it too. */
+#include <assert.h>
+
+struct S
+{
+  int e[4];
+};
+
+static void run(struct S *s)
+{
+  __ESBMC_loop_invariant(s->e[0] >= 0);
+  while (s->e[0] > 0)
+  {
+    s->e[0]--;
+  }
+  assert(0);
+}
+
+int main()
+{
+  struct S s;
+  s.e[0] = 4;
+  run(&s);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_array_ptr_fail/test.desc
+++ b/regression/loop-invariants/github_7478_array_ptr_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^WARNING: loop invariant at .* not checked beyond its base case
+^\s+FAILED\s+\[run\.assertion\.4\]\s+line\s+18\s+assertion 0$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_call/main.c
+++ b/regression/loop-invariants/github_7478_call/main.c
@@ -1,0 +1,22 @@
+/* Regression: GitHub #7478 -- the passing half for a guard that calls a
+ * function.  The exit state has to be constrained, not merely reachable: the
+ * loop leaves `cnt == 0`, which only holds if the guard is re-evaluated on the
+ * havoc'd state. */
+#include <assert.h>
+
+static int positive(int c)
+{
+  return c > 0;
+}
+
+int main()
+{
+  int cnt = 4;
+  __ESBMC_loop_invariant(cnt >= 0);
+  while (positive(cnt))
+  {
+    cnt--;
+  }
+  assert(cnt == 0);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_call/test.desc
+++ b/regression/loop-invariants/github_7478_call/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+PASSED\s+\[main\.assertion\.3\]\s+line\s+20\s+assertion cnt == 0$
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7478_call_fail/main.c
+++ b/regression/loop-invariants/github_7478_call_fail/main.c
@@ -1,0 +1,21 @@
+/* Regression: GitHub #7478 -- same defect reached through a guard that calls a
+ * function.  The DECL/FUNCTION_CALL pair sits between the loop head and the
+ * IF, so the call was evaluated on the pre-havoc state. */
+#include <assert.h>
+
+static int positive(int c)
+{
+  return c > 0;
+}
+
+int main()
+{
+  int cnt = 4;
+  __ESBMC_loop_invariant(cnt >= 0);
+  while (positive(cnt))
+  {
+    cnt--;
+  }
+  assert(0);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_call_fail/test.desc
+++ b/regression/loop-invariants/github_7478_call_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+19\s+assertion 0$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_call_ret_fail/main.c
+++ b/regression/loop-invariants/github_7478_call_ret_fail/main.c
@@ -1,0 +1,21 @@
+/* Regression: GitHub #7478 -- the write is the return of a call, `*p = dec(*p)`,
+ * not an ASSIGN.  Its target is still a dereference the havoc cannot cover. */
+#include <assert.h>
+
+static int dec(int c)
+{
+  return c - 1;
+}
+
+int main()
+{
+  int cnt = 4;
+  int *p = &cnt;
+  __ESBMC_loop_invariant(cnt >= 0);
+  while (*p)
+  {
+    *p = dec(*p);
+  }
+  assert(0);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_call_ret_fail/test.desc
+++ b/regression/loop-invariants/github_7478_call_ret_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^WARNING: loop invariant at .* not checked beyond its base case
+^\s+FAILED\s+\[main\.assertion\.4\]\s+line\s+19\s+assertion 0$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_declined_base_case_fail/main.c
+++ b/regression/loop-invariants/github_7478_declined_base_case_fail/main.c
@@ -1,0 +1,16 @@
+/* Regression: GitHub #7478 -- declining the loop must not drop the base case.
+ * `cnt` is 4 on entry, so the annotated invariant is false there and has to be
+ * reported even though the havoc cannot cover the loop's pointer write. */
+#include <assert.h>
+
+int main()
+{
+  int cnt = 4;
+  int *p = &cnt;
+  __ESBMC_loop_invariant(cnt < 0);
+  while (*p)
+  {
+    (*p)--;
+  }
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_declined_base_case_fail/test.desc
+++ b/regression/loop-invariants/github_7478_declined_base_case_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^WARNING: loop invariant at .* not checked beyond its base case
+^\s+FAILED\s+\[main\.assertion\.2\]\s+line\s+11\s+loop invariant base case$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_dowhile/main.c
+++ b/regression/loop-invariants/github_7478_dowhile/main.c
@@ -1,0 +1,18 @@
+/* Regression: GitHub #7478 -- a do-while back edge carries the loop's own exit
+ * test.  Cutting it with ASSUME(false) also killed the fall-through, deleting
+ * every claim after the loop, and the inductive step was required of the
+ * iteration that exits.  Compare k_induction_issue_dowhile_entry_cond, which
+ * pins the same semantics for the combined pass (PR #3777). */
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  __ESBMC_loop_invariant(x <= 4);
+  do
+  {
+    x++;
+  } while (x < 5);
+  assert(x == 5);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_dowhile/test.desc
+++ b/regression/loop-invariants/github_7478_dowhile/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+PASSED\s+\[main\.assertion\.3\]\s+line\s+16\s+assertion x == 5$
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7478_dowhile_fail/main.c
+++ b/regression/loop-invariants/github_7478_dowhile_fail/main.c
@@ -1,0 +1,15 @@
+/* Regression: GitHub #7478 -- the failing half for do-while.  The loop exits
+ * with x == 5, so the post-loop assertion is false and must be reported. */
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  __ESBMC_loop_invariant(x <= 4);
+  do
+  {
+    x++;
+  } while (x < 5);
+  assert(x == 4);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_dowhile_fail/test.desc
+++ b/regression/loop-invariants/github_7478_dowhile_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+13\s+assertion x == 4$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_fail/main.c
+++ b/regression/loop-invariants/github_7478_fail/main.c
@@ -1,0 +1,15 @@
+/* Regression: GitHub #7478 -- the failing half.  The post-loop assertion is
+ * plainly false; before the fix it was never reached and the run reported
+ * VERIFICATION SUCCESSFUL. */
+#include <assert.h>
+
+int main()
+{
+  int cnt = 4;
+  __ESBMC_loop_invariant(cnt >= 0);
+  while (cnt--)
+  {
+  }
+  assert(0);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_fail/test.desc
+++ b/regression/loop-invariants/github_7478_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+13\s+assertion 0$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_pointer/main.c
+++ b/regression/loop-invariants/github_7478_pointer/main.c
@@ -1,0 +1,18 @@
+/* Regression: GitHub #7478 -- the loop writes a scalar through a dereference,
+ * which has no named symbol for the havoc to cover.  The schema declines the
+ * loop and says so rather than reporting a proof it did not make; the unwinder
+ * then discharges the post-loop assertion. */
+#include <assert.h>
+
+int main()
+{
+  int cnt = 4;
+  int *p = &cnt;
+  __ESBMC_loop_invariant(cnt >= 0);
+  while (*p)
+  {
+    (*p)--;
+  }
+  assert(cnt == 0);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_pointer/test.desc
+++ b/regression/loop-invariants/github_7478_pointer/test.desc
@@ -1,6 +1,7 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^WARNING: loop invariant at .* not checked: the loop writes through a pointer
-^\s+PASSED\s+\[main\.assertion\.3\]\s+line\s+16\s+assertion cnt == 0$
+^WARNING: loop invariant at .* not checked beyond its base case
+^\s+PASSED\s+\[main\.assertion\.2\]\s+line\s+12\s+loop invariant base case$
+^\s+PASSED\s+\[main\.assertion\.4\]\s+line\s+16\s+assertion cnt == 0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7478_pointer/test.desc
+++ b/regression/loop-invariants/github_7478_pointer/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^WARNING: loop invariant at .* not checked: the loop writes through a pointer
+^\s+PASSED\s+\[main\.assertion\.3\]\s+line\s+16\s+assertion cnt == 0$
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7478_pointer_fail/main.c
+++ b/regression/loop-invariants/github_7478_pointer_fail/main.c
@@ -1,0 +1,17 @@
+/* Regression: GitHub #7478 -- the failing half.  With the write invisible to
+ * the havoc the loop stayed concrete, its exit edge was infeasible and this
+ * assertion was reported as passing. */
+#include <assert.h>
+
+int main()
+{
+  int cnt = 4;
+  int *p = &cnt;
+  __ESBMC_loop_invariant(cnt >= 0);
+  while (*p)
+  {
+    (*p)--;
+  }
+  assert(0);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_pointer_fail/test.desc
+++ b/regression/loop-invariants/github_7478_pointer_fail/test.desc
@@ -1,6 +1,7 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^WARNING: loop invariant at .* not checked: the loop writes through a pointer
-^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+15\s+assertion 0$
+^WARNING: loop invariant at .* not checked beyond its base case
+^\s+PASSED\s+\[main\.assertion\.2\]\s+line\s+11\s+loop invariant base case$
+^\s+FAILED\s+\[main\.assertion\.4\]\s+line\s+15\s+assertion 0$
 ^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_pointer_fail/test.desc
+++ b/regression/loop-invariants/github_7478_pointer_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^WARNING: loop invariant at .* not checked: the loop writes through a pointer
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+15\s+assertion 0$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_shortcircuit/main.c
+++ b/regression/loop-invariants/github_7478_shortcircuit/main.c
@@ -1,0 +1,14 @@
+/* Regression: GitHub #7478 -- the passing half for a short-circuit guard.
+ * `a--` runs before the test, so the loop leaves `a == -1`. */
+#include <assert.h>
+
+int main()
+{
+  int a = 4, b = 1;
+  __ESBMC_loop_invariant(a >= 0);
+  while (a-- && b)
+  {
+  }
+  assert(a == -1);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_shortcircuit/test.desc
+++ b/regression/loop-invariants/github_7478_shortcircuit/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+PASSED\s+\[main\.assertion\.3\]\s+line\s+12\s+assertion a == -1$
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7478_shortcircuit_fail/main.c
+++ b/regression/loop-invariants/github_7478_shortcircuit_fail/main.c
@@ -1,0 +1,14 @@
+/* Regression: GitHub #7478 -- a short-circuit guard puts its own GOTO in the
+ * loop head block, so the first GOTO after the head is not the loop test. */
+#include <assert.h>
+
+int main()
+{
+  int a = 4, b = 1;
+  __ESBMC_loop_invariant(a >= 0);
+  while (a-- && b)
+  {
+  }
+  assert(0);
+  return 0;
+}

--- a/regression/loop-invariants/github_7478_shortcircuit_fail/test.desc
+++ b/regression/loop-invariants/github_7478_shortcircuit_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+12\s+assertion 0$
+^VERIFICATION FAILED$

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -166,6 +166,37 @@ void goto_loop_invariant(
   goto_functions.update();
 }
 
+static void
+collect_symbols_local(const expr2tc &expr, std::set<irep_idt> &symbols);
+
+/// True when some symbol the loop's guard reads is one the havoc covers. When
+/// nothing the guard reads is havoc'd, the exit edge is decided by the
+/// concrete pre-loop state and cannot change, so the claims after the loop are
+/// never reached rather than checked (issue #7478).
+static bool guard_reads_havocd_var(
+  goto_programt::targett head,
+  const goto_functiont &fn,
+  const loopst &loop)
+{
+  std::set<irep_idt> havocd_names;
+  for (const auto &v : loop.get_modified_loop_vars())
+    if (is_symbol2t(v))
+      havocd_names.insert(to_symbol2t(v).get_symbol_name());
+
+  for (goto_programt::targett it = head; it != fn.body.instructions.end(); ++it)
+  {
+    std::set<irep_idt> read;
+    collect_symbols_local(it->code, read);
+    collect_symbols_local(it->guard, read);
+    for (const auto &name : read)
+      if (havocd_names.count(name))
+        return true;
+    if (it->is_goto())
+      break;
+  }
+  return false;
+}
+
 void goto_loop_invariantt::goto_loop_invariant()
 {
   for (auto &function_loop : function_loops)
@@ -189,21 +220,6 @@ void goto_loop_invariantt::convert_loop_with_invariant(loopst &loop)
   if (invariants.empty())
     return;
 
-  // The schema replaces the loop with a havoc of its modified symbols. A write
-  // through a dereference has no named symbol to havoc, so the loop would be
-  // symex'd from its concrete pre-loop state: the exit edge turns infeasible,
-  // the invariant is discharged against one concrete iteration and every claim
-  // after the loop is dropped without being solved (issue #7478). Leave the
-  // loop for the unwinder rather than report a proof we did not make.
-  if (loop.writes_through_pointer())
-  {
-    log_warning(
-      "loop invariant at {} not checked: the loop writes through a pointer, "
-      "which the havoc cannot cover",
-      loop.get_original_loop_head()->location.as_string());
-    return;
-  }
-
   log_status(
     "Processing {} loop invariant{}",
     invariants.size(),
@@ -225,6 +241,24 @@ void goto_loop_invariantt::convert_loop_with_invariant(loopst &loop)
 
   // 1. Insert ASSERT invariant before loop (base case)
   insert_assert_before_loop(loop_head, invariants, side_effects);
+
+  // A write through a dereference has no named symbol for the havoc to cover.
+  // When the guard reads nothing the havoc does reach, the loop is left at its
+  // concrete pre-loop state: the exit edge cannot change, the invariant is
+  // discharged against one concrete iteration and every claim after the loop is
+  // dropped without being solved (issue #7478). Leave the loop for the unwinder
+  // rather than report a proof we did not make. The base case above is checked
+  // against the concrete pre-loop state and needs no havoc, so it still stands.
+  if (
+    loop.writes_through_pointer() &&
+    !guard_reads_havocd_var(std::prev(after_head), goto_function, loop))
+  {
+    log_warning(
+      "loop invariant at {} not checked beyond its base case: the loop writes "
+      "through a pointer the havoc cannot cover",
+      loop.get_original_loop_head()->location.as_string());
+    return;
+  }
 
   // 2. Insert HAVOC and ASSUME at the loop head, ahead of the guard
   insert_havoc_and_assume_before_condition(

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -202,12 +202,18 @@ void goto_loop_invariantt::convert_loop_with_invariant(loopst &loop)
   goto_programt side_effects;
   extract_and_remove_side_effects(loop_head, loop, invariants, side_effects);
 
+  // insert_assert_before_loop swaps the base case into the loop-head slot and
+  // moves the head's own instruction to a fresh node behind it, so the
+  // `loop_head` iterator no longer denotes the loop head afterwards. Anchor the
+  // instruction that follows it, which no insertion before the head can move.
+  goto_programt::targett after_head = std::next(loop_head);
+
   // 1. Insert ASSERT invariant before loop (base case)
   insert_assert_before_loop(loop_head, invariants, side_effects);
 
-  // 2. Insert HAVOC and ASSUME before loop condition (after base case assert)
+  // 2. Insert HAVOC and ASSUME at the loop head, ahead of the guard
   insert_havoc_and_assume_before_condition(
-    loop_head, loop, invariants, loop_assigns, side_effects);
+    std::prev(after_head), loop, invariants, loop_assigns, side_effects);
 
   // 3. Insert inductive step verification and loop termination
   insert_inductive_step_and_termination(loop, invariants, side_effects);
@@ -556,23 +562,20 @@ void goto_loop_invariantt::insert_assert_before_loop(
 }
 
 void goto_loop_invariantt::insert_havoc_and_assume_before_condition(
-  goto_programt::targett &loop_head,
+  goto_programt::targett loop_head,
   const loopst &loop,
   const std::vector<expr2tc> &invariants,
   const std::vector<expr2tc> &loop_assigns,
   goto_programt &side_effects)
 {
-  // Find the loop condition (IF instruction) - this should be right at loop_head
-  goto_programt::targett condition_it = loop_head;
-  while (condition_it != goto_function.body.instructions.end() &&
-         !condition_it->is_goto())
-    ++condition_it;
-
-  if (condition_it == goto_function.body.instructions.end())
-    return; // No loop condition found
-
-  // Insert BEFORE the loop condition (after the base case assert)
-  goto_programt::targett insert_point = condition_it;
+  // The havoc models an arbitrary iteration, so it belongs at the loop head,
+  // where the base case and the inductive step already anchor the invariant --
+  // not at the guard's IF. A guard with a side effect (`while (cnt--)`), a call
+  // (`while (f(&x))`) or a short circuit is lowered to instructions that sit
+  // between the two; havoc'ing after them leaves the IF testing a pre-havoc
+  // temporary, which makes the loop-exit edge infeasible and silently drops
+  // every claim after the loop (issue #7478).
+  goto_programt::targett insert_point = loop_head;
 
   goto_programt dest;
 

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -744,22 +744,42 @@ void goto_loop_invariantt::insert_inductive_step_and_termination(
       active_loop_assigns, dest, loop_exit->location, frame_modet::ASSERT);
   }
 
+  // A `do`-`while` back edge carries the loop's own exit test, so unlike the
+  // unconditional back edge of a `while` or `for` loop it cannot be cut with
+  // ASSUME(false): the fall-through is the exit path, and killing it drops
+  // every claim after the loop (issue #7478). Assume the negated condition
+  // instead and drop the back edge outright, and guard the inductive step by
+  // that condition so it is required only of an iteration that would actually
+  // follow -- the same correction the combined pass made for do-while in
+  // PR #3777.
+  const bool conditional_back_edge =
+    loop_exit->is_goto() && !is_true(loop_exit->guard);
+  const expr2tc exit_cond =
+    conditional_back_edge ? not2tc(loop_exit->guard) : gen_false_expr();
+
   // 3. ASSERT for inductive step.
   for (const auto &invariant : invariants)
   {
     // Create assert instruction for each invariant
     goto_programt::targett t = dest.add_instruction(ASSERT);
-    t->guard = invariant;
+    t->guard =
+      conditional_back_edge ? expr2tc(or2tc(exit_cond, invariant)) : invariant;
     t->location = loop_exit->location;
     t->location.comment("loop invariant inductive step");
     t->location.property("invariant-inductive-step");
   }
 
-  // 4. Insert ASSUME(FALSE) to terminate the loop
+  // 4. Cut the back edge: the havoc already covers every iteration.
   goto_programt::targett t = dest.add_instruction(ASSUME);
-  t->guard = gen_false_expr();
+  t->guard = exit_cond;
   t->location = loop_exit->location;
   t->location.comment("loop termination");
+
+  // ASSUME(false) leaves an unconditional back edge statically unreachable, but
+  // a conditional one still has a satisfiable guard and symex would unwind it
+  // forever. Remove it; the ASSUME above already constrains the exit path.
+  if (conditional_back_edge)
+    loop_exit->make_skip();
 
   // Insert at the insert point
   goto_function.body.insert_swap(insert_point, dest);

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -189,6 +189,21 @@ void goto_loop_invariantt::convert_loop_with_invariant(loopst &loop)
   if (invariants.empty())
     return;
 
+  // The schema replaces the loop with a havoc of its modified symbols. A write
+  // through a dereference has no named symbol to havoc, so the loop would be
+  // symex'd from its concrete pre-loop state: the exit edge turns infeasible,
+  // the invariant is discharged against one concrete iteration and every claim
+  // after the loop is dropped without being solved (issue #7478). Leave the
+  // loop for the unwinder rather than report a proof we did not make.
+  if (loop.writes_through_pointer())
+  {
+    log_warning(
+      "loop invariant at {} not checked: the loop writes through a pointer, "
+      "which the havoc cannot cover",
+      loop.get_original_loop_head()->location.as_string());
+    return;
+  }
+
   log_status(
     "Processing {} loop invariant{}",
     invariants.size(),

--- a/src/goto-programs/goto_loop_invariant.h
+++ b/src/goto-programs/goto_loop_invariant.h
@@ -104,13 +104,14 @@ protected:
     const std::vector<expr2tc> &invariants,
     const goto_programt &side_effects);
 
-  // Insert HAVOC and ASSUME before loop condition (inserts side_effects
-  // between the HAVOC block and the ASSUME).
+  // Insert HAVOC and ASSUME at \p loop_head, which must be the loop head's own
+  // instruction, so that everything the guard evaluates runs after the havoc
+  // (inserts side_effects between the HAVOC block and the ASSUME).
   // side_effects is non-const: if frame rule is active, old_snapshot assigns
   // are patched in-place so insert_inductive_step_and_termination (called
   // after this) sees the patched version too.
   void insert_havoc_and_assume_before_condition(
-    goto_programt::targett &loop_head,
+    goto_programt::targett loop_head,
     const loopst &loop,
     const std::vector<expr2tc> &invariants,
     const std::vector<expr2tc> &loop_assigns,

--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -160,27 +160,16 @@ void goto_loopst::create_function_loop(
   it1->set_size(size + 1);
 }
 
-/// True when a write target is storage reached through a dereference
-/// (`*p = ...`, `p->f = ...`, `p->e[i] = ...`): nothing named is written, so a
-/// havoc over named symbols cannot cover it. `modifies_pointer_array` reports
-/// the array case too, but only goto_k_induction reads it, so the array shapes
-/// are included here rather than deferred to it (#5224, #5230).
+/// True when a write target is storage reached through a pointer (`*p = ...`,
+/// `p->f = ...`, `p->e[i] = ...`, `((S *)v)->f = ...`): nothing named is
+/// written, so a havoc over named symbols cannot cover it. Writing the pointer
+/// variable itself (`p = ...`) names a symbol the havoc does cover.
+/// `modifies_pointer_array` reports the array shapes too, but only
+/// goto_k_induction reads that flag, so they are recognised here rather than
+/// deferred to it (#5224, #5230).
 static bool writes_through_pointer(const expr2tc &lhs)
 {
-  if (is_nil_expr(lhs))
-    return false;
-
-  for (const expr2tc *e = &lhs;;)
-  {
-    if (is_dereference2t(*e))
-      return true;
-    if (is_member2t(*e))
-      e = &to_member2t(*e).source_value;
-    else if (is_index2t(*e))
-      e = &to_index2t(*e).source_value;
-    else
-      return false;
-  }
+  return !is_nil_expr(lhs) && !is_symbol2t(lhs) && indexes_through_pointer(lhs);
 }
 
 void goto_loopst::collect_loop_symbols(

--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -160,6 +160,19 @@ void goto_loopst::create_function_loop(
   it1->set_size(size + 1);
 }
 
+/// True when an assignment's write target is scalar storage reached through a
+/// dereference (`*p = ...`, `p->f = ...`): nothing named is written, so a
+/// havoc over named symbols cannot cover it. An array element reached through
+/// a pointer (`p[i] = ...`, `p->e[i] = ...`) is excluded -- that is already
+/// reported by loopst::set_modifies_pointer_array (#5224, #5230).
+static bool writes_scalar_through_pointer(const expr2tc &lhs)
+{
+  const expr2tc *e = &lhs;
+  while (is_member2t(*e))
+    e = &to_member2t(*e).source_value;
+  return is_dereference2t(*e);
+}
+
 void goto_loopst::collect_loop_symbols(
   const expr2tc &expr,
   loopst::loop_varst &out) const
@@ -179,16 +192,14 @@ void goto_loopst::collect_loop_symbols(
 // distinction applied to the function-summary path.
 void goto_loopst::collect_lhs_symbols(
   const expr2tc &expr,
-  loopst::loop_varst &modified,
-  loopst::loop_varst &unmodified,
-  bool &modifies_pointer_array) const
+  function_summaryt &out) const
 {
   if (is_nil_expr(expr))
     return;
 
   if (is_dereference2t(expr))
   {
-    collect_loop_symbols(to_dereference2t(expr).value, unmodified);
+    collect_loop_symbols(to_dereference2t(expr).value, out.unmodified);
     return;
   }
   if (is_index2t(expr))
@@ -197,20 +208,17 @@ void goto_loopst::collect_lhs_symbols(
     // An array-element write into pointer-reached memory cannot be havoc'd
     // by the inductive step, making its hypothesis unsound (#5224).
     if (indexes_through_pointer(idx.source_value))
-      modifies_pointer_array = true;
-    collect_lhs_symbols(
-      idx.source_value, modified, unmodified, modifies_pointer_array);
-    collect_loop_symbols(idx.index, unmodified);
+      out.modifies_pointer_array = true;
+    collect_lhs_symbols(idx.source_value, out);
+    collect_loop_symbols(idx.index, out.unmodified);
     return;
   }
 
   expr->foreach_operand(
-    [this, &modified, &unmodified, &modifies_pointer_array](const expr2tc &e) {
-      collect_lhs_symbols(e, modified, unmodified, modifies_pointer_array);
-    });
+    [this, &out](const expr2tc &e) { collect_lhs_symbols(e, out); });
 
   if (is_symbol2t(expr) && check_var_name(expr))
-    modified.insert(expr);
+    out.modified.insert(expr);
 }
 
 bool goto_loopst::compute_function_summary(
@@ -227,6 +235,7 @@ bool goto_loopst::compute_function_summary(
     out.unmodified.insert(
       cached->second.unmodified.begin(), cached->second.unmodified.end());
     out.modifies_pointer_array |= cached->second.modifies_pointer_array;
+    out.writes_through_pointer |= cached->second.writes_through_pointer;
     return true;
   }
 
@@ -250,11 +259,10 @@ bool goto_loopst::compute_function_summary(
   {
     if (instr.is_assign())
     {
-      collect_lhs_symbols(
-        to_code_assign2t(instr.code).target,
-        local.modified,
-        local.unmodified,
-        local.modifies_pointer_array);
+      const expr2tc &target = to_code_assign2t(instr.code).target;
+      if (writes_scalar_through_pointer(target))
+        local.writes_through_pointer = true;
+      collect_lhs_symbols(target, local);
     }
     else if (instr.is_function_call())
     {
@@ -291,6 +299,7 @@ bool goto_loopst::compute_function_summary(
   out.modified.insert(local.modified.begin(), local.modified.end());
   out.unmodified.insert(local.unmodified.begin(), local.unmodified.end());
   out.modifies_pointer_array |= local.modifies_pointer_array;
+  out.writes_through_pointer |= local.writes_through_pointer;
 
   if (complete)
     function_summary_cache[fname] = std::move(local);
@@ -305,6 +314,8 @@ void goto_loopst::get_modified_variables(
   if (instruction->is_assign())
   {
     const code_assign2t &assign = to_code_assign2t(instruction->code);
+    if (writes_scalar_through_pointer(assign.target))
+      loop->set_writes_through_pointer();
     add_loop_var(*loop, assign.target, true);
   }
   else if (instruction->is_function_call())
@@ -336,6 +347,8 @@ void goto_loopst::get_modified_variables(
       loop->add_modified_var_to_loop(v);
     for (const auto &v : summary.unmodified)
       loop->add_unmodified_var_to_loop(v);
+    if (summary.writes_through_pointer)
+      loop->set_writes_through_pointer();
     if (summary.modifies_pointer_array)
     {
       loop->set_modifies_pointer_array();

--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -160,17 +160,27 @@ void goto_loopst::create_function_loop(
   it1->set_size(size + 1);
 }
 
-/// True when an assignment's write target is scalar storage reached through a
-/// dereference (`*p = ...`, `p->f = ...`): nothing named is written, so a
-/// havoc over named symbols cannot cover it. An array element reached through
-/// a pointer (`p[i] = ...`, `p->e[i] = ...`) is excluded -- that is already
-/// reported by loopst::set_modifies_pointer_array (#5224, #5230).
-static bool writes_scalar_through_pointer(const expr2tc &lhs)
+/// True when a write target is storage reached through a dereference
+/// (`*p = ...`, `p->f = ...`, `p->e[i] = ...`): nothing named is written, so a
+/// havoc over named symbols cannot cover it. `modifies_pointer_array` reports
+/// the array case too, but only goto_k_induction reads it, so the array shapes
+/// are included here rather than deferred to it (#5224, #5230).
+static bool writes_through_pointer(const expr2tc &lhs)
 {
-  const expr2tc *e = &lhs;
-  while (is_member2t(*e))
-    e = &to_member2t(*e).source_value;
-  return is_dereference2t(*e);
+  if (is_nil_expr(lhs))
+    return false;
+
+  for (const expr2tc *e = &lhs;;)
+  {
+    if (is_dereference2t(*e))
+      return true;
+    if (is_member2t(*e))
+      e = &to_member2t(*e).source_value;
+    else if (is_index2t(*e))
+      e = &to_index2t(*e).source_value;
+    else
+      return false;
+  }
 }
 
 void goto_loopst::collect_loop_symbols(
@@ -260,8 +270,7 @@ bool goto_loopst::compute_function_summary(
     if (instr.is_assign())
     {
       const expr2tc &target = to_code_assign2t(instr.code).target;
-      if (writes_scalar_through_pointer(target))
-        local.writes_through_pointer = true;
+      local.writes_through_pointer |= writes_through_pointer(target);
       collect_lhs_symbols(target, local);
     }
     else if (instr.is_function_call())
@@ -270,6 +279,7 @@ bool goto_loopst::compute_function_summary(
       if (is_dereference2t(call.function))
         continue;
 
+      local.writes_through_pointer |= writes_through_pointer(call.ret);
       collect_loop_symbols(call.ret, local.modified);
 
       const irep_idt &callee = to_symbol2t(call.function).thename;
@@ -314,7 +324,7 @@ void goto_loopst::get_modified_variables(
   if (instruction->is_assign())
   {
     const code_assign2t &assign = to_code_assign2t(instruction->code);
-    if (writes_scalar_through_pointer(assign.target))
+    if (writes_through_pointer(assign.target))
       loop->set_writes_through_pointer();
     add_loop_var(*loop, assign.target, true);
   }
@@ -328,6 +338,8 @@ void goto_loopst::get_modified_variables(
       return;
 
     // First, add its return
+    if (writes_through_pointer(function_call.ret))
+      loop->set_writes_through_pointer();
     add_loop_var(*loop, function_call.ret, true);
 
     const irep_idt &identifier = to_symbol2t(function_call.function).thename;

--- a/src/goto-programs/goto_loops.h
+++ b/src/goto-programs/goto_loops.h
@@ -47,7 +47,7 @@ protected:
     /// Propagated to the calling loop so the inductive step is disabled
     /// (see loopst::set_modifies_pointer_array and issue #5224).
     bool modifies_pointer_array = false;
-    /// True iff the callee writes a scalar through a dereference.
+    /// True iff the callee writes through a dereference.
     /// See loopst::set_writes_through_pointer and issue #7478.
     bool writes_through_pointer = false;
   };
@@ -80,9 +80,7 @@ protected:
   /// is actually written goes to `modified`, sub-expressions used to
   /// locate that storage (pointer in `*p`, index in `arr[i]`) go to
   /// `unmodified`. Sets `modifies_pointer_array` when the write is to an
-  /// array element reached through a pointer (issue #5224), and
-  /// `writes_through_pointer` when it is to a scalar reached through one
-  /// (issue #7478).
+  /// array element reached through a pointer (issue #5224).
   void collect_lhs_symbols(const expr2tc &expr, function_summaryt &out) const;
 
   void add_modified_var(loopst &loop, const expr2tc &expr);

--- a/src/goto-programs/goto_loops.h
+++ b/src/goto-programs/goto_loops.h
@@ -47,6 +47,9 @@ protected:
     /// Propagated to the calling loop so the inductive step is disabled
     /// (see loopst::set_modifies_pointer_array and issue #5224).
     bool modifies_pointer_array = false;
+    /// True iff the callee writes a scalar through a dereference.
+    /// See loopst::set_writes_through_pointer and issue #7478.
+    bool writes_through_pointer = false;
   };
   std::unordered_map<irep_idt, function_summaryt, irep_id_hash>
     function_summary_cache;
@@ -77,12 +80,10 @@ protected:
   /// is actually written goes to `modified`, sub-expressions used to
   /// locate that storage (pointer in `*p`, index in `arr[i]`) go to
   /// `unmodified`. Sets `modifies_pointer_array` when the write is to an
-  /// array element reached through a pointer (issue #5224).
-  void collect_lhs_symbols(
-    const expr2tc &expr,
-    loopst::loop_varst &modified,
-    loopst::loop_varst &unmodified,
-    bool &modifies_pointer_array) const;
+  /// array element reached through a pointer (issue #5224), and
+  /// `writes_through_pointer` when it is to a scalar reached through one
+  /// (issue #7478).
+  void collect_lhs_symbols(const expr2tc &expr, function_summaryt &out) const;
 
   void add_modified_var(loopst &loop, const expr2tc &expr);
   void add_unmodified_var(loopst &loop, const expr2tc &expr);

--- a/src/goto-programs/loopst.h
+++ b/src/goto-programs/loopst.h
@@ -97,6 +97,21 @@ public:
     return pointer_array_write_unresolvable_;
   }
 
+  /// Record that the loop, or a function it calls, writes a scalar through a
+  /// dereference (`*p = ...`). The pointee is not a named symbol, so a
+  /// schema that havocs named symbols cannot cover it. k-induction keeps the
+  /// original loop in its base case and stays sound; the loop-invariant schema
+  /// replaces the loop outright, so it must decline instead (issue #7478).
+  void set_writes_through_pointer()
+  {
+    writes_through_pointer_ = true;
+  }
+
+  bool writes_through_pointer() const
+  {
+    return writes_through_pointer_;
+  }
+
   void dump() const;
   void dump_loop_vars() const;
   void output_to(std::ostream &oss) const;
@@ -117,6 +132,7 @@ protected:
   std::size_t size;
   bool modifies_pointer_array_ = false;
   bool pointer_array_write_unresolvable_ = false;
+  bool writes_through_pointer_ = false;
   loop_varst pointer_array_write_ptrs_;
 };
 

--- a/src/goto-programs/loopst.h
+++ b/src/goto-programs/loopst.h
@@ -97,11 +97,12 @@ public:
     return pointer_array_write_unresolvable_;
   }
 
-  /// Record that the loop, or a function it calls, writes a scalar through a
-  /// dereference (`*p = ...`). The pointee is not a named symbol, so a
-  /// schema that havocs named symbols cannot cover it. k-induction keeps the
-  /// original loop in its base case and stays sound; the loop-invariant schema
-  /// replaces the loop outright, so it must decline instead (issue #7478).
+  /// Record that the loop, or a function it calls, writes through a
+  /// dereference (`*p = ...`, `p->f = ...`, `p->e[i] = ...`). The pointee is
+  /// not a named symbol, so a schema that havocs named symbols cannot cover it.
+  /// k-induction keeps the original loop in its base case and stays sound; the
+  /// loop-invariant schema replaces the loop outright, so it declines a loop
+  /// whose guard the havoc cannot reach (issue #7478).
   void set_writes_through_pointer()
   {
     writes_through_pointer_ = true;


### PR DESCRIPTION
Fixes #7478.

`--loop-invariant-check` reported `VERIFICATION SUCCESSFUL` on programs with
real bugs, because claims after the loop were never solved. A sweep of the
guard and loop shapes found three distinct causes of the same symptom, fixed
here in one commit each.

### 1. The havoc landed after the guard's side effects

The pass scanned forward from the loop head to the first GOTO and havoc'd
there. A guard that has a side effect, calls a function, or short-circuits is
lowered to instructions that sit between the head and that IF, so the IF
tested a pre-havoc temporary, the loop-exit edge was infeasible and every
post-loop claim was dropped unsolved.

The havoc now goes at the loop head, where the base case and the inductive
step already anchor the invariant. `goto_k_induction` has always placed its
havoc this way, which is why the combined `--loop-invariant` mode reports the
issue's reproducer correctly.

### 2. A do-while back edge was cut with ASSUME(false)

That back edge carries the loop's own exit test, so assuming false killed the
fall-through as well: every claim after the loop vanished from the GOTO
program, and the inductive step was asserted of the iteration that exits,
refuting invariants that hold at every loop head. The pass now assumes the
negated condition and drops the back edge, and guards the inductive step by
that condition — the correction PR #3777 made for the combined pass.

### 3. A scalar write through a pointer left nothing to havoc

`*p = ...` writes storage that is not a named symbol, in the loop body or in
a callee, so the modified-vars analysis recorded nothing. The loop was then
symex'd from its concrete pre-loop state and the invariant was "discharged"
against one concrete iteration. k-induction keeps the original loop in its
base case and stays sound here; this pass replaces the loop outright, so it
now declines and says so instead of claiming a proof. Array elements reached
through a pointer keep the existing `modifies_pointer_array` treatment
(#5224, #5230), which `quantified_array_invariant` relies on.

### Before and after

Every row is a program whose post-loop `assert` is false, so `FAILED` is the
correct verdict.

| shape | master | this PR |
|---|---|---|
| `while (cnt--)` | **SUCCESSFUL** | FAILED |
| `while (f(cnt))` | **SUCCESSFUL** | FAILED |
| `while (a-- && b)` | **SUCCESSFUL** | FAILED |
| `while (*p) { (*p)--; }` | **SUCCESSFUL** | FAILED |
| callee writes `*x` | **SUCCESSFUL** | FAILED |
| `p->f` written through a pointer | **SUCCESSFUL** | FAILED |
| `do { ... } while (c)` | FAILED, but the claim was absent and the inductive step falsely refuted | FAILED |
| `while (*p++)` | FAILED, claim absent | FAILED |
| nested, inner `while (j--)` | FAILED, outer inductive step silently dropped | FAILED |
| `while (--cnt)` | FAILED | FAILED |
| `for`, `while (c > 0)` | FAILED | FAILED |

### Tests

Eight tests in `regression/loop-invariants`, a pass/fail pair per cause, each
pinning the post-loop claim's own row in the `--multi-property` table rather
than just the verdict — the dropped claim is invisible in the verdict alone
for half of them.

Mutation-checked: reverting all three fixes fails all eight; reverting only
the havoc placement fails six; only the do-while fix, the do-while pair; only
the pointer guard, the pointer pair.

`loop-invariants` 89/89, `esbmc` 2024/2024, `k-induction` and
`k-induction-parallel` 198/198, `function_contract` 426/426, `termination`
72/72, `goto-coverage` 144/144, unit 745/745. No new clang-format findings;
complexity gate reports +0 over threshold.

### Note

#7480 is the opposite direction on the same schema — post-havoc claims that
*are* checked, but against abstract states, producing false alarms. It is not
addressed here; fixing it will revisit what verdict a post-havoc violation
deserves, which is what the `_fail` tests above pin.


### Review round

Three more shapes reached the same false `SUCCESSFUL`, and the decline was too
blunt in one direction and too narrow in two others.

- **A call return can be the write.** `*p = dec(*p)` is a FUNCTION_CALL whose
  `ret` is a dereference, not an ASSIGN. `ret` is now checked in both the loop
  walk and the function summary.
- **Array elements reached through a pointer.** `s->e[0]--` was deferred to
  `modifies_pointer_array`, which only `goto_k_induction` reads. Recognised here
  now, with the decline moved to the condition that actually characterises the
  defect: the loop writes through a pointer *and* the guard reads nothing the
  havoc covers, so the exit edge cannot change. `quantified_array_invariant`
  (#6217) writes `p->e[i]` under a havoc-covered counter and keeps the
  transformation on that second clause.
- **Declining dropped the base case**, which is checked against the concrete
  pre-loop state and needs no havoc, so a false invariant went unreported. It is
  emitted before the decline now.
- The shape test reuses `indexes_through_pointer` rather than carrying a second
  walker beside it, which also covers typecast bases and an index over a pointer
  symbol. A write to a named symbol (`p = p + 1`) is excluded: the havoc covers
  it.

Four more tests, including the passing halves for the call and short-circuit
guards asked for in review — they assert `cnt == 0` and `a == -1`, so they pin
the exit state rather than mere reachability.

`loop-invariants` 94/94, `esbmc` 2024/2024, `k-induction` 198/198,
`function_contract` 426/426, `termination` 72/72, `goto-coverage` 144/144, unit
745/745. Ten negative-control shapes (local array, local struct, global written
in a callee, plain `while`/`for`, nested, pointer reassignment) keep the
transformation and report correctly.
