### PR TITLE
[goto-programs] Verify a do-while under the combined invariant pass

### DIFF
--- a/regression/loop-invariants/github_7494/main.c
+++ b/regression/loop-invariants/github_7494/main.c
@@ -1,0 +1,15 @@
+/* Regression: GitHub #7494 -- the passing half.  The same loop, asserting what
+ * it actually leaves, so the exit path has to survive *and* stay constrained. */
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  __ESBMC_loop_invariant(x <= 4);
+  do
+  {
+    x++;
+  } while (x < 5);
+  assert(x == 5);
+  return 0;
+}

--- a/regression/loop-invariants/github_7494/test.desc
+++ b/regression/loop-invariants/github_7494/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant
+^\s+PASSED\s+\[main\.assertion\.4\]\s+line\s+13\s+assertion x == 5$
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7494_fail/main.c
+++ b/regression/loop-invariants/github_7494_fail/main.c
@@ -1,0 +1,16 @@
+/* Regression: GitHub #7494 -- the combined pass killed a do-while's exit path.
+ * `x <= 4` holds at every loop head; the loop leaves x == 5, so this assertion
+ * is false and must be reported. */
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  __ESBMC_loop_invariant(x <= 4);
+  do
+  {
+    x++;
+  } while (x < 5);
+  assert(x == 4);
+  return 0;
+}

--- a/regression/loop-invariants/github_7494_fail/test.desc
+++ b/regression/loop-invariants/github_7494_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant
+^\s+FAILED\s+\[main\.assertion\.4\]\s+line\s+14\s+assertion x == 4$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7494_inv_fail/main.c
+++ b/regression/loop-invariants/github_7494_inv_fail/main.c
@@ -1,0 +1,15 @@
+/* Regression: GitHub #7494 -- the verification branch copied no body for a
+ * do-while, so ASSUME(INV) was followed straight by ASSERT(INV) and any
+ * invariant passed.  `x <= 2` is false once the third iteration runs. */
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  __ESBMC_loop_invariant(x <= 2);
+  do
+  {
+    x++;
+  } while (x < 5);
+  return 0;
+}

--- a/regression/loop-invariants/github_7494_inv_fail/test.desc
+++ b/regression/loop-invariants/github_7494_inv_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant
+^\s+FAILED\s+\[main\.assertion\.1\]\s+line\s+10\s+loop invariant inductive step$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7494_verification_branch/main.c
+++ b/regression/loop-invariants/github_7494_verification_branch/main.c
@@ -1,0 +1,22 @@
+/* Regression: GitHub #7494 -- pins the shape of the transformation, which the
+ * verdict cannot: on the unfixed pass every post-loop claim of a do-while is
+ * vacuously true, so a correct program reports SUCCESSFUL either way.
+ *
+ * Two things have to hold.  The verification branch must contain a copy of the
+ * body between ASSUME(INV) and ASSERT(INV), guarded by the loop's continue
+ * condition -- without the copy the inductive step is discharged against
+ * nothing.  And the k-induction hint must be assumed at the loop head, ahead of
+ * the body, not at the tail where the exit test lives. */
+#include <assert.h>
+
+int main()
+{
+  int x = 0;
+  __ESBMC_loop_invariant(x <= 4);
+  do
+  {
+    x++;
+  } while (x < 5);
+  assert(x == 4);
+  return 0;
+}

--- a/regression/loop-invariants/github_7494_verification_branch/test.desc
+++ b/regression/loop-invariants/github_7494_verification_branch/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant --goto-functions-only
+ASSUME x <= 4 // loop invariant assume \(verification branch\)\n\s+// .*\n\s+ASSIGN x=x \+ 1;\n\s+// .*\n\s+ASSUME x < 5 // loop continue condition
+ASSUME x <= 4 // loop invariant assume \(k-induction hint\)\n\s+// .*\n\s+ASSIGN x=x \+ 1;

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -855,7 +855,7 @@ void goto_loop_invariant_combinedt::process_loops_combined()
 }
 
 void goto_loop_invariant_combinedt::copy_loop_body(
-  goto_programt::targett loop_head,
+  goto_programt::targett body_begin,
   goto_programt::targett loop_exit,
   goto_programt &out) const
 {
@@ -863,7 +863,7 @@ void goto_loop_invariant_combinedt::copy_loop_body(
   std::map<goto_programt::targett, unsigned> target_map;
   {
     unsigned count = 0;
-    for (auto t = std::next(loop_head); t != loop_exit; ++t, ++count)
+    for (auto t = body_begin; t != loop_exit; ++t, ++count)
       target_map[t] = count;
   }
 
@@ -871,7 +871,7 @@ void goto_loop_invariant_combinedt::copy_loop_body(
   std::vector<goto_programt::targett> target_vector;
   target_vector.reserve(target_map.size());
 
-  for (auto t = std::next(loop_head); t != loop_exit; ++t)
+  for (auto t = body_begin; t != loop_exit; ++t)
   {
     goto_programt::targett copied_t = out.add_instruction(*t);
     target_vector.push_back(copied_t);
@@ -889,6 +889,44 @@ void goto_loop_invariant_combinedt::copy_loop_body(
         target = target_vector[m_it->second];
     }
   }
+}
+
+/// The condition under which a while or for loop is entered: the negation of
+/// its head IF's guard, which ASSUME(entry_cond) stands in for so the head need
+/// not be copied. Nil for a do-while, whose head is not a conditional goto but
+/// the first instruction of the body -- it always enters (issue #7494).
+static expr2tc loop_entry_cond(goto_programt::targett loop_head)
+{
+  if (loop_head->is_goto() && !loop_head->is_backwards_goto())
+    return not2tc(loop_head->guard);
+  return expr2tc();
+}
+
+/// Where the copied body starts: after the head when ASSUME(entry_cond) stands
+/// in for it, at the head otherwise, because a do-while head is a body
+/// instruction and skipping it left the verification branch empty (#7494).
+static goto_programt::targett
+loop_body_begin(goto_programt::targett loop_head, const expr2tc &entry_cond)
+{
+  return is_nil_expr(entry_cond) ? loop_head : std::next(loop_head);
+}
+
+/// Constrain the copied iteration to one another would follow. A do-while's
+/// exit test lives on its back edge, so the copy may be the last iteration, and
+/// a head invariant need not hold where the loop exits: `x <= 4` on
+/// `do x++; while (x < 5)` holds at every head and is false once the exiting
+/// iteration leaves x == 5. No-op for the unconditional back edge of a while or
+/// for loop (issue #7494).
+static void
+assume_continue_cond(goto_programt::targett loop_exit, goto_programt &out)
+{
+  if (!loop_exit->is_goto() || is_true(loop_exit->guard))
+    return;
+
+  auto t = out.add_instruction(ASSUME);
+  t->guard = loop_exit->guard;
+  t->location = loop_exit->location;
+  t->location.comment("loop continue condition (verification branch)");
 }
 
 void goto_loop_invariant_combinedt::insert_invariant_verification_branch(
@@ -911,18 +949,11 @@ void goto_loop_invariant_combinedt::insert_invariant_verification_branch(
   extract_and_remove_side_effects_impl(
     goto_function, loop_head, loop, invariants, side_effects);
 
-  // ── 2. Copy loop body
-  goto_programt body_copy;
-  copy_loop_body(loop_head, loop_exit, body_copy);
+  // ── 2. Copy loop body, and the entry condition that stands in for the head
+  const expr2tc entry_cond = loop_entry_cond(loop_head);
 
-  // ── 3. Extract the loop entry condition ───────────────────────────────────
-  // loop_head is "IF !(cond) GOTO exit", so the entry condition is "cond"
-  // i.e. the negation of the GOTO guard.
-  expr2tc entry_cond;
-  if (loop_head->is_goto() && !loop_head->is_backwards_goto())
-    entry_cond = not2tc(loop_head->guard);
-  // If loop_head is not a conditional GOTO (e.g. do-while), entry_cond
-  // stays nil and we omit the ASSUME(entry_cond) — always enters.
+  goto_programt body_copy;
+  copy_loop_body(loop_body_begin(loop_head, entry_cond), loop_exit, body_copy);
 
   // ── 4. Build Branch 1 ─────────────────────────────────────────────────────
   const auto &loop_vars = loop.get_modified_loop_vars();
@@ -977,6 +1008,11 @@ void goto_loop_invariant_combinedt::insert_invariant_verification_branch(
   // [4e] One iteration of the loop body
   branch1.destructive_insert(branch1.instructions.end(), body_copy);
 
+  // [4e'] Only an iteration another would follow has to preserve the invariant.
+  // PR #3777 describes this for the copied body; it never bit because a
+  // do-while's body was not copied at all (issue #7494).
+  assume_continue_cond(loop_exit, branch1);
+
   // [4f] Inductive-step ASSERT(INV)
   for (const auto &instr : side_effects.instructions)
     branch1.instructions.push_back(instr);
@@ -1010,10 +1046,15 @@ void goto_loop_invariant_combinedt::insert_invariant_verification_branch(
     branch1.destructive_insert(branch1.instructions.begin(), gate);
   }
 
-  // ── 6. Add ASSUME(INV) at end of original loop body (Branch 2) ───────────
-  // Inserting ASSUME(INV) just before loop_exit (the backward GOTO) means
-  // k-induction will see the assumption at the end of every iteration without
-  // any modification to goto_k_induction itself.
+  // ── 6. Add ASSUME(INV) at the loop head (Branch 2) ───────────────────────
+  // The invariant holds where it is annotated, at the head of an iteration, so
+  // that is where k-induction gets to assume it. For a while or for loop the
+  // head is the guard, and the assumption goes just inside it, where the body
+  // begins. A do-while head is already the first body instruction: advancing
+  // past it puts the ASSUME at the body tail, ahead of the loop's own exit
+  // test, where a head invariant need not hold -- the exiting iteration then
+  // contradicts it, the exit edge is assumed away and every claim after the
+  // loop silently disappears (issue #7494).
 
   // ── 7. Insert before loop_head using splice (NOT insert_swap) ─────────────
   // splice() inserts before loop_head without moving it, so any existing
@@ -1029,7 +1070,8 @@ void goto_loop_invariant_combinedt::insert_invariant_verification_branch(
     t->guard = inv;
     t->location = loop_head->location;
     t->location.comment("loop invariant assume (k-induction hint)");
-    loop_head++;
+    if (!is_nil_expr(entry_cond))
+      loop_head++;
     goto_function.body.insert_swap(loop_head, assume_inv);
   }
 }

--- a/src/goto-programs/goto_loop_invariant.h
+++ b/src/goto-programs/goto_loop_invariant.h
@@ -170,13 +170,15 @@ private:
   void insert_invariant_verification_branch(loopst &loop);
 
   /**
-   * Copy the loop body instructions (from the instruction immediately after
-   * @p loop_head up to, but not including, @p loop_exit) into @p out.
-   * Intra-loop jump targets are remapped to the copied instructions; targets
-   * outside the loop are left unchanged.
+   * Copy the loop body instructions (from @p body_begin up to, but not
+   * including, @p loop_exit) into @p out. Intra-loop jump targets are remapped
+   * to the copied instructions; targets outside the loop are left unchanged.
+   * @p body_begin is the instruction after the loop head when the head is the
+   * loop's guard, which ASSUME(entry_cond) models instead, and the head itself
+   * otherwise -- a do-while head is a body instruction (issue #7494).
    */
   void copy_loop_body(
-    goto_programt::targett loop_head,
+    goto_programt::targett body_begin,
     goto_programt::targett loop_exit,
     goto_programt &out) const;
 };


### PR DESCRIPTION
Fixes #7494. Branched from master and independent of #7482 and #7491, which
touch the standalone schema; this one is the combined pass.

`--loop-invariant` proved a false post-loop assertion on a do-while, and never
checked the invariant either.

```c
int x = 0;
__ESBMC_loop_invariant(x <= 4);
do { x++; } while (x < 5);
assert(x == 4);              // false: the loop leaves x == 5
```

```
$ esbmc main.c --unwind 12                  VERIFICATION FAILED       correct
$ esbmc main.c --loop-invariant --unwind 12 VERIFICATION SUCCESSFUL   before
$ esbmc main.c --loop-invariant --unwind 12 VERIFICATION FAILED       after
```

### Two defects, both from treating the loop head as a guard

**The verification branch copied no body.** `copy_loop_body` started at
`std::next(loop_head)`, which is right for a while or for loop: the head is the
guard IF and `ASSUME(entry_cond)` stands in for it. A do-while head is the first
instruction of the body, so with a one-instruction body the copy range was
empty and `ASSUME(INV)` ran straight into `ASSERT(INV)`. The inductive step was
discharged against no iteration at all and every invariant passed, including a
plainly wrong one.

**The k-induction hint was assumed past the head.** Step 7 advanced one
instruction before inserting `ASSUME(INV)`. For a guard head that lands where the
body begins; for a do-while it lands at the body *tail*, ahead of the loop's own
exit test, where a head invariant need not hold. `x <= 4` holds at every head and
is false once the exiting iteration leaves `x == 5`, so that assumption
contradicted the exit state, the exit edge was assumed away, and every claim
after the loop silently disappeared — which is what produced the proof.

Copying the body then requires the third piece, which PR #3777 described for
this pass and could never exercise because the body was not copied: the inductive
step is asserted only of an iteration another would follow, so a conditional back
edge contributes `ASSUME(continue_cond)` after the copy.

The transformed program now reads:

```
        ASSUME x <= 4 // loop invariant assume (verification branch)
        ASSIGN x=x + 1                                  <- body, copied
        ASSUME x < 5  // loop continue condition (verification branch)
        ASSERT x <= 4 // loop invariant inductive step
        ASSUME 0
     1: ASSIGN x=NONDET
     2: ASSUME x <= 4 // loop invariant assume (k-induction hint)   <- at the head
        ASSIGN x=x + 1
        IF x < 5 THEN GOTO 2                            <- exit path alive
```

### Tests

- `github_7494_fail` — the reproducer; the post-loop assertion is reported.
- `github_7494_inv_fail` — a wrong invariant (`x <= 2`) on the same loop; pins
  that the inductive step is discharged against a real iteration.
- `github_7494` — the passing half: the same loop asserting `x == 5`, what it
  actually leaves.
- `github_7494_verification_branch` — pins the shape of the transformation
  through `--goto-functions-only`: the copied body sits between `ASSUME(INV)` and
  the continue condition, and the hint precedes the body rather than following
  it.

Mutation-checked against master: `github_7494_fail`, `github_7494_inv_fail` and
`github_7494_verification_branch` all fail without the change.

**`github_7494` does not bite, and cannot.** On the unfixed pass a do-while's
exit path is assumed away, so every post-loop claim is vacuously true and any
correct program reports `SUCCESSFUL` either way — no assertion can distinguish
the two. It is the pairs-convention half, holding the correct program fixed;
`github_7494_verification_branch` is what actually gates that program's
behaviour, which is why it is there.

`loop-invariants` 85/85, `esbmc` 2024/2024, `k-induction` and
`k-induction-parallel` 198/198, `function_contract` 426/426, `termination` 72/72,
`goto-coverage` 144/144, unit 745/745. No new clang-format findings; complexity
gate reports nothing added or worsened over threshold.

### Note

`regression/loop-invariants/k_induction_issue_dowhile_entry_cond` (PR #3777)
passes before and after. It was passing vacuously: with no body copied, the
inductive step it exists to constrain was never checked.
