### PR TITLE
[simplifier] Fold decidable null-pointer comparisons

### DIFF
--- a/regression/esbmc/null_fnptr_guard_const_fold/main.c
+++ b/regression/esbmc/null_fnptr_guard_const_fold/main.c
@@ -1,0 +1,50 @@
+/* Bytecode-VM dispatch, one level deeper than the naive shape: the
+ * null check and the handler call live in a callee, and the handler
+ * mutates a shared machine struct. Without the fold the impossible
+ * null path survives to the callee's return merge, the whole struct
+ * becomes a phi of updated-vs-original, and every later member read
+ * -- including the loop bound -- stops folding. */
+typedef struct
+{
+  unsigned short cells[64];
+  unsigned char sp;
+  unsigned short pc;
+} vm_t;
+typedef int (*handler_t)(vm_t *);
+
+static int op_push(vm_t *v)
+{
+  v->cells[v->sp] = 7;
+  v->sp += 1;
+  v->pc += 1;
+  return 0;
+}
+static const handler_t table[4] = {op_push, op_push, op_push, op_push};
+static vm_t vm;
+
+static int step(vm_t *v)
+{
+  handler_t h = table[v->pc & 3];
+  if (h == 0)
+    return 15;
+  return h(v);
+}
+
+int main(void)
+{
+  vm.sp = 1;
+  int st = step(&vm);
+  int n = 0;
+  for (unsigned short i = 0; i < (st == 0 ? vm.sp : 30000); i++)
+    n++;
+  __ESBMC_assert(n == 2, "the null guard folded; sp bounded the loop");
+
+  /* The other polarity: a `!= NULL` guard over a provably real address
+   * must fold true the same way. */
+  int m = 0;
+  if (table[(vm.pc + 1) & 3] != 0)
+    for (unsigned short i = 0; i < vm.sp; i++)
+      m++;
+  __ESBMC_assert(m == 2, "the nonnull guard folded too");
+  return 0;
+}

--- a/regression/esbmc/null_fnptr_guard_const_fold/main.c
+++ b/regression/esbmc/null_fnptr_guard_const_fold/main.c
@@ -46,5 +46,15 @@ int main(void)
     for (unsigned short i = 0; i < vm.sp; i++)
       m++;
   __ESBMC_assert(m == 2, "the nonnull guard folded too");
+
+  /* Constant-offset forms: an object base plus or minus a constant is
+   * still a real object's address in the (object, offset) model, even
+   * past the object's end. */
+  unsigned short *q = vm.cells + 8;
+  int k = 0;
+  if (q != 0 && q - 3 != 0 && 0 != q + 60)
+    for (unsigned short i = 0; i < vm.sp; i++)
+      k++;
+  __ESBMC_assert(k == 2, "the offset guards folded too");
   return 0;
 }

--- a/regression/esbmc/null_fnptr_guard_const_fold/main.c
+++ b/regression/esbmc/null_fnptr_guard_const_fold/main.c
@@ -1,6 +1,7 @@
-/* Bytecode-VM dispatch, one level deeper than the naive shape: the
- * null check and the handler call live in a callee, and the handler
- * mutates a shared machine struct. Without the fold the impossible
+/* Distilled from verifying a JavaCard VM's interpreter loop: handler
+ * dispatch through a static function-pointer table, one level deeper
+ * than the naive shape — the null check and the handler call live in a
+ * callee, and the handler mutates a shared machine struct. Without the fold the impossible
  * null path survives to the callee's return merge, the whole struct
  * becomes a phi of updated-vs-original, and every later member read
  * -- including the loop bound -- stops folding. */

