### PR TITLE
[solver] Release the Bitwuzla sorts and model values ESBMC leaked

### DIFF
--- a/src/solvers/bitwuzla/CMakeLists.txt
+++ b/src/solvers/bitwuzla/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(Bitwuzla_MIN_VERSION "0.1")
+# The BitwuzlaTermManager interface this backend is written against, and the
+# term/sort reference counting it uses, both arrived in 0.4.0 (Bitwuzla NEWS.md).
+set(Bitwuzla_MIN_VERSION "0.4")
 
 if(DEFINED Bitwuzla_DIR)
     set(ENABLE_BITWUZLA ON)

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -22,6 +22,31 @@ namespace
  *  itself (issue #7063) that still leaves ESBMC's own reference, taken when the
  *  term was built, intact -- this holds only while nothing else in this file
  *  releases a term ESBMC still stores. */
+/** Owns one sort reference. bitwuzla.h states that any API function returning
+ *  a BitwuzlaSort returns a copy the receiver may release, so a getter's result
+ *  is +1 exactly like a term query's. */
+class sort_reft
+{
+public:
+  explicit sort_reft(BitwuzlaSort s) : s(s)
+  {
+  }
+  ~sort_reft()
+  {
+    bitwuzla_sort_release(s);
+  }
+  sort_reft(const sort_reft &) = delete;
+  sort_reft &operator=(const sort_reft &) = delete;
+
+  operator BitwuzlaSort() const
+  {
+    return s;
+  }
+
+private:
+  BitwuzlaSort s;
+};
+
 class value_reft
 {
 public:
@@ -926,8 +951,8 @@ void bitwuzla_convt::print_model()
   for (const auto &entry : symtable)
   {
     smt_astt term = entry.ast;
-    BitwuzlaSort sort =
-      bitwuzla_term_get_sort(to_solver_smt_ast<bitw_smt_ast>(term)->a);
+    sort_reft sort(
+      bitwuzla_term_get_sort(to_solver_smt_ast<bitw_smt_ast>(term)->a));
     fprintf(
       messaget::state.out,
       "(define-fun %s (",
@@ -947,11 +972,12 @@ void bitwuzla_convt::print_model()
       while (bitwuzla_term_get_kind(children[1]) == BITWUZLA_KIND_LAMBDA)
       {
         assert(bitwuzla_term_is_var(children[0]));
+        sort_reft child_sort(bitwuzla_term_get_sort(children[0]));
         fprintf(
           messaget::state.out,
           "(%s %s) ",
           bitwuzla_term_to_string(children[0]),
-          bitwuzla_sort_to_string(bitwuzla_term_get_sort(children[0])));
+          bitwuzla_sort_to_string(child_sort));
         value = children[1];
         children = bitwuzla_term_get_children(value, &size);
       }
@@ -963,15 +989,14 @@ void bitwuzla_convt::print_model()
       //       functions is called more than once in one printf call.
       //       Alternatively, we could also first get and copy the strings, use
       //       a single printf call, and then free the copied strings.
+      sort_reft last_sort(bitwuzla_term_get_sort(children[0]));
       fprintf(
         messaget::state.out,
         "(%s %s))",
         bitwuzla_term_to_string(children[0]),
-        bitwuzla_sort_to_string(bitwuzla_term_get_sort(children[0])));
-      fprintf(
-        messaget::state.out,
-        " %s",
-        bitwuzla_sort_to_string(bitwuzla_sort_fun_get_codomain(sort)));
+        bitwuzla_sort_to_string(last_sort));
+      sort_reft codomain(bitwuzla_sort_fun_get_codomain(sort));
+      fprintf(messaget::state.out, " %s", bitwuzla_sort_to_string(codomain));
       fprintf(
         messaget::state.out, " %s)\n", bitwuzla_term_to_string(children[1]));
     }
@@ -1471,8 +1496,9 @@ smt_astt bitwuzla_convt::mk_quantifier(
     original_terms.push_back(orig);
     std::string name =
       "qvar_" + std::to_string(quantifier_counter) + "_" + std::to_string(i);
-    bound_vars.push_back(bitwuzla_mk_var(
-      bitw_term_manager, bitwuzla_term_get_sort(orig), name.c_str()));
+    sort_reft orig_sort(bitwuzla_term_get_sort(orig));
+    bound_vars.push_back(
+      bitwuzla_mk_var(bitw_term_manager, orig_sort, name.c_str()));
   }
 
   // Substitute SSA terms with bound vars in the body.

--- a/src/solvers/bitwuzla/bitwuzla_conv.cpp
+++ b/src/solvers/bitwuzla/bitwuzla_conv.cpp
@@ -11,6 +11,40 @@ smt_astt bitw_smt_ast::with_sort(smt_solver_baset *ctx, smt_sortt s) const
   return ctx->new_solver_ast<bitw_smt_ast>(a, s);
 }
 
