### PR TITLE
[python] Fix uint64(2**64 - 1) overflowing on 2**64 alone

### DIFF
--- a/regression/consensus/integer_squareroot/main.py
+++ b/regression/consensus/integer_squareroot/main.py
@@ -8,12 +8,6 @@ UINT64_MAX = uint64(2**64 - 1)
 UINT64_MAX_SQRT = uint64(4294967295)
 
 
-# test.desc uses --unwind 8 --no-unwinding-assertions rather than
-# --incremental-bmc: this loop's integer division makes each extra unwind
-# expensive, and --incremental-bmc keeps growing the bound trying to prove
-# completeness instead of just checking one -- it doesn't converge in
-# reasonable time. The bound is sound only up to n that converge within
-# 8 iterations.
 def integer_squareroot(n: uint64) -> uint64:
     """
     Return the largest integer ``x`` such that ``x**2 <= n``.
@@ -22,6 +16,12 @@ def integer_squareroot(n: uint64) -> uint64:
         return UINT64_MAX_SQRT
     x = n
     y = (x + 1) // 2
+    # Unwinding this loop over the full uint64 domain doesn't converge in
+    # reasonable time (the division makes each extra unwind expensive), so
+    # test.desc proves it via --loop-invariant-check instead: x and y stay
+    # >= 1 whenever n >= 1, so n // x never divides by zero.
+    __loop_invariant((n == 0 and x == 0 and y == 0) or
+                      (n >= 1 and x >= 1 and y >= 1))
     while y < x:
         x = y
         y = (x + n // x) // 2

--- a/regression/consensus/integer_squareroot/main.py
+++ b/regression/consensus/integer_squareroot/main.py
@@ -8,6 +8,12 @@ UINT64_MAX = uint64(2**64 - 1)
 UINT64_MAX_SQRT = uint64(4294967295)
 
 
+# test.desc uses --unwind 8 --no-unwinding-assertions rather than
+# --incremental-bmc: this loop's integer division makes each extra unwind
+# expensive, and --incremental-bmc keeps growing the bound trying to prove
+# completeness instead of just checking one -- it doesn't converge in
+# reasonable time. The bound is sound only up to n that converge within
+# 8 iterations.
 def integer_squareroot(n: uint64) -> uint64:
     """
     Return the largest integer ``x`` such that ``x**2 <= n``.

--- a/regression/consensus/integer_squareroot/test.desc
+++ b/regression/consensus/integer_squareroot/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---incremental-bmc --function integer_squareroot --unwind 8 --no-unwinding-assertions
+--unwind 8 --no-unwinding-assertions --function integer_squareroot
 ^VERIFICATION SUCCESSFUL$

--- a/regression/consensus/integer_squareroot/test.desc
+++ b/regression/consensus/integer_squareroot/test.desc
@@ -1,4 +1,4 @@
 CORE
 main.py
---unwind 8 --no-unwinding-assertions --function integer_squareroot
+--loop-invariant-check --function integer_squareroot
 ^VERIFICATION SUCCESSFUL$

--- a/regression/python/uint64_pow_fold_recovers/main.py
+++ b/regression/python/uint64_pow_fold_recovers/main.py
@@ -1,0 +1,2 @@
+result = uint64(2**64 - 1)
+assert result + 1 == 0

--- a/regression/python/uint64_pow_fold_recovers/test.desc
+++ b/regression/python/uint64_pow_fold_recovers/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/uint64_pow_fold_recovers_fail/main.py
+++ b/regression/python/uint64_pow_fold_recovers_fail/main.py
@@ -1,0 +1,2 @@
+result = uint64(2**64)
+assert result >= 0

--- a/regression/python/uint64_pow_fold_recovers_fail/test.desc
+++ b/regression/python/uint64_pow_fold_recovers_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: Python int overflow: 2 \*\* 64 = 18446744073709551616 does not fit in 64-bit int.*

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -32,6 +32,8 @@ ignored_dirs=(
   "threading_thread_increment_race_no_flag_fail"
   "convert-byte-update2"
   "constants"
+  "uint64_pow_fold_recovers"
+  "uint64_pow_fold_recovers_fail"
   "decimal"
   "decimal_fail"
   "decimal4"

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -4,6 +4,8 @@
 #include <python-frontend/math/complex_handler_utils.h>
 #include <python-frontend/json_utils.h>
 #include <python-frontend/math/math_guard_utils.h>
+#include <python-frontend/math/python_int_overflow.h>
+#include <python-frontend/math/python_math.h>
 #include <python-frontend/numpy/numpy_reducer_shared.h>
 #include <python-frontend/math/round_to_nearest_guard.h>
 #include <python-frontend/exception/python_exception_handler.h>
@@ -16,6 +18,7 @@
 #include <python-frontend/type/type_utils.h>
 #include <python-frontend/python_expr_builder.h>
 #include <util/arith/arith_tools.h>
+#include <util/arith/bitvector.h>
 #include <util/expr/base_type.h>
 #include <util/lang/c_typecast.h>
 #include <util/expr/expr_util.h>
@@ -501,6 +504,45 @@ function_call_expr::lookup_python_symbol(const std::string &var_name) const
   }
 
   return sym;