--- a/regression/esbmc/null_fnptr_guard_const_fold/test.desc
+++ b/regression/esbmc/null_fnptr_guard_const_fold/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--unwind 30001 --no-unwinding-assertions
+^Generated \d+ VCC\(s\), 0 remaining after simplification \(\d+ assignments\)$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/null_fnptr_guard_const_fold_fail/main.c
+++ b/regression/esbmc/null_fnptr_guard_const_fold_fail/main.c
@@ -1,0 +1,37 @@
+/* Soundness twin: this table HAS null entries and the index is
+ * nondet, so the miss path is genuinely reachable — the fold must
+ * only fire for provably-nonnull addresses, never for a table read
+ * that can yield null. */
+typedef struct
+{
+  unsigned short cells[64];
+  unsigned char sp;
+  unsigned short pc;
+} vm_t;
+typedef int (*handler_t)(vm_t *);
+
+static int op_push(vm_t *v)
+{
+  v->cells[v->sp] = 7;
+  v->sp += 1;
+  return 0;
+}
+static const handler_t table[4] = {op_push, 0, op_push, 0};
+static vm_t vm;
+unsigned int nondet_u4(void);
+
+static int step(vm_t *v, unsigned int op)
+{
+  handler_t h = table[op & 3];
+  if (h == 0)
+    return 15;
+  return h(v);
+}
+
+int main(void)
+{
+  vm.sp = 1;
+  int st = step(&vm, nondet_u4());
+  __ESBMC_assert(st == 0, "a null entry must keep its miss path");
+  return 0;
+}

--- a/regression/esbmc/null_fnptr_guard_const_fold_fail/test.desc
+++ b/regression/esbmc/null_fnptr_guard_const_fold_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 4
+^VERIFICATION FAILED$

--- a/regression/esbmc/null_fnptr_guard_const_fold_fail/test.desc
+++ b/regression/esbmc/null_fnptr_guard_const_fold_fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
 --unwind 4
+^.*a null entry must keep its miss path.*$
 ^VERIFICATION FAILED$

--- a/src/util/expr/expr_simplifier.cpp
+++ b/src/util/expr/expr_simplifier.cpp
@@ -4368,11 +4368,110 @@ static expr2tc cancel_common_unary_operand(
   return expr2tc();
 }
 
+// Pointer-comparison constant folding. A comparison against the null
+// pointer is decidable whenever the other side is either also null or
+// provably a real object's address: in the memory model no object lives
+// at address zero, so `&sym == NULL` is false, as is
+// `(T*)((char*)&sym + k) == NULL` for ANY constant offset k — a
+// pointer value is an (object, offset) pair here, NULL is the null
+// object, and the comparison is decided by the object base alone, so
+// even an offset that walks past the object cannot alias null.
+// Without this fold every `p == NULL` guard over a concrete pointer
+// stays symbolic, every assignment downstream of it becomes guarded,
+// constant propagation dies with it, and data-independent loops behind
+// such guards unroll into formulas that scale with the object size.
+static bool is_null_pointer_value(const expr2tc &e)
+{
+  const expr2tc *p = &e;
+  while (is_typecast2t(*p))
+    p = &to_typecast2t(*p).from;
+  if (is_symbol2t(*p) && to_symbol2t(*p).thename == "NULL")
+    return true;
+  if (is_constant_int2t(*p) && to_constant_int2t(*p).value.is_zero())
+    return true;
+  return false;
+}
+
+static bool is_provably_nonnull_pointer(const expr2tc &e)
+{
+  const expr2tc *p = &e;
+  while (is_typecast2t(*p))
+    p = &to_typecast2t(*p).from;
+  if (is_address_of2t(*p))
+    return true;
+  // &sym + k / k + &sym / &sym - k: object base plus a constant offset
+  if (is_add2t(*p))
+  {
+    const add2t &a = to_add2t(*p);
+    if (is_constant_int2t(a.side_2))
+      return is_provably_nonnull_pointer(a.side_1);
+    if (is_constant_int2t(a.side_1))
+      return is_provably_nonnull_pointer(a.side_2);
+  }
+  if (is_sub2t(*p))
+  {
+    const sub2t &s = to_sub2t(*p);
+    if (is_constant_int2t(s.side_2))
+      return is_provably_nonnull_pointer(s.side_1);
+  }
+  return false;
+}
+
+// Returns true/false constant when the pointer comparison is decidable,
+// nil otherwise. `eq` selects the polarity.
+static expr2tc
+simplify_pointer_null_cmp(const expr2tc &s1, const expr2tc &s2, bool eq)
+{
+  if (!is_pointer_type(s1) && !is_pointer_type(s2))
+    return expr2tc();
+  bool n1 = is_null_pointer_value(s1);
+  bool n2 = is_null_pointer_value(s2);
+  if (n1 && n2)
+    return eq ? gen_true_expr() : gen_false_expr();
+  if (
+    (n1 && is_provably_nonnull_pointer(s2)) ||
+    (n2 && is_provably_nonnull_pointer(s1)))
+    return eq ? gen_false_expr() : gen_true_expr();
+  return expr2tc();
+}
+
+/// (x * c) == 0 -> x == 0 when c is odd, or nothing. Restricted to odd
+/// constants because modular bv multiplication is injective only for
+/// invertibles mod 2^width — i.e. constants coprime to 2^width, which
+/// for power-of-two moduli is exactly the odd constants. With c=2 in
+/// 8-bit unsigned, for example, x=128 also satisfies x*2 == 0 (mod
+/// 256), so dropping the multiplication would silently strengthen the
+/// predicate. The type guards keep the rewritten equality homogeneous.
+static expr2tc
+fold_odd_multiple_of_zero(const expr2tc &side_1, const expr2tc &side_2)
+{
+  if (!is_mul2t(side_1) || !is_constant_int2t(side_2))
+    return expr2tc();
+  if (!to_constant_int2t(side_2).value.is_zero())
+    return expr2tc();
+
+  const mul2t &mul_expr = to_mul2t(side_1);
+  if (
+    is_constant_int2t(mul_expr.side_2) &&
+    mul_expr.side_1->type == side_2->type &&
+    to_constant_int2t(mul_expr.side_2).value.is_odd())
+    return equality2tc(mul_expr.side_1, side_2);
+  if (
+    is_constant_int2t(mul_expr.side_1) &&
+    mul_expr.side_2->type == side_2->type &&
+    to_constant_int2t(mul_expr.side_1).value.is_odd())
+    return equality2tc(mul_expr.side_2, side_2);
+  return expr2tc();
+}
+
 expr2tc equality2t::do_simplify() const
 {
   // Self-comparison: x == x is always true (except for floats with NaN)
   if (side_1 == side_2 && !is_floatbv_type(side_1) && !is_floatbv_type(side_2))
     return gen_true_expr();
+
+  if (expr2tc r = simplify_pointer_null_cmp(side_1, side_2, true))
+    return r;
 
   // If we're dealing with floatbvs, call IEEE_equalitytor instead
   if (is_floatbv_type(side_1) || is_floatbv_type(side_2))
@@ -4396,44 +4495,8 @@ expr2tc equality2t::do_simplify() const
       !is_nil_expr(r))
     return r;
 
-  // (x * c) == 0 -> x == 0 when c is odd. Restricted to odd constants
-  // because modular bv multiplication is injective only for invertibles
-  // mod 2^width — i.e. constants coprime to 2^width, which for power-of-two
-  // moduli is exactly the odd constants. With c=2 in 8-bit unsigned, for
-  // example, x=128 also satisfies x*2 == 0 (mod 256), so dropping the
-  // multiplication would silently strengthen the predicate.
-  //
-  // Defensive type guard: equality2tc requires both sides to share a type.
-  // A well-formed mul2t already has homogeneous operands, but if a future
-  // construction path produces a mixed-width mul, the rewritten equality
-  // would mix widths too. Skip the rewrite unless mul.side_*->type matches
-  // side_2->type.
-  if (is_mul2t(side_1) && is_constant_int2t(side_2))
-  {
-    const mul2t &mul_expr = to_mul2t(side_1);
-    const BigInt &c2 = to_constant_int2t(side_2).value;
-
-    if (c2 == 0)
-    {
-      if (
-        is_constant_int2t(mul_expr.side_2) &&
-        mul_expr.side_1->type == side_2->type)
-      {
-        const BigInt &c1 = to_constant_int2t(mul_expr.side_2).value;
-        if (c1.is_odd())
-          return equality2tc(mul_expr.side_1, side_2);
-      }
-
-      if (
-        is_constant_int2t(mul_expr.side_1) &&
-        mul_expr.side_2->type == side_2->type)
-      {
-        const BigInt &c1 = to_constant_int2t(mul_expr.side_1).value;
-        if (c1.is_odd())
-          return equality2tc(mul_expr.side_2, side_2);
-      }
-    }
-  }
+  if (expr2tc r = fold_odd_multiple_of_zero(side_1, side_2); !is_nil_expr(r))
+    return r;
 
   if (expr2tc r = cancel_common_addend_operand(side_1, side_2, rebuild_eq);
       !is_nil_expr(r))
@@ -4497,6 +4560,9 @@ expr2tc notequal2t::do_simplify() const
   // Self-comparison: x != x is always false (except for floats with NaN)
   if (side_1 == side_2 && !is_floatbv_type(side_1) && !is_floatbv_type(side_2))
     return gen_false_expr();
+
+  if (expr2tc r = simplify_pointer_null_cmp(side_1, side_2, false))
+    return r;
 
   // If we're dealing with floatbvs, call IEEE_notequalitytor instead
   if (is_floatbv_type(side_1) || is_floatbv_type(side_2))

--- a/src/util/expr/expr_simplifier.cpp
+++ b/src/util/expr/expr_simplifier.cpp
@@ -4385,10 +4385,14 @@ simplify_pointer_null_cmp(const expr2tc &s1, const expr2tc &s2, bool eq)
     return eq ? gen_true_expr() : gen_false_expr();
   if (n1 == n2)
     return expr2tc();
+  // Only pointer-typed links preserve nullness: a cast through an
+  // integer type may truncate, and integer arithmetic can wrap to
+  // zero, so the peel stops at the first non-pointer node.
   const expr2tc *p = n1 ? &s2 : &s1;
-  while (true)
+  while (is_pointer_type((*p)->type))
   {
-    if (is_typecast2t(*p))
+    if (
+      is_typecast2t(*p) && is_pointer_type(to_typecast2t(*p).from->type))
       p = &to_typecast2t(*p).from;
     else if (is_add2t(*p) && is_constant_int2t(to_add2t(*p).side_2))
       p = &to_add2t(*p).side_1;

--- a/src/util/expr/expr_simplifier.cpp
+++ b/src/util/expr/expr_simplifier.cpp
@@ -4368,60 +4368,38 @@ static expr2tc cancel_common_unary_operand(
   return expr2tc();
 }
 
-// Null-pointer comparison folding: a pointer value is an (object,
-// offset) pair and no object lives at address zero, so `&sym ± k`
-// never aliases NULL for any constant k.
-static bool is_null_pointer(const expr2tc &e)
-{
-  const expr2tc *p = &e;
-  while (is_typecast2t(*p))
-    p = &to_typecast2t(*p).from;
-  if (is_symbol2t(*p) && to_symbol2t(*p).get_symbol_name() == "NULL")
-    return true;
-  return is_null_pointer_constant(*p);
-}
-
-static bool is_provably_nonnull_pointer(const expr2tc &e)
-{
-  const expr2tc *p = &e;
-  while (is_typecast2t(*p))
-    p = &to_typecast2t(*p).from;
-  // address_of(dereference(q)) is just q and may be NULL;
-  // same_object2t::do_simplify refuses the shape for the same reason.
-  if (is_address_of2t(*p))
-    return !is_dereference2t(to_address_of2t(*p).ptr_obj);
-  // &sym + k / k + &sym / &sym - k: object base plus a constant offset
-  if (is_add2t(*p))
-  {
-    const add2t &a = to_add2t(*p);
-    if (is_constant_int2t(a.side_2))
-      return is_provably_nonnull_pointer(a.side_1);
-    if (is_constant_int2t(a.side_1))
-      return is_provably_nonnull_pointer(a.side_2);
-  }
-  if (is_sub2t(*p))
-  {
-    const sub2t &s = to_sub2t(*p);
-    if (is_constant_int2t(s.side_2))
-      return is_provably_nonnull_pointer(s.side_1);
-  }
-  return false;
-}
-
-// Returns true/false constant when the pointer comparison is decidable,
-// nil otherwise. `eq` selects the polarity.
+// Returns a Boolean constant when a pointer comparison against NULL is
+// decidable, nil otherwise. `eq` selects the polarity. A pointer value
+// is an (object, offset) pair and no object lives at address zero, so
+// the non-null side peels casts and constant ± offsets down to its
+// root before the address_of root check: `(T *)(&sym + k) == NULL`
+// folds exactly like `&sym == NULL`.
 static expr2tc
 simplify_pointer_null_cmp(const expr2tc &s1, const expr2tc &s2, bool eq)
 {
   if (!is_pointer_type(s1) && !is_pointer_type(s2))
     return expr2tc();
-  bool n1 = is_null_pointer(s1);
-  bool n2 = is_null_pointer(s2);
+  bool n1 = is_null_pointer_value(s1);
+  bool n2 = is_null_pointer_value(s2);
   if (n1 && n2)
     return eq ? gen_true_expr() : gen_false_expr();
-  if (
-    (n1 && is_provably_nonnull_pointer(s2)) ||
-    (n2 && is_provably_nonnull_pointer(s1)))
+  if (n1 == n2)
+    return expr2tc();
+  const expr2tc *p = n1 ? &s2 : &s1;
+  while (true)
+  {
+    if (is_typecast2t(*p))
+      p = &to_typecast2t(*p).from;
+    else if (is_add2t(*p) && is_constant_int2t(to_add2t(*p).side_2))
+      p = &to_add2t(*p).side_1;
+    else if (is_add2t(*p) && is_constant_int2t(to_add2t(*p).side_1))
+      p = &to_add2t(*p).side_2;
+    else if (is_sub2t(*p) && is_constant_int2t(to_sub2t(*p).side_2))
+      p = &to_sub2t(*p).side_1;
+    else
+      break;
+  }
+  if (address_of_is_provably_non_null(*p))
     return eq ? gen_false_expr() : gen_true_expr();
   return expr2tc();
 }
@@ -4564,12 +4542,6 @@ expr2tc notequal2t::do_simplify() const
   if (expr2tc b = widened_bool_compared_to_zero(side_1, side_2);
       !is_nil_expr(b))
     return b;
-
-  // &x != NULL is true, the mirror of the == NULL rule same_object2t has.
-  if (is_null_pointer_value(side_1) && address_of_is_provably_non_null(side_2))
-    return gen_true_expr();
-  if (is_null_pointer_value(side_2) && address_of_is_provably_non_null(side_1))
-    return gen_true_expr();
 
   // The shape-canonicalizations below mirror equality2t::do_simplify. They are
   // the same rewrites: != x y holds iff == x y doesn't, so any rewrite that
@@ -5288,6 +5260,15 @@ static expr2tc obj_equals_addr_of(const expr2tc &a, const expr2tc &b)
 
   // We can't determine if they are the same object
   return expr2tc();
+}
+
+static bool is_null_pointer(const expr2tc &expr)
+{
+  // Check for explicit NULL symbol
+  if (is_symbol2t(expr) && to_symbol2t(expr).get_symbol_name() == "NULL")
+    return true;
+
+  return false;
 }
 
 expr2tc same_object2t::do_simplify() const

--- a/src/util/expr/expr_simplifier.cpp
+++ b/src/util/expr/expr_simplifier.cpp
@@ -4368,28 +4368,17 @@ static expr2tc cancel_common_unary_operand(
   return expr2tc();
 }
 
-// Pointer-comparison constant folding. A comparison against the null
-// pointer is decidable whenever the other side is either also null or
-// provably a real object's address: in the memory model no object lives
-// at address zero, so `&sym == NULL` is false, as is
-// `(T*)((char*)&sym + k) == NULL` for ANY constant offset k — a
-// pointer value is an (object, offset) pair here, NULL is the null
-// object, and the comparison is decided by the object base alone, so
-// even an offset that walks past the object cannot alias null.
-// Without this fold every `p == NULL` guard over a concrete pointer
-// stays symbolic, every assignment downstream of it becomes guarded,
-// constant propagation dies with it, and data-independent loops behind
-// such guards unroll into formulas that scale with the object size.
-static bool is_null_pointer_value(const expr2tc &e)
+// Null-pointer comparison folding: a pointer value is an (object,
+// offset) pair and no object lives at address zero, so `&sym ± k`
+// never aliases NULL for any constant k.
+static bool is_null_pointer(const expr2tc &e)
 {
   const expr2tc *p = &e;
   while (is_typecast2t(*p))
     p = &to_typecast2t(*p).from;
-  if (is_symbol2t(*p) && to_symbol2t(*p).thename == "NULL")
+  if (is_symbol2t(*p) && to_symbol2t(*p).get_symbol_name() == "NULL")
     return true;
-  if (is_constant_int2t(*p) && to_constant_int2t(*p).value.is_zero())
-    return true;
-  return false;
+  return is_null_pointer_constant(*p);
 }
 
 static bool is_provably_nonnull_pointer(const expr2tc &e)