+namespace
+{
+/** Owns the term reference bitwuzla_get_value() hands back. The C API refcounts
+ *  every term it exports, so a model query that never releases its result pins
+ *  that term in the term manager for the lifetime of the solver.
+ *
+ *  Balanced because every export is exactly +1: releasing once undoes the
+ *  query's increment and no more. Where the query hands back the argument
+ *  itself (issue #7063) that still leaves ESBMC's own reference, taken when the
+ *  term was built, intact -- this holds only while nothing else in this file
+ *  releases a term ESBMC still stores. */
+class value_reft
+{
+public:
+  explicit value_reft(BitwuzlaTerm t) : t(t)
+  {
+  }
+  ~value_reft()
+  {
+    bitwuzla_term_release(t);
+  }
+  value_reft(const value_reft &) = delete;
+  value_reft &operator=(const value_reft &) = delete;
+
+  operator BitwuzlaTerm() const
+  {
+    return t;
+  }
+
+private:
+  BitwuzlaTerm t;
+};
+} // namespace
+
 void bitwuzla_error_handler(const char *msg)
 {
   log_error("Bitwuzla error encountered\n{}", msg);
@@ -720,7 +754,7 @@ smt_astt bitwuzla_convt::mk_ite(smt_astt cond, smt_astt t, smt_astt f)
 tvt bitwuzla_convt::get_bool(smt_astt a)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  BitwuzlaTerm value = bitwuzla_get_value(bitw, ast->a);
+  value_reft value(bitwuzla_get_value(bitw, ast->a));
 
   if (bitwuzla_term_is_true(value))
     return tvt(true);
@@ -737,10 +771,8 @@ tvt bitwuzla_convt::get_bool(smt_astt a)
 BigInt bitwuzla_convt::get_bv(smt_astt a, bool is_signed)
 {
   const bitw_smt_ast *ast = to_solver_smt_ast<bitw_smt_ast>(a);
-  const char *result =
-    bitwuzla_term_value_get_str(bitwuzla_get_value(bitw, ast->a));
-  BigInt val = binary2integer(result, is_signed);
-  return val;
+  value_reft value(bitwuzla_get_value(bitw, ast->a));
+  return binary2integer(bitwuzla_term_value_get_str(value), is_signed);
 }
 
 expr2tc bitwuzla_convt::get_array_elem(
@@ -757,11 +789,11 @@ expr2tc bitwuzla_convt::get_array_elem(
     idx = to_solver_smt_ast<bitw_smt_ast>(
       mk_smt_bv(BigInt(index), mk_bv_sort(array_bound)));
 
+  value_reft array_value(bitwuzla_get_value(bitw, za->a));
+  value_reft index_value(bitwuzla_get_value(bitw, idx->a));
+
   BitwuzlaTerm e = bitwuzla_mk_term2(
-    bitw_term_manager,
-    BITWUZLA_KIND_ARRAY_SELECT,
-    bitwuzla_get_value(bitw, za->a),
-    bitwuzla_get_value(bitw, idx->a));
+    bitw_term_manager, BITWUZLA_KIND_ARRAY_SELECT, array_value, index_value);
 
   return get_by_ast(subtype, new_ast(e, convert_sort(subtype)));
 }
@@ -904,6 +936,11 @@ void bitwuzla_convt::print_model()
     {
       BitwuzlaTerm value =
         bitwuzla_get_value(bitw, to_solver_smt_ast<bitw_smt_ast>(term)->a);
+      /* value walks down the lambda chain below; this owns the reference the
+       * query handed back, which the walk leaves behind on its first step. The
+       * walk stays valid past that release because bitwuzla_term_get_children
+       * exports every child with its own increment and never drops it. */
+      value_reft root(value);
       size_t size;
       BitwuzlaTerm *children = bitwuzla_term_get_children(value, &size);
       assert(size == 2);
@@ -940,74 +977,103 @@ void bitwuzla_convt::print_model()
     }
     else
     {
+      value_reft value(
+        bitwuzla_get_value(bitw, to_solver_smt_ast<bitw_smt_ast>(term)->a));
       fprintf(
         messaget::state.out,
         ") %s %s)\n",
         bitwuzla_sort_to_string(sort),
-        bitwuzla_term_to_string(
-          bitwuzla_get_value(bitw, to_solver_smt_ast<bitw_smt_ast>(term)->a)));
+        bitwuzla_term_to_string(value));
     }
   }
 }
 
 smt_sortt bitwuzla_convt::mk_bool_sort()
 {
-  return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BOOL, bitwuzla_mk_bool_sort(bitw_term_manager), 1);
+  return cached_sort({SMT_SORT_BOOL, 0, 0}, [this] {
+    return new solver_smt_sort<BitwuzlaSort>(
+      SMT_SORT_BOOL, bitwuzla_mk_bool_sort(bitw_term_manager), 1);
+  });
 }
 
 smt_sortt bitwuzla_convt::mk_bv_sort(std::size_t width)
 {
-  return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BV, bitwuzla_mk_bv_sort(bitw_term_manager, width), width);
+  return cached_sort({SMT_SORT_BV, width, 0}, [this, width] {
+    return new solver_smt_sort<BitwuzlaSort>(
+      SMT_SORT_BV, bitwuzla_mk_bv_sort(bitw_term_manager, width), width);
+  });
 }
 
 smt_sortt bitwuzla_convt::mk_fbv_sort(std::size_t width)
 {
-  return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_FIXEDBV, bitwuzla_mk_bv_sort(bitw_term_manager, width), width);
+  return cached_sort({SMT_SORT_FIXEDBV, width, 0}, [this, width] {
+    return new solver_smt_sort<BitwuzlaSort>(
+      SMT_SORT_FIXEDBV, bitwuzla_mk_bv_sort(bitw_term_manager, width), width);
+  });
 }
 
 smt_sortt bitwuzla_convt::mk_array_sort(smt_sortt domain, smt_sortt range)
 {
-  auto domain_sort = to_solver_smt_sort<BitwuzlaSort>(domain);
-  auto range_sort = to_solver_smt_sort<BitwuzlaSort>(range);
+  /* Keyed on the operand sorts' addresses: no smt_sort is ever freed (nothing
+   * under src/solvers/ deletes one, and pop_ctx frees only smt_asts), so an
+   * address can never be recycled into a different sort. Identity rather than
+   * width because a Bool domain and a 1-bit bit-vector domain are distinct
+   * Bitwuzla sorts that share a width. */
+  sort_keyt key{
+    SMT_SORT_ARRAY,
+    reinterpret_cast<uintptr_t>(domain),
+    reinterpret_cast<uintptr_t>(range)};
 
-  auto t =
-    bitwuzla_mk_array_sort(bitw_term_manager, domain_sort->s, range_sort->s);
-  return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_ARRAY, t, domain_sort->get_data_width(), range);
+  return cached_sort(key, [this, domain, range] {
+    auto domain_sort = to_solver_smt_sort<BitwuzlaSort>(domain);
+    return new solver_smt_sort<BitwuzlaSort>(
+      SMT_SORT_ARRAY,
+      bitwuzla_mk_array_sort(
+        bitw_term_manager,
+        domain_sort->s,
+        to_solver_smt_sort<BitwuzlaSort>(range)->s),
+      domain_sort->get_data_width(),
+      range);
+  });
 }
 
 smt_sortt bitwuzla_convt::mk_bvfp_sort(std::size_t ew, std::size_t sw)
 {
-  return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BVFP,
-    bitwuzla_mk_bv_sort(bitw_term_manager, ew + sw + 1),
-    ew + sw + 1,
-    sw + 1);
+  return cached_sort({SMT_SORT_BVFP, ew, sw}, [this, ew, sw] {
+    return new solver_smt_sort<BitwuzlaSort>(
+      SMT_SORT_BVFP,
+      bitwuzla_mk_bv_sort(bitw_term_manager, ew + sw + 1),
+      ew + sw + 1,
+      sw + 1);
+  });
 }
 
 smt_sortt bitwuzla_convt::mk_bvfp_rm_sort()
 {
-  return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(bitw_term_manager, 3), 3);
+  return cached_sort({SMT_SORT_BVFP_RM, 0, 0}, [this] {
+    return new solver_smt_sort<BitwuzlaSort>(
+      SMT_SORT_BVFP_RM, bitwuzla_mk_bv_sort(bitw_term_manager, 3), 3);
+  });
 }
 
 smt_sortt bitwuzla_convt::mk_fpbv_sort(const unsigned ew, const unsigned sw)
 {
   // sw excludes the hidden bit, which Bitwuzla's significand width includes.
-  return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_FPBV,
-    bitwuzla_mk_fp_sort(bitw_term_manager, ew, sw + 1),
-    ew + sw + 1,
-    sw + 1);
+  return cached_sort({SMT_SORT_FPBV, ew, sw}, [this, ew, sw] {
+    return new solver_smt_sort<BitwuzlaSort>(
+      SMT_SORT_FPBV,
+      bitwuzla_mk_fp_sort(bitw_term_manager, ew, sw + 1),
+      ew + sw + 1,
+      sw + 1);
+  });
 }
 
 smt_sortt bitwuzla_convt::mk_fpbv_rm_sort()
 {
-  return new solver_smt_sort<BitwuzlaSort>(
-    SMT_SORT_FPBV_RM, bitwuzla_mk_rm_sort(bitw_term_manager), 3);
+  return cached_sort({SMT_SORT_FPBV_RM, 0, 0}, [this] {
+    return new solver_smt_sort<BitwuzlaSort>(
+      SMT_SORT_FPBV_RM, bitwuzla_mk_rm_sort(bitw_term_manager), 3);
+  });
 }
 
 smt_astt bitwuzla_convt::mk_smt_fpbv(const ieee_floatt &thereal)
@@ -1376,8 +1442,8 @@ ieee_floatt bitwuzla_convt::get_fpbv(smt_astt a)
   const char *sign;
   const char *exponent;
   const char *significand;
-  bitwuzla_term_value_get_fp_ieee(
-    bitwuzla_get_value(bitw, ast->a), &sign, &exponent, &significand, 2);
+  value_reft value(bitwuzla_get_value(bitw, ast->a));
+  bitwuzla_term_value_get_fp_ieee(value, &sign, &exponent, &significand, 2);
 
   const unsigned ew = a->sort->get_exponent_width();
   const unsigned sw = a->sort->get_significand_width() - 1;

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -179,9 +179,10 @@ public:
   std::unordered_map<std::string, BitwuzlaTerm> uf_decls;
 
 private:
-  /** Identifies a sort by kind plus the two widths that parameterise it: the
+  /** Identifies a sort by kind plus the two values that parameterise it: the
    *  bit-width for bit-vectors, (exponent, significand) for floating-point, and
-   *  (domain width, range sort) for arrays. */
+   *  the domain and range sorts' addresses for arrays -- identity rather than
+   *  width, for the reason mk_array_sort gives. */
   typedef std::tuple<smt_sort_kind, uint64_t, uint64_t> sort_keyt;
 
   /** Sorts are immutable and outlive every context, so one instance per

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -2,6 +2,7 @@
 #define _ESBMC_SOLVERS_BITWUZLA_BITWUZLA_CONV_H_
 
 #include <cstdio>
+#include <map>
 #include <solvers/smt/smt_solver.h>
 #include <irep2/irep2.h>
 #include <util/symtab/namespace.h>
@@ -177,6 +178,26 @@ public:
   std::unordered_map<std::string, BitwuzlaTerm> uf_decls;
 
 private:
+  /** Identifies a sort by kind plus the two widths that parameterise it: the
+   *  bit-width for bit-vectors, (exponent, significand) for floating-point, and
+   *  (domain width, range sort) for arrays. */
+  typedef std::tuple<smt_sort_kind, uint64_t, uint64_t> sort_keyt;
+
+  /** Sorts are immutable and outlive every context, so one instance per
+   *  distinct sort suffices. mk_extract, mk_concat and the extends ask for a
+   *  bit-vector sort per call, and neither the solver_smt_sort nor the
+   *  Bitwuzla sort reference behind it is ever freed. */
+  std::map<sort_keyt, smt_sortt> bitw_sorts;
+
+  template <typename buildt>
+  smt_sortt cached_sort(const sort_keyt &key, buildt build)
+  {
+    auto it = bitw_sorts.find(key);
+    if (it == bitw_sorts.end())
+      it = bitw_sorts.emplace(key, build()).first;
+    return it->second;
+  }
+
   smt_astt
   mk_fp_arith(BitwuzlaKind kind, smt_astt lhs, smt_astt rhs, smt_astt rm);
   smt_astt mk_fp_pred(BitwuzlaKind kind, smt_astt lhs, smt_astt rhs);

--- a/src/solvers/bitwuzla/bitwuzla_conv.h
+++ b/src/solvers/bitwuzla/bitwuzla_conv.h
@@ -3,6 +3,7 @@
 
 #include <cstdio>
 #include <map>
+#include <tuple>
 #include <solvers/smt/smt_solver.h>
 #include <irep2/irep2.h>
 #include <util/symtab/namespace.h>

--- a/unit/solvers/CMakeLists.txt
+++ b/unit/solvers/CMakeLists.txt
@@ -26,6 +26,17 @@ if(ENABLE_Z3)
     PRIVATE ${Z3_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/src/solvers/z3)
 endif()
 
+if(ENABLE_BITWUZLA)
+  # Links `solverbitw` (the static lib carrying bitwuzla_conv.cpp) so the test
+  # can construct the backend directly: mk_*_sort is not reachable through
+  # smt_convt, and the sort cache it pins is a property of the backend, not of
+  # any query it answers. `solvers` supplies create_solver for the model half.
+  new_unit_test(bitwuzla_sort_cache_test "bitwuzla_sort_cache.test.cpp"
+                "solvers;util_esbmc;filesystem;bigint")
+  target_include_directories(bitwuzla_sort_cache_test
+    PRIVATE ${Bitwuzla_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/src/solvers/bitwuzla)
+endif()
+
 if(ENABLE_SMTLIB)
   # Verdict scanner shared by the one-shot subprocess backends (bitwuzllob,
   # neurosym); lives in the smtlib library. util_esbmc supplies the logging

--- a/unit/solvers/CMakeLists.txt
+++ b/unit/solvers/CMakeLists.txt
@@ -31,10 +31,15 @@ if(ENABLE_BITWUZLA)
   # can construct the backend directly: mk_*_sort is not reachable through
   # smt_convt, and the sort cache it pins is a property of the backend, not of
   # any query it answers. `solvers` supplies create_solver for the model half.
+  # Only the backend's own source dir is named here. Bitwuzla's include dirs
+  # arrive as a usage requirement of PkgConfig::Bitwuzla, which solverbitw
+  # links with the plain signature; naming that imported target here instead
+  # is a configure error, as pkg_check_modules created it in the solver's
+  # directory scope rather than GLOBAL.
   new_unit_test(bitwuzla_sort_cache_test "bitwuzla_sort_cache.test.cpp"
                 "solvers;util_esbmc;filesystem;bigint")
   target_include_directories(bitwuzla_sort_cache_test
-    PRIVATE ${Bitwuzla_INCLUDE_DIRS} ${CMAKE_SOURCE_DIR}/src/solvers/bitwuzla)
+    PRIVATE ${CMAKE_SOURCE_DIR}/src/solvers/bitwuzla)
 endif()
 
 if(ENABLE_SMTLIB)

--- a/unit/solvers/bitwuzla_sort_cache.test.cpp
+++ b/unit/solvers/bitwuzla_sort_cache.test.cpp
@@ -1,0 +1,221 @@
+// Sort and model-value ownership in the Bitwuzla backend.
+//
+// Bitwuzla's C API refcounts every sort and term it exports and expects the
+// caller to release them (src/api/c/bitwuzla_structs.cpp). The backend used to
+// mint a fresh solver_smt_sort -- and with it a fresh Bitwuzla sort reference
+// -- on every mk_bv_sort call, and mk_extract/mk_concat/mk_sign_ext/mk_zero_ext
+// ask for one per operation, so neither was ever freed. The first SCENARIO
+// pins the cache that fixes it: a sort is built once per distinct sort, and
+// the key discriminates the kinds that share a width.
+//
+// The second drives a full solve and reads every value back, which is the only
+// way the matching model-query fix is observable: over-releasing the reference
+// bitwuzla_get_value() hands out is a use-after-free inside the term manager,
+// not a wrong answer.
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <memory>
+#include <irep2/irep2_utils.h>
+#include <solvers/smt/smt_conv.h>
+#include <solvers/smt/smt_result.h>
+#include <solvers/smt/smt_solver.h>
+#include <solvers/solve.h>
+#include <util/arith/arith_tools.h>
+#include <util/config/config.h>
+#include <util/config/options.h>
+#include <util/lang/c_types.h>
+#include <util/symtab/context.h>
+#include <util/symtab/namespace.h>
+#include <bitwuzla_conv.h>
+
+// The Bitwuzla backend publishes no header for its creator; solve.cpp declares
+// the type, bitwuzla_conv.cpp defines the symbol.
+extern solver_creator create_new_bitwuzla_solver;
+
+SCENARIO("the Bitwuzla backend builds each sort once", "[solvers][bitwuzla]")
+{
+  contextt ctx;
+  namespacet ns(ctx);
+  optionst options;
+  tuple_iface *tuple_api = nullptr;
+  array_iface *array_api = nullptr;
+  fp_convt *fp_api = nullptr;
+  std::unique_ptr<smt_solver_baset> base{
+    create_new_bitwuzla_solver(options, ns, &tuple_api, &array_api, &fp_api)};
+  REQUIRE(base != nullptr);
+  bitwuzla_convt *solver = dynamic_cast<bitwuzla_convt *>(base.get());
+  REQUIRE(solver != nullptr);
+
+  GIVEN("a bit-vector sort requested twice at the same width")
+  {
+    THEN("the same sort object comes back")
+    {
+      REQUIRE(solver->mk_bv_sort(32) == solver->mk_bv_sort(32));
+    }
+    THEN("a different width is a different sort")
+    {
+      REQUIRE(solver->mk_bv_sort(32) != solver->mk_bv_sort(64));
+    }
+    THEN("the cached sort still reports its own width")
+    {
+      REQUIRE(solver->mk_bv_sort(32)->get_data_width() == 32);
+      REQUIRE(solver->mk_bv_sort(64)->get_data_width() == 64);
+    }
+  }
+
+  GIVEN("two sort kinds that share a width")
+  {
+    THEN("a fixed-point sort is not the bit-vector sort of the same width")
+    {
+      REQUIRE(solver->mk_bv_sort(32) != solver->mk_fbv_sort(32));
+      REQUIRE(solver->mk_fbv_sort(32)->id == SMT_SORT_FIXEDBV);
+    }
+    THEN("a bit-vector float is not the native float of the same format")
+    {
+      REQUIRE(solver->mk_bvfp_sort(8, 23) != solver->mk_fpbv_sort(8, 23));
+      REQUIRE(solver->mk_bvfp_sort(8, 23)->id == SMT_SORT_BVFP);
+      REQUIRE(solver->mk_fpbv_sort(8, 23)->id == SMT_SORT_FPBV);
+    }
+    THEN("the two rounding-mode sorts stay distinct")
+    {
+      REQUIRE(solver->mk_bvfp_rm_sort() != solver->mk_fpbv_rm_sort());
+    }
+  }
+
+  GIVEN("the nullary sorts")
+  {
+    THEN("each is built once")
+    {
+      REQUIRE(solver->mk_bool_sort() == solver->mk_bool_sort());
+      REQUIRE(solver->mk_bvfp_rm_sort() == solver->mk_bvfp_rm_sort());
+      REQUIRE(solver->mk_fpbv_rm_sort() == solver->mk_fpbv_rm_sort());
+    }
+  }
+
+  GIVEN("floating-point sorts differing in their field widths")
+  {
+    // Bitwuzla is built --no-fpexp, so a native fp sort must name one of the
+    // standard formats; the bit-vector encodings below are unconstrained.
+    THEN("a native float sort is built once per format")
+    {
+      REQUIRE(solver->mk_fpbv_sort(8, 23) == solver->mk_fpbv_sort(8, 23));
+      REQUIRE(solver->mk_fpbv_sort(8, 23) != solver->mk_fpbv_sort(11, 52));
+      REQUIRE(solver->mk_fpbv_sort(5, 10) != solver->mk_fpbv_sort(8, 23));
+    }
+    THEN("exponent and significand discriminate independently")
+    {
+      // Same total width, different split: a key on width alone collides.
+      REQUIRE(solver->mk_bvfp_sort(8, 23) != solver->mk_bvfp_sort(11, 20));
+      REQUIRE(
+        solver->mk_bvfp_sort(8, 23)->get_data_width() ==
+        solver->mk_bvfp_sort(11, 20)->get_data_width());
+      // Differing only in the significand, so the key's last field carries it.
+      REQUIRE(solver->mk_bvfp_sort(8, 23) != solver->mk_bvfp_sort(8, 24));
+      REQUIRE(solver->mk_bvfp_sort(8, 24)->get_data_width() == 33);
+    }
+  }
+
+  GIVEN("array sorts over cached domains and ranges")
+  {
+    smt_sortt dom = solver->mk_bv_sort(8);
+    smt_sortt u32 = solver->mk_bv_sort(32);
+    smt_sortt u64 = solver->mk_bv_sort(64);
+
+    THEN("the same domain and range give the same array sort")
+    {
+      REQUIRE(
+        solver->mk_array_sort(dom, u32) == solver->mk_array_sort(dom, u32));
+    }
+    THEN("a different range is a different array sort")
+    {
+      REQUIRE(
+        solver->mk_array_sort(dom, u32) != solver->mk_array_sort(dom, u64));
+    }
+    THEN("a different domain is a different array sort")
+    {
+      REQUIRE(
+        solver->mk_array_sort(dom, u32) !=
+        solver->mk_array_sort(solver->mk_bv_sort(16), u32));
+      // Same width, different kind: the domain half of the key is an identity,
+      // not a width, so these must not collide.
+      REQUIRE(
+        solver->mk_array_sort(solver->mk_bv_sort(8), u32) !=
+        solver->mk_array_sort(solver->mk_fbv_sort(8), u32));
+    }
+    THEN("the cached array sort keeps its domain width and range")
+    {
+      smt_sortt arr = solver->mk_array_sort(dom, u32);
+      REQUIRE(arr->id == SMT_SORT_ARRAY);
+      REQUIRE(arr->get_domain_width() == 8);
+      REQUIRE(arr->get_range_sort() == u32);
+    }
+  }
+}
+
+SCENARIO("Bitwuzla model values survive being read back", "[solvers][bitwuzla]")
+{
+  config.ansi_c.set_data_model(configt::LP64);
+  contextt ctx;
+  namespacet ns(ctx);
+  optionst options;
+  std::unique_ptr<smt_convt> solver{create_solver("bitwuzla", ns, options)};
+  REQUIRE(solver != nullptr);
+
+  const type2tc u32 = get_uint32_type();
+  const type2tc arr_type = array_type2tc(u32, from_integer(4, u32), false);
+
+  // One constrained scalar per query, plus a bool and an array element, so
+  // every model-reading path in the backend runs at least once.
+  std::vector<expr2tc> scalars;
+  for (unsigned i = 0; i < 8; i++)
+  {
+    expr2tc sym = symbol2tc(u32, "s" + std::to_string(i));
+    solver->assert_expr(equality2tc(sym, from_integer(0xdead0000 + i, u32)));
+    scalars.push_back(sym);
+  }
+
+  const expr2tc flag = symbol2tc(get_bool_type(), "flag");
+  solver->assert_expr(flag);
+
+  const expr2tc arr = symbol2tc(arr_type, "a");
+  const expr2tc elem = index2tc(u32, arr, from_integer(2, u32));
+  solver->assert_expr(equality2tc(elem, from_integer(0xbeef, u32)));
+
+  REQUIRE(solver->dec_solve() == smt_resultt::P_SATISFIABLE);
+
+  GIVEN("a satisfiable model")
+  {
+    THEN("every scalar reads back its asserted value")
+    {
+      for (unsigned i = 0; i < scalars.size(); i++)
+      {
+        expr2tc v = solver->get(scalars[i]);
+        REQUIRE(is_constant_int2t(v));
+        REQUIRE(to_constant_int2t(v).value == BigInt(0xdead0000 + i));
+      }
+    }
+    THEN("the boolean reads back true")
+    {
+      REQUIRE(solver->l_get(flag).is_true());
+    }
+    THEN("the array element reads back its asserted value")
+    {
+      expr2tc v = solver->get(elem);
+      REQUIRE(is_constant_int2t(v));
+      REQUIRE(to_constant_int2t(v).value == BigInt(0xbeef));
+    }
+    THEN("repeating every query returns the same values")
+    {
+      for (unsigned round = 0; round < 3; round++)
+      {
+        for (unsigned i = 0; i < scalars.size(); i++)
+          REQUIRE(
+            to_constant_int2t(solver->get(scalars[i])).value ==
+            BigInt(0xdead0000 + i));
+        REQUIRE(solver->l_get(flag).is_true());
+        REQUIRE(to_constant_int2t(solver->get(elem)).value == BigInt(0xbeef));
+      }
+    }
+  }
+}

--- a/unit/solvers/bitwuzla_sort_cache.test.cpp
+++ b/unit/solvers/bitwuzla_sort_cache.test.cpp
@@ -165,8 +165,9 @@ SCENARIO("Bitwuzla model values survive being read back", "[solvers][bitwuzla]")
   const type2tc u32 = get_uint32_type();
   const type2tc arr_type = array_type2tc(u32, from_integer(4, u32), false);
 
-  // One constrained scalar per query, plus a bool and an array element, so
-  // every model-reading path in the backend runs at least once.
+  // One constrained scalar per query, plus a bool, a float and an array
+  // element, so every backend entry point that takes a value_reft runs at
+  // least once: get_bv, get_bool, get_fpbv, get_array_elem and print_model.
   std::vector<expr2tc> scalars;
   for (unsigned i = 0; i < 8; i++)
   {
@@ -181,6 +182,14 @@ SCENARIO("Bitwuzla model values survive being read back", "[solvers][bitwuzla]")
   const expr2tc arr = symbol2tc(arr_type, "a");
   const expr2tc elem = index2tc(u32, arr, from_integer(2, u32));
   solver->assert_expr(equality2tc(elem, from_integer(0xbeef, u32)));
+
+  // create_new_bitwuzla_solver hands the convt out as the fp_convt, so a
+  // floatbv symbol routes smt_convt::get() into bitwuzla_convt::get_fpbv.
+  ieee_floatt half(ieee_float_spect::double_precision());
+  half.from_double(0.5);
+  const expr2tc fsym =
+    symbol2tc(ieee_float_spect::double_precision().get_type(), "f");
+  solver->assert_expr(equality2tc(fsym, constant_floatbv2tc(half)));
 
   REQUIRE(solver->dec_solve() == smt_resultt::P_SATISFIABLE);
 
@@ -204,6 +213,16 @@ SCENARIO("Bitwuzla model values survive being read back", "[solvers][bitwuzla]")
       expr2tc v = solver->get(elem);
       REQUIRE(is_constant_int2t(v));
       REQUIRE(to_constant_int2t(v).value == BigInt(0xbeef));
+    }
+    THEN("the float reads back its asserted value")
+    {
+      expr2tc v = solver->get(fsym);
+      REQUIRE(is_constant_floatbv2t(v));
+      REQUIRE(to_constant_floatbv2t(v).value.to_double() == 0.5);
+    }
+    THEN("printing the model releases every value it reads")
+    {
+      solver->print_model();
     }
     THEN("repeating every query returns the same values")
     {


### PR DESCRIPTION
Bitwuzla's C API refcounts every sort and term it exports and expects the caller to release them; the backend released neither. `mk_extract`, `mk_concat` and the extends ask for a bit-vector sort per operation, so each minted a `solver_smt_sort` plus a Bitwuzla sort reference that nothing freed — 12,216 allocations for five distinct sorts on an 8k-line input, now constant in the problem size. Model queries now release the reference `bitwuzla_get_value()` hands back.

This is step one of moving the backend to Bitwuzla's C++ API (upstream's suggestion); it fixes the leaks that need no API change.

Notes for review:

- SCENARIO 1 of the new test is a gate: disabling the cache flips 4 assertions, and each of the key's three fields was mutated independently and caught. SCENARIO 2 passes on unpatched code unless built with ASan — under ASan an injected double-release SEGVs in `bzla::Node::is_value()`. The Sanitizers workflow runs only the CORE regression suite, so that gate is manual for now.
- The three added lines under `print_model`'s `bitwuzla_sort_is_fun` branch look unreachable (`is_fun` is false for arrays, and `symtable` holds no fun-sorted symbol). Kept, since they are correct if it ever runs; deleting the branch needs its own PR and a C-Dead proof.
- `Bitwuzla_MIN_VERSION` 0.1 to 0.4: the file already called `bitwuzla_term_manager_new`, which 0.1-0.3 do not have.
- The same `solver_smt_sort`-per-call leak exists in every other backend; a shared helper on `smt_solver_baset` is the follow-up.