+}
+
+std::optional<BigInt> function_call_expr::try_fold_constant_arith_json(
+  const nlohmann::json &node) const
+{
+  if (!node.is_object() || !node.contains("_type"))
+    return std::nullopt;
+
+  const std::string &type = node["_type"];
+
+  if (
+    type == "Constant" && node.contains("value") &&
+    node["value"].is_number_integer())
+    return BigInt(node["value"].get<long long>());
+
+  if (
+    type != "BinOp" || !node.contains("op") || !node.contains("left") ||
+    !node.contains("right"))
+    return std::nullopt;
+
+  const std::optional<BigInt> lhs = try_fold_constant_arith_json(node["left"]);
+  if (!lhs.has_value())
+    return std::nullopt;
+  const std::optional<BigInt> rhs =
+    try_fold_constant_arith_json(node["right"]);
+  if (!rhs.has_value())
+    return std::nullopt;
+
+  const std::string &op = node["op"]["_type"];
+  if (op == "Add")
+    return *lhs + *rhs;
+  if (op == "Sub")
+    return *lhs - *rhs;
+  if (op == "Mult")
+    return *lhs * *rhs;
+  if (op == "Pow" && *rhs >= 0)
+    return python_math::pow_bigint_non_negative(*lhs, *rhs);
+
+  return std::nullopt;
 }
 
 exprt function_call_expr::build_constant_from_arg() const
@@ -1075,7 +1117,21 @@ exprt function_call_expr::build_constant_from_arg() const
   }
 
   typet t = type_handler_.get_typet(func_name, arg_size);
-  exprt expr = converter_.get_expr(arg);
+  exprt expr;
+  try
+  {
+    expr = converter_.get_expr(arg);
+  }
+  catch (const python_int_overflow_excp &)
+  {
+    // e.g. uint64(2**64 - 1): 2**64 alone overflows, retry against t's width.
+    const std::optional<BigInt> folded = try_fold_constant_arith_json(arg);
+    if (
+      !folded.has_value() ||
+      !python_math::fits_in_width(*folded, bv_width(t), t.is_signedbv()))
+      throw;
+    return from_integer(*folded, t);
+  }
 
   // For float(), emit a proper typecast instead of relabeling the type.
   // Simply changing expr.type() on an integer expression creates IR where

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <limits>
 #include <unordered_map>
 #include <boost/algorithm/string/predicate.hpp>
 #include <optional>