@@ -4397,8 +4386,10 @@ static bool is_provably_nonnull_pointer(const expr2tc &e)
   const expr2tc *p = &e;
   while (is_typecast2t(*p))
     p = &to_typecast2t(*p).from;
+  // address_of(dereference(q)) is just q and may be NULL;
+  // same_object2t::do_simplify refuses the shape for the same reason.
   if (is_address_of2t(*p))
-    return true;
+    return !is_dereference2t(to_address_of2t(*p).ptr_obj);
   // &sym + k / k + &sym / &sym - k: object base plus a constant offset
   if (is_add2t(*p))
   {
@@ -4424,8 +4415,8 @@ simplify_pointer_null_cmp(const expr2tc &s1, const expr2tc &s2, bool eq)
 {
   if (!is_pointer_type(s1) && !is_pointer_type(s2))
     return expr2tc();
-  bool n1 = is_null_pointer_value(s1);
-  bool n2 = is_null_pointer_value(s2);
+  bool n1 = is_null_pointer(s1);
+  bool n2 = is_null_pointer(s2);
   if (n1 && n2)
     return eq ? gen_true_expr() : gen_false_expr();
   if (
@@ -5297,15 +5288,6 @@ static expr2tc obj_equals_addr_of(const expr2tc &a, const expr2tc &b)
 
   // We can't determine if they are the same object
   return expr2tc();
-}
-
-static bool is_null_pointer(const expr2tc &expr)
-{
-  // Check for explicit NULL symbol
-  if (is_symbol2t(expr) && to_symbol2t(expr).get_symbol_name() == "NULL")
-    return true;
-
-  return false;
 }
 
 expr2tc same_object2t::do_simplify() const

--- a/src/util/expr/expr_simplifier.cpp
+++ b/src/util/expr/expr_simplifier.cpp
@@ -4391,8 +4391,7 @@ simplify_pointer_null_cmp(const expr2tc &s1, const expr2tc &s2, bool eq)
   const expr2tc *p = n1 ? &s2 : &s1;
   while (is_pointer_type((*p)->type))
   {
-    if (
-      is_typecast2t(*p) && is_pointer_type(to_typecast2t(*p).from->type))
+    if (is_typecast2t(*p) && is_pointer_type(to_typecast2t(*p).from->type))
       p = &to_typecast2t(*p).from;
     else if (is_add2t(*p) && is_constant_int2t(to_add2t(*p).side_2))
       p = &to_add2t(*p).side_1;

--- a/unit/irep2/CMakeLists.txt
+++ b/unit/irep2/CMakeLists.txt
@@ -13,6 +13,7 @@ new_unit_test(irep2crcconsistencytest "crc_consistency.test.cpp" "util_esbmc")
 new_unit_test(irep2withtypetest "with_type.test.cpp" "util_esbmc")
 new_unit_test(irep2serialisationtest "serialisation.test.cpp" "util_esbmc")
 new_unit_test(irep2guardalgebratest "guard_algebra.test.cpp" "util_esbmc")
+new_unit_test(irep2nullcmpfoldtest "null_cmp_fold.test.cpp" "util_esbmc")
 
 # What the simplifier hook is handed (issue #7260). Only meaningful where the
 # build compiled verify_rewrite() into something other than a no-op.

--- a/unit/irep2/null_cmp_fold.test.cpp
+++ b/unit/irep2/null_cmp_fold.test.cpp
@@ -44,3 +44,36 @@ TEST_CASE("&*p == NULL must not fold", "[irep2][simplify]")
   if (!is_nil_expr(s))
     REQUIRE(!is_constant_bool2t(s));
 }
+
+TEST_CASE("(T *)(&obj + k) == NULL folds to false", "[irep2][simplify]")
+{
+  expr2tc obj = symbol2tc(get_int32_type(), irep_idt("obj"));
+  expr2tc arith = add2tc(
+    int_ptr(),
+    address_of2tc(int_ptr(), obj),
+    constant_int2tc(get_int32_type(), BigInt(2)));
+  expr2tc eq = equality2tc(typecast2tc(int_ptr(), arith), null_ptr());
+  expr2tc s = eq->simplify();
+  REQUIRE(is_constant_bool2t(s));
+  REQUIRE(!to_constant_bool2t(s).value);
+}
+
+TEST_CASE("&(*p)[i] + k == NULL must not fold", "[irep2][simplify]")
+{
+  // The peel must bottom out at the chain root: an index over a
+  // dereference roots at p, which may be NULL.
+  type2tc arr = array_type2tc(get_int32_type(), expr2tc(), true);
+  expr2tc p = symbol2tc(pointer_type2tc(arr), irep_idt("p"));
+  expr2tc elem = index2tc(
+    get_int32_type(),
+    dereference2tc(arr, p),
+    constant_int2tc(get_int32_type(), BigInt(1)));
+  expr2tc arith = add2tc(
+    int_ptr(),
+    address_of2tc(int_ptr(), elem),
+    constant_int2tc(get_int32_type(), BigInt(2)));
+  expr2tc eq = equality2tc(arith, null_ptr());
+  expr2tc s = eq->simplify();
+  if (!is_nil_expr(s))
+    REQUIRE(!is_constant_bool2t(s));
+}

--- a/unit/irep2/null_cmp_fold.test.cpp
+++ b/unit/irep2/null_cmp_fold.test.cpp
@@ -1,0 +1,46 @@
+// The null-comparison fold decides `&sym == NULL` but must refuse an
+// address_of over a dereference: `&*p` is p and may be NULL. Pinned
+// here because no C input reaches the fold with that shape — clang
+// folds `&*p` to `p` (C99 6.5.3.2p3) and `&p->m` lowers to pointer
+// arithmetic over the refused base symbol; the shape is internal.
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <irep2/irep2.h>
+#include <irep2/irep2_expr.h>
+#include <irep2/irep2_utils.h>
+#include <util/lang/c_types.h>
+#include <util/config/config.h>
+
+namespace
+{
+type2tc int_ptr()
+{
+  return pointer_type2tc(get_int32_type());
+}
+
+expr2tc null_ptr()
+{
+  return symbol2tc(int_ptr(), irep_idt("NULL"));
+}
+} // namespace
+
+TEST_CASE("&obj == NULL folds to false", "[irep2][simplify]")
+{
+  expr2tc obj = symbol2tc(get_int32_type(), irep_idt("obj"));
+  expr2tc eq = equality2tc(address_of2tc(int_ptr(), obj), null_ptr());
+  expr2tc s = eq->simplify();
+  REQUIRE(is_constant_bool2t(s));
+  REQUIRE(!to_constant_bool2t(s).value);
+}
+
+TEST_CASE("&*p == NULL must not fold", "[irep2][simplify]")
+{
+  expr2tc p = symbol2tc(int_ptr(), irep_idt("p"));
+  expr2tc roundtrip =
+    address_of2tc(int_ptr(), dereference2tc(get_int32_type(), p));
+  expr2tc eq = equality2tc(roundtrip, null_ptr());
+  expr2tc s = eq->simplify();
+  if (!is_nil_expr(s))
+    REQUIRE(!is_constant_bool2t(s));
+}

--- a/unit/irep2/null_cmp_fold.test.cpp
+++ b/unit/irep2/null_cmp_fold.test.cpp
@@ -58,6 +58,22 @@ TEST_CASE("(T *)(&obj + k) == NULL folds to false", "[irep2][simplify]")
   REQUIRE(!to_constant_bool2t(s).value);
 }
 
+TEST_CASE("truncating cast chain must not fold", "[irep2][simplify]")
+{
+  // (int *)(uint8_t)(uintptr_t)&obj: the 8-bit link can be zero even
+  // though &obj is not, so the peel must stop at the integer cast.
+  expr2tc obj = symbol2tc(get_int32_type(), irep_idt("obj"));
+  expr2tc chain = typecast2tc(
+    int_ptr(),
+    typecast2tc(
+      get_uint8_type(),
+      typecast2tc(get_uint64_type(), address_of2tc(int_ptr(), obj))));
+  expr2tc eq = equality2tc(chain, null_ptr());
+  expr2tc s = eq->simplify();
+  if (!is_nil_expr(s))
+    REQUIRE(!is_constant_bool2t(s));
+}
+
 TEST_CASE("&(*p)[i] + k == NULL must not fold", "[irep2][simplify]")
 {
   // The peel must bottom out at the chain root: an index over a


### PR DESCRIPTION
A comparison against the null pointer is decidable whenever the other side is provably a real object's address: no object lives at address zero, so `&sym == NULL` folds false, along with its typecast and constant-offset forms. Without the fold, a dispatch table's null guard forks; the impossible path survives to the callee's return merge, the shared machine struct becomes a phi of updated-vs-original, and every later member read — loop bounds included — stops folding.

Motivation (not an in-repo measurement): the fold was cut from verifying a JavaCard VM interpreter, where one such guard's fork turned a fast proof into an OOM at scale. That input is not in this repo, and the distilled `null_fnptr_guard_const_fold` does not reproduce the blowup — master discharges it in ~0.14 s. What the regression pair pins instead is the fold *firing*, via the VCC-count gate (`1 remaining` on master → `0 remaining` here); master fails the `^…0 remaining…$` line, so the test bites on behaviour, not timing. Independent audit measured the real effect as ~6% on a 424-test pointer-vs-NULL corpus — modest and real, not order-of-magnitude.

Rebased onto master per review: `simplify_pointer_null_cmp` peels casts and constant ± offsets and delegates to `address_of_is_provably_non_null`, with `is_null_pointer_value` on the null side — no new predicates, and the now-subsumed inline pair in `notequal2t` is removed. The pre-existing odd-multiplier rewrite moves to `fold_odd_multiple_of_zero`, keeping `equality2t::do_simplify` under its complexity baseline.

The review's guard concern was confirmed in-tree: python's list model emits deref-rooted address_of chains, and at the old head `github_3003_4_fail` generated 2 VCCs where 5 properties were expected. It passes on this branch. The unit cases pin the ±k peel and the deref-rooted refusal (mutation-checked).

Recorded assumption (per audit): `address_of_is_provably_non_null` answers yes for any `symbol2t` root, sound only because ESBMC does not model ELF weak symbols — `&weak_undefined_sym == NULL` is true in C. No change needed; noted against the day weak symbols are modelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KF35UFsRLTepueVdMce6bH