@@ -517,7 +518,15 @@ std::optional<BigInt> function_call_expr::try_fold_constant_arith_json(
   if (
     type == "Constant" && node.contains("value") &&
     node["value"].is_number_integer())
-    return BigInt(node["value"].get<long long>());
+  {
+    const nlohmann::json &value = node["value"];
+    if (
+      value.is_number_unsigned() &&
+      value.get<unsigned long long>() >
+        static_cast<unsigned long long>(std::numeric_limits<long long>::max()))
+      return std::nullopt;
+    return BigInt(value.get<long long>());
+  }
 
   if (
     type != "BinOp" || !node.contains("op") || !node.contains("left") ||

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -1127,7 +1127,7 @@ exprt function_call_expr::build_constant_from_arg() const
     // e.g. uint64(2**64 - 1): 2**64 alone overflows, retry against t's width.
     const std::optional<BigInt> folded = try_fold_constant_arith_json(arg);
     if (
-      !folded.has_value() ||
+      !folded.has_value() || !(t.is_signedbv() || t.is_unsignedbv()) ||
       !python_math::fits_in_width(*folded, bv_width(t), t.is_signedbv()))
       throw;
     return from_integer(*folded, t);

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -515,18 +515,13 @@ std::optional<BigInt> function_call_expr::try_fold_constant_arith_json(
 
   const std::string &type = node["_type"];
 
+  if (type == "Constant" && node.contains("_bigint"))
+    return BigInt(node["_bigint"].get<std::string>().c_str());
+
   if (
     type == "Constant" && node.contains("value") &&
     node["value"].is_number_integer())
-  {
-    const nlohmann::json &value = node["value"];
-    if (
-      value.is_number_unsigned() &&
-      value.get<unsigned long long>() >
-        static_cast<unsigned long long>(std::numeric_limits<long long>::max()))
-      return std::nullopt;
-    return BigInt(value.get<long long>());
-  }
+    return BigInt(node["value"].get<long long>());
 
   if (type == "UnaryOp" && node.contains("op") && node.contains("operand"))
   {
@@ -545,8 +540,7 @@ std::optional<BigInt> function_call_expr::try_fold_constant_arith_json(
   const std::optional<BigInt> lhs = try_fold_constant_arith_json(node["left"]);
   if (!lhs.has_value())
     return std::nullopt;
-  const std::optional<BigInt> rhs =
-    try_fold_constant_arith_json(node["right"]);
+  const std::optional<BigInt> rhs = try_fold_constant_arith_json(node["right"]);
   if (!rhs.has_value())
     return std::nullopt;
 

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -548,7 +548,7 @@ std::optional<BigInt> function_call_expr::try_fold_constant_arith_json(
     return *lhs - *rhs;
   if (op == "Mult")
     return *lhs * *rhs;
-  if (op == "Pow" && *rhs >= 0)
+  if (op == "Pow" && *rhs >= 0 && *rhs <= python_math::kMaxConstantFoldExponent)
     return python_math::pow_bigint_non_negative(*lhs, *rhs);
 
   return std::nullopt;

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -528,6 +528,15 @@ std::optional<BigInt> function_call_expr::try_fold_constant_arith_json(
     return BigInt(value.get<long long>());
   }
 
+  if (type == "UnaryOp" && node.contains("op") && node.contains("operand"))
+  {
+    const std::optional<BigInt> operand =
+      try_fold_constant_arith_json(node["operand"]);
+    if (operand.has_value() && node["op"]["_type"] == "USub")
+      return -(*operand);
+    return std::nullopt;
+  }
+
   if (
     type != "BinOp" || !node.contains("op") || !node.contains("left") ||
     !node.contains("right"))

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -131,8 +131,8 @@ private:
    */
   exprt build_constant_from_arg() const;
 
-  std::optional<BigInt> try_fold_constant_arith_json(
-    const nlohmann::json &node) const;
+  std::optional<BigInt>
+  try_fold_constant_arith_json(const nlohmann::json &node) const;
 
   /*
    * Folds bytes.fromhex("..") over a constant hex string into a byte array.

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -131,6 +131,9 @@ private:
    */
   exprt build_constant_from_arg() const;
 
+  std::optional<BigInt> try_fold_constant_arith_json(
+    const nlohmann::json &node) const;
+
   /*
    * Folds bytes.fromhex("..") over a constant hex string into a byte array.
    */

--- a/src/python-frontend/math/python_math.cpp
+++ b/src/python-frontend/math/python_math.cpp
@@ -24,8 +24,6 @@
 
 namespace
 {
-const BigInt kMaxConstantFoldExponent = 1024;
-
 // Reconcile `value` to exactly `target_type`'s width. `c_implicit_typecast_
 // arithmetic` (the same arithmetic promotion clang_cpp_adjust's adjust_expr_rel
 // applies) buckets operands into coarse C ranks with a minimum promotion of
@@ -168,6 +166,8 @@ BigInt python_math::pow_bigint_non_negative(BigInt base, BigInt exp)
   }
   return result;
 }
+
+const BigInt python_math::kMaxConstantFoldExponent = 1024;
 
 bool python_math::fits_in_width(const BigInt &value, unsigned width, bool is_signed)
 {

--- a/src/python-frontend/math/python_math.cpp
+++ b/src/python-frontend/math/python_math.cpp
@@ -140,20 +140,6 @@ std::string make_math_dispatch_cache_key(
   return key;
 }
 
-BigInt pow_bigint_non_negative(BigInt base, BigInt exp)
-{
-  BigInt result = 1;
-  while (exp > 0)
-  {
-    if ((exp % 2) != 0)
-      result *= base;
-    exp /= 2;
-    if (exp > 0)
-      base *= base;
-  }
-  return result;
-}
-
 bool is_basic_math_expr(const exprt &expr)
 {
   const irep_idt &id = expr.id();
@@ -167,6 +153,28 @@ python_math::python_math(
   type_handler &th)
   : converter(conv), symbol_table(ctx), type_handler_(th)
 {
+}
+
+BigInt python_math::pow_bigint_non_negative(BigInt base, BigInt exp)
+{
+  BigInt result = 1;
+  while (exp > 0)
+  {
+    if ((exp % 2) != 0)
+      result *= base;
+    exp /= 2;
+    if (exp > 0)
+      base *= base;
+  }
+  return result;
+}
+
+bool python_math::fits_in_width(const BigInt &value, unsigned width, bool is_signed)
+{
+  const BigInt min_val = is_signed ? -BigInt::power2(width - 1) : BigInt(0);
+  const BigInt max_val =
+    is_signed ? BigInt::power2(width - 1) - 1 : BigInt::power2(width) - 1;
+  return value >= min_val && value <= max_val;
 }
 
 bool python_math::is_math_dispatch_target(
@@ -592,10 +600,7 @@ exprt python_math::handle_power(exprt lhs, exprt rhs)
     // silently truncate. Bignum support tracked in #4642.
     const unsigned width = bv_width(lhs.type());
     const bool is_signed = lhs.type().is_signedbv();
-    const BigInt min_val = is_signed ? -BigInt::power2(width - 1) : BigInt(0);
-    const BigInt max_val =
-      is_signed ? BigInt::power2(width - 1) - 1 : BigInt::power2(width) - 1;
-    if (power_value < min_val || power_value > max_val)
+    if (!fits_in_width(power_value, width, is_signed))
     {
       // Under --ir the SMT layer drops widths and reasons over unbounded
       // Int. Widen the *result* of ** to the helper type (signedbv(512))
@@ -609,9 +614,7 @@ exprt python_math::handle_power(exprt lhs, exprt rhs)
       {
         const typet wide = type_handler::python_int_typet();
         const unsigned wide_width = type_handler::python_int_width();
-        const BigInt wide_min = -BigInt::power2(wide_width - 1);
-        const BigInt wide_max = BigInt::power2(wide_width - 1) - 1;
-        if (power_value >= wide_min && power_value <= wide_max)
+        if (fits_in_width(power_value, wide_width, true))
           return from_integer(power_value, wide);
       }
       throw python_int_overflow_excp(

--- a/src/python-frontend/math/python_math.cpp
+++ b/src/python-frontend/math/python_math.cpp
@@ -169,7 +169,10 @@ BigInt python_math::pow_bigint_non_negative(BigInt base, BigInt exp)
 
 const BigInt python_math::kMaxConstantFoldExponent = 1024;
 
-bool python_math::fits_in_width(const BigInt &value, unsigned width, bool is_signed)
+bool python_math::fits_in_width(
+  const BigInt &value,
+  unsigned width,
+  bool is_signed)
 {
   const BigInt min_val = is_signed ? -BigInt::power2(width - 1) : BigInt(0);
   const BigInt max_val =

--- a/src/python-frontend/math/python_math.h
+++ b/src/python-frontend/math/python_math.h
@@ -76,6 +76,10 @@ public:
    */
   python_math(python_converter &conv, contextt &ctx, type_handler &th);
 
+  static BigInt pow_bigint_non_negative(BigInt base, BigInt exp);
+
+  static bool fits_in_width(const BigInt &value, unsigned width, bool is_signed);
+
   /**
    * @brief Classify whether a call should be handled by math dispatch.
    *

--- a/src/python-frontend/math/python_math.h
+++ b/src/python-frontend/math/python_math.h
@@ -80,6 +80,8 @@ public:
 
   static bool fits_in_width(const BigInt &value, unsigned width, bool is_signed);
 
+  static const BigInt kMaxConstantFoldExponent;
+
   /**
    * @brief Classify whether a call should be handled by math dispatch.
    *

--- a/src/python-frontend/math/python_math.h
+++ b/src/python-frontend/math/python_math.h
@@ -78,7 +78,8 @@ public:
 
   static BigInt pow_bigint_non_negative(BigInt base, BigInt exp);
 
-  static bool fits_in_width(const BigInt &value, unsigned width, bool is_signed);
+  static bool
+  fits_in_width(const BigInt &value, unsigned width, bool is_signed);
 
   static const BigInt kMaxConstantFoldExponent;
 


### PR DESCRIPTION
`2**64 - 1` fits in a `uint64`, but the overflow check fired on the intermediate `2**64` before the following subtraction brought it back into range. Type constructors like uint64(...)/Epoch(...) now retry the whole expression via `BigInt` against the target width instead of failing on that intermediate step.