### PR TITLE
[clang-c] Decode both IREP2 call shapes behind one accessor

### DIFF
--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -10,6 +10,7 @@
 #include <util/symtab/namespace.h>
 #include <util/symtab/pretty.h>
 #include <util/symtab/cprover_prefix.h>
+#include <optional>
 #include <utility>
 
 bool clang_c_adjust_irep2::adjust()
@@ -138,6 +139,74 @@ static bool is_call_site(const expr2tc &expr)
 {
   return is_code_function_call2t(expr) || is_sideeffect2t(expr);
 }
+
+namespace
+{
+/// A call decoded to interior pointers into the live node. IREP2 spells a call
+/// two ways -- a code_function_call2t (callee in `.function`, arguments in
+/// `.operands`) and a sideeffect2t of kind function_call (callee in `.operand`,
+/// arguments in `.arguments`) -- and this is the one place that knows which.
+/// The pointers give a caller both a read and an in-place write of the callee
+/// (`*callee = x`) and of the argument vector, from a single decode.
+///
+/// It deliberately carries no location: a code_function_call2t has its own, a
+/// sideeffect2t borrows the enclosing statement's, and the two are recovered
+/// inconsistently per site, so that stays with each caller.
+///
+/// A borrow: the pointers are valid only while `expr` keeps its current node. A
+/// callee write-back keeps them valid -- it reassigns the member, not the node;
+/// rebinding the whole node (`expr = <other>`) invalidates them. No caller here
+/// does the latter while a view is live.
+struct call_view
+{
+  expr2tc *callee;
+  std::vector<expr2tc> *arguments;
+};
+
+struct const_call_view
+{
+  const expr2tc *callee;
+  const std::vector<expr2tc> *arguments;
+};
+
+/// nullopt when `expr` is not a call -- a sideeffect2t of any other kind, or a
+/// node of neither shape. The per-site is_nil_expr / is_symbol2t checks on the
+/// callee stay with the callers.
+std::optional<call_view> as_call(expr2tc &expr)
+{
+  if (is_code_function_call2t(expr))
+  {
+    code_function_call2t &c = to_code_function_call2t(expr);
+    return call_view{&c.function, &c.operands};
+  }
+  if (is_sideeffect2t(expr))
+  {
+    sideeffect2t &s = to_sideeffect2t(expr);
+    if (s.kind == sideeffect_allockind::function_call)
+      return call_view{&s.operand, &s.arguments};
+  }
+  return std::nullopt;
+}
+
+/// The const overload for a read-only caller. It uses the non-detaching const
+/// accessor, so a site holding a `const expr2tc &` stays read-only and pays no
+/// copy-on-write clone.
+std::optional<const_call_view> as_call(const expr2tc &expr)
+{
+  if (is_code_function_call2t(expr))
+  {
+    const code_function_call2t &c = to_code_function_call2t(expr);
+    return const_call_view{&c.function, &c.operands};
+  }
+  if (is_sideeffect2t(expr))
+  {
+    const sideeffect2t &s = to_sideeffect2t(expr);
+    if (s.kind == sideeffect_allockind::function_call)
+      return const_call_view{&s.operand, &s.arguments};
+  }
+  return std::nullopt;
+}
+} // namespace
 
 /// The unary operators promote_unary_bool_operand claims: the complement of
 /// is_complex_unary within the family. The chain spelled this exclusion as the
@@ -889,17 +958,13 @@ void clang_c_adjust_irep2::adjust_function_designators(expr2tc &expr)
 
 void clang_c_adjust_irep2::adjust_call_callee(expr2tc &expr)
 {
-  expr2tc callee;
-  if (is_code_function_call2t(expr))
-    callee = to_code_function_call2t(expr).function;
-  else
-  {
-    const sideeffect2t &se = to_sideeffect2t(expr);
-    if (se.kind != sideeffect_allockind::function_call)
-      return;
-    callee = se.operand;
-  }
+  const std::optional<call_view> call = as_call(expr);
+  if (!call)
+    return;
 
+  // A local copy of the callee, as the original kept, independent of the slot
+  // the write-backs below overwrite.
+  const expr2tc callee = *call->callee;
   if (is_nil_expr(callee))
     return;
 
@@ -908,24 +973,14 @@ void clang_c_adjust_irep2::adjust_call_callee(expr2tc &expr)
   // carries the same shape and is told apart only by the implicit bit (§100).
   if (is_address_of2t(callee) && to_address_of2t(callee).implicit)
   {
-    const expr2tc target = to_address_of2t(callee).ptr_obj;
-    if (is_code_function_call2t(expr))
-      to_code_function_call2t(expr).function = target;
-    else
-      to_sideeffect2t(expr).operand = target;
+    *call->callee = to_address_of2t(callee).ptr_obj;
     return;
   }
 
   if (!is_pointer_type(callee->type))
     return;
 
-  const expr2tc deref =
-    dereference2tc(to_pointer_type(callee->type).subtype, callee);
-
-  if (is_code_function_call2t(expr))
-    to_code_function_call2t(expr).function = deref;
-  else
-    to_sideeffect2t(expr).operand = deref;
+  *call->callee = dereference2tc(to_pointer_type(callee->type).subtype, callee);
 }
 
 /// True when \p arg is bound to parameter \p i of \p callee rather than
@@ -978,25 +1033,15 @@ static bool binds_by_reference(
 
 void clang_c_adjust_irep2::adjust_call_arguments(expr2tc &expr)
 {
-  expr2tc callee;
-  std::vector<expr2tc> *args;
-  if (is_code_function_call2t(expr))
-  {
-    code_function_call2t &call = to_code_function_call2t(expr);
-    callee = call.function;
-    args = &call.operands;
-  }
-  else
-  {
-    sideeffect2t &se = to_sideeffect2t(expr);
-    if (se.kind != sideeffect_allockind::function_call)
-      return;
-    callee = se.operand;
-    args = &se.arguments;
-  }
+  const std::optional<call_view> call = as_call(expr);
+  if (!call)
+    return;
 
+  const expr2tc &callee = *call->callee;
   if (is_nil_expr(callee))
     return;
+
+  std::vector<expr2tc> &args = *call->arguments;
 
   type2tc ct = callee->type;
   if (is_pointer_type(ct))
@@ -1006,9 +1051,9 @@ void clang_c_adjust_irep2::adjust_call_arguments(expr2tc &expr)
 
   const std::vector<type2tc> &params = to_code_type(ct).arguments;
 
-  for (std::size_t i = 0; i < args->size(); i++)
+  for (std::size_t i = 0; i < args.size(); i++)
   {
-    expr2tc &arg = (*args)[i];
+    expr2tc &arg = args[i];
     if (is_nil_expr(arg))
       continue;
 
@@ -1328,38 +1373,26 @@ void clang_c_adjust_irep2::adjust_complex_unary(expr2tc &expr)
 
 void clang_c_adjust_irep2::declare_polymorphic_builtin(expr2tc &expr)
 {
-  // The caller admits these two kinds only, so there is no third arm to guard:
-  // to_sideeffect2t throws loudly on anything else rather than silently
-  // skipping a call that should have been declared.
-  expr2tc callee;
-  const std::vector<expr2tc> *args = nullptr;
-  locationt loc;
-  if (is_code_function_call2t(expr))
-  {
-    const code_function_call2t &call = to_code_function_call2t(expr);
-    callee = call.function;
-    args = &call.operands;
-    loc = call.location;
-  }
-  else
-  {
-    const sideeffect2t &se = to_sideeffect2t(expr);
-    if (se.kind != sideeffect_allockind::function_call)
-      return;
-    callee = se.operand;
-    args = &se.arguments;
-    loc = enclosing_location;
-  }
+  const std::optional<call_view> call = as_call(expr);
+  if (!call)
+    return;
 
+  const expr2tc callee = *call->callee;
   if (is_nil_expr(callee) || !is_symbol2t(callee))
     return;
+
+  // Location stays per site, not in the call view: a code_function_call2t
+  // carries its own, a sideeffect2t borrows the enclosing statement's.
+  const locationt loc = is_code_function_call2t(expr)
+                          ? to_code_function_call2t(expr).location
+                          : enclosing_location;
 
   // Every arm of the matcher selects on the first argument's *type* alone, so
   // the values need not cross the seam. A future arm that reads a value gets a
   // nil operand and fails visibly rather than silently selecting wrong.
   exprt::operandst arg_types;
-  arg_types.reserve(args->size());
-  for (const expr2tc &arg : *args)
+  arg_types.reserve(call->arguments->size());
+  for (const expr2tc &arg : *call->arguments)
   {
     if (is_nil_expr(arg))
       return;
@@ -1379,10 +1412,7 @@ void clang_c_adjust_irep2::declare_polymorphic_builtin(expr2tc &expr)
 
   expr2tc target;
   migrate_expr(poly, target);
-  if (is_code_function_call2t(expr))
-    to_code_function_call2t(expr).function = target;
-  else
-    to_sideeffect2t(expr).operand = target;
+  *call->callee = target;
 }
 
 void clang_c_adjust_irep2::declare_implicit_callee(
@@ -1390,31 +1420,23 @@ void clang_c_adjust_irep2::declare_implicit_callee(
   const locationt &stmt_location)
 {
   // A bare `f(x);` statement is a sideeffect2t of kind function_call, not a
-  // code_function_call2t; both spellings reach here.
-  expr2tc callee;
-  locationt loc;
-  if (is_code_function_call2t(expr))
-  {
-    const code_function_call2t &call = to_code_function_call2t(expr);
-    callee = call.function;
-    loc = call.location;
-  }
-  else if (is_sideeffect2t(expr))
-  {
-    const sideeffect2t &se = to_sideeffect2t(expr);
-    if (se.kind != sideeffect_allockind::function_call)
-      return;
-    callee = se.operand;
-    // sideeffect2t has no location of its own. The enclosing statement's is
-    // the call's only when the call is the whole statement, which is the one
-    // position this is passed from.
-    loc = stmt_location;
-  }
-  else
+  // code_function_call2t; both spellings reach here. The const overload keeps
+  // this a read-only, non-detaching decode.
+  const std::optional<const_call_view> call = as_call(expr);
+  if (!call)
     return;
 
+  const expr2tc &callee = *call->callee;
   if (is_nil_expr(callee) || !is_symbol2t(callee))
     return;
+
+  // Location stays per site: a code_function_call2t carries its own; a
+  // sideeffect2t has none, so the caller passes the enclosing statement's --
+  // the call's only when the call is the whole statement, the one position this
+  // is reached from.
+  const locationt loc = is_code_function_call2t(expr)
+                          ? to_code_function_call2t(expr).location
+                          : stmt_location;
 
   const irep_idt id = to_symbol2t(callee).thename;
   if (context.find_symbol(id) != nullptr)

--- a/unit/clang-c-frontend/adjust_arms.test.cpp
+++ b/unit/clang-c-frontend/adjust_arms.test.cpp
@@ -187,6 +187,138 @@ SCENARIO(
   }
 }
 
+SCENARIO(
+  "the IREP2 adjuster decodes both call shapes and rewrites the callee",
+  "[core][clang-c-frontend][irep2-adjust]")
+{
+  // A no-argument function, and the implicit `&f` designator sugar the frontend
+  // installs on a direct call. adjust_call_callee strips it back to a direct f.
+  const type2tc ftype = code_type2tc(
+    std::vector<type2tc>{}, get_empty_type(), std::vector<irep_idt>{}, false);
+  const expr2tc f = symbol2tc(ftype, "f");
+  const expr2tc sugar = address_of2tc(ftype, f, /*is_implicit=*/true);
+
+  GIVEN("a code_function_call2t whose callee is the implicit &f sugar")
+  {
+    contextt ctx;
+    clang_c_adjust_irep2 pass(ctx, true);
+    expr2tc call =
+      code_function_call2tc(expr2tc(), sugar, std::vector<expr2tc>{});
+
+    WHEN("the pass adjusts it")
+    {
+      // Driven through adjust_expr, the pass's own interface. as_call reads the
+      // callee from the code_function_call2t's .function slot and writes it
+      // back there; the implicit &f collapses to a direct f.
+      pass.adjust_expr(call);
+
+      THEN("the callee is decoded from .function and the sugar stripped")
+      {
+        REQUIRE(to_code_function_call2t(call).function == f);
+      }
+    }
+  }
+
+  GIVEN("a sideeffect2t of kind function_call with the same &f sugar")
+  {
+    contextt ctx;
+    clang_c_adjust_irep2 pass(ctx, true);
+    expr2tc call = sideeffect2tc(
+      get_empty_type(),
+      sugar,
+      expr2tc(),
+      std::vector<expr2tc>{},
+      type2tc(),
+      sideeffect_allockind::function_call);
+
+    WHEN("the pass adjusts it")
+    {
+      // The other spelling: the callee lives in .operand, not .function, and
+      // as_call must read and write the same node through that slot.
+      pass.adjust_expr(call);
+
+      THEN("the callee is decoded from .operand and the sugar stripped")
+      {
+        REQUIRE(to_sideeffect2t(call).operand == f);
+      }
+    }
+  }
+
+  GIVEN("a sideeffect2t of a non-call kind through a function pointer")
+  {
+    contextt ctx;
+    clang_c_adjust_irep2 pass(ctx, true);
+    const expr2tc fp = symbol2tc(pointer_type2tc(ftype), "fp");
+    expr2tc se = sideeffect2tc(
+      get_int_type(32),
+      fp,
+      expr2tc(),
+      std::vector<expr2tc>{},
+      type2tc(),
+      sideeffect_allockind::nondet);
+
+    WHEN("the pass adjusts it")
+    {
+      // as_call's kind gate rejects any sideeffect2t that is not a call, so
+      // adjust_call_callee leaves the pointer-typed operand undereferenced.
+      pass.adjust_expr(se);
+
+      THEN("the callee slot is untouched")
+      {
+        REQUIRE(to_sideeffect2t(se).operand == fp);
+      }
+    }
+  }
+
+  // The other write-back branch: a pointer-typed callee is dereferenced in
+  // place, through the same *call->callee slot, for both shapes.
+  const expr2tc fp = symbol2tc(pointer_type2tc(ftype), "fp");
+
+  GIVEN("a code_function_call2t through a function pointer")
+  {
+    contextt ctx;
+    clang_c_adjust_irep2 pass(ctx, true);
+    expr2tc call = code_function_call2tc(expr2tc(), fp, std::vector<expr2tc>{});
+
+    WHEN("the pass adjusts it")
+    {
+      pass.adjust_expr(call);
+
+      THEN("the .function slot is dereferenced")
+      {
+        const expr2tc &callee = to_code_function_call2t(call).function;
+        REQUIRE(is_dereference2t(callee));
+        REQUIRE(to_dereference2t(callee).value == fp);
+      }
+    }
+  }
+
+  GIVEN("a sideeffect2t of kind function_call through a function pointer")
+  {
+    contextt ctx;
+    clang_c_adjust_irep2 pass(ctx, true);
+    expr2tc call = sideeffect2tc(
+      get_empty_type(),
+      fp,
+      expr2tc(),
+      std::vector<expr2tc>{},
+      type2tc(),
+      sideeffect_allockind::function_call);
+
+    WHEN("the pass adjusts it")
+    {
+      pass.adjust_expr(call);
+
+      THEN("the .operand slot is dereferenced")
+      {
+        const expr2tc &callee = to_sideeffect2t(call).operand;
+        REQUIRE(is_dereference2t(callee));
+        REQUIRE(to_dereference2t(callee).value == fp);
+      }
+    }
+  }
+}
+
 int main(int argc, char *argv[])
 {
   // c_typecastt ranks operands against config.ansi_c, which is zero-initialised


### PR DESCRIPTION
## What & why

The IREP2 C-frontend adjust pass (`clang_c_adjust_irep2.cpp`, the hottest file in
the tree — 30 edits in the last 300 commits) is a **shallow seam** around a real
variation: an IREP2 call has two representations, and every method that touches a
call had to re-destructure both by hand.

- `code_function_call2t` — callee in `.function`, arguments in `.operands`, carries a location.
- `sideeffect2t` with `kind == function_call` — callee in `.operand`, arguments in `.arguments`, no location.

**Four** methods each opened with a ~10–14 line `if/else` decoding both shapes, and
two wrote the callee back with a *second* `if/else`. The knowledge of "which member
holds the callee" was spread across the file, and the copies had drifted.

## The deepening (codebase-design vocabulary)

Introduce a **deep seam** — a file-local `call_view` returned by `as_call()` — that
concentrates the two-representation decode in one place. `as_call` decodes once into
**interior pointers** into the live node, so a caller reads *and* writes the callee
(`*call->callee = x`) and mutates the argument vector in place through a single
interface. The callee write-back `if/else` disappears entirely.

**Before** — every site wires the decode itself (solid = interface a caller learns):

```mermaid
graph LR
  A1[adjust_call_callee] --> D[decode: code_function_call2t vs sideeffect2t]
  A2[adjust_call_arguments] --> D
  A3[declare_polymorphic_builtin] --> D
  A4[declare_implicit_callee] --> D
  A1 --> W[write-back: two if/else copies]
  A3 --> W
```

**After** — one seam; the decode and write-back are inside it (dashed = implementation):

```mermaid
graph LR
  A1[adjust_call_callee] --> V[as_call / call_view]
  A2[adjust_call_arguments] --> V
  A3[declare_polymorphic_builtin] --> V
  A4[declare_implicit_callee] --> V
  V -.-> D[decode both shapes]
  V -.-> W[read/write callee, mutate args]
```

- **Leverage**: four call sites stop re-destructuring; a fifth call-shaped arm reuses the seam instead of copying a decode.
- **Locality**: the two-representation knowledge lives in one function; a future IREP2 change to how calls are represented is a one-seam edit.
- **Test surface**: both call shapes are now pinnable through the existing
  `adjust_arms.test.cpp` Catch2 harness (which drives the pass via `adjust_expr`),
  where before this behaviour was only reachable end-to-end.

### Deliberately out of scope
- **Location is recovered per-site, not unified.** The two shapes recover a call's
  location *differently and inconsistently* (`declare_polymorphic_builtin` reads the
  `enclosing_location` member; `declare_implicit_callee` reads its `stmt_location`
  parameter). Unifying it would change behaviour, so `as_call` carries no location and
  each `loc = …` line stays put.
- **`adjust_special_functions` is left untouched** — it is single-shape
  (`is_sideeffect2t`-gated) and reassigns `expr` while a node reference is live, so a
  borrowed `call_view` would dangle there for no decode saving.

## Testing

- One new `SCENARIO` in `adjust_arms.test.cpp` with 5 `GIVEN`s (the target now runs
  4 scenarios / 23 assertions total), driving **both** call shapes through
  `adjust_expr`: `adjust_call_callee`'s two write-back branches (implicit-`&f` strip
  *and* pointer dereference), both callee slots (`.function` and `.operand`), and the
  `kind == function_call` gate (a `nondet` sideeffect is left untouched). The
  `declare_polymorphic_builtin` write-back only fires for a real `__sync_*` builtin, so
  it stays regression-covered rather than unit-pinned here; its decode and per-site
  location path *are* exercised by the pointer-callee cases.
- **Mutation-checked**: removing `as_call`'s kind gate flips the negative test red
  (the operand gets dereferenced); the whole target is green with it restored.
- `adjustarmstest` (23 assertions) and `typecasttest` (12) pass; clang-format 11 clean.
- This is a **behaviour-preserving refactor** — no verification behaviour changes, so
  a `VERIFICATION SUCCESSFUL` / `VERIFICATION FAILED` regression pair does not apply;
  the unit scenario is what pins the change. The full solver-backed regression suite
  was **not** run in this budget-constrained routine (Release, `-j6`, no solver); CI
  runs it.

## How this PR was produced (pm-deepen audit)

Autonomous architecture-deepening pass. Three sub-agents scanned the repo's hot spots;
candidates were scored `leverage×2 + locality + heat + (6 − blast_radius)`:

| Candidate | Score | Note |
|---|---|---|
| **`call-site-decode-seam` (this PR)** | **22/25** | lev 4, loc 4, blast 1, heat 5 |
| `python-list-shadow-type-map-sync` | 22/25 | runner-up candidate — lev 5, loc 5, blast 3, heat 4 |
| `simplify-constant-domain-dispatch` | 21/25 | one constant-domain dispatcher for the simplifier |
| `python-list-mutator-prologue-seam` | 21/25 | receiver-resolver behind the list-method tables |
| `binary-operand-pair-walk-seam` | 19/25 | companion seam in the same file |

**Runner-up candidate**: `python-list-shadow-type-map-sync` tied at 22/25 (folding the
element-type shadow into the list builders — highest leverage, kills a documented bug
class), but **lost the deterministic tie-break on blast radius** (3 vs 1: ~10 files/43
call sites, correctness-critical, end-to-end test surface) — the wrong shape for the
first unattended firing, better landed once the contained seams exist.

### Design (design-it-twice + independent adjudication)

Three interfaces were designed and an independent adjudicator (which authored none)
picked the winner on depth → locality → seam placement → test surface → blast radius:

- **Winner** — decoded `call_view` via `std::optional` (this PR): deepest — one
  `as_call` yields kind-check + callee + arguments + in-place write from a single decode.
- **Runner-up design** — a `call_sitet` wrapper class. It matches the winner's
  single-decode depth but **reaches it only by breaking a `const` contract the winner
  keeps**: its constructor needs a mutable `expr2tc&`, forcing
  `declare_implicit_callee(const expr2tc&)` to non-const (a header change + a COW detach
  at a read-only site). The winner maps a `const` overload onto the existing
  non-detaching const accessor, so the read-only site stays read-only for free.
- Third — minimal free functions; rejected for failing the "one decode is better than N"
  seam test (it triple-decodes at `declare_polymorphic_builtin`).

## Proposed ADR

> **ADR: A call's two IREP2 representations are decoded through one accessor, not re-destructured.**
>
> **Context.** IREP2 spells a function call two ways — `code_function_call2t` and
> `sideeffect2t{kind == function_call}` — with the callee and argument list in
> differently-named members. Code that must handle both (notably the C-frontend adjust
> passes) tends to re-destructure both shapes inline at every site, which drifts.
>
> **Decision.** Such code decodes a call through a single accessor that yields the callee
> and arguments (and, where mutation is needed, interior pointers for in-place write),
> rather than branching on the representation at each site. Location is not part of that
> accessor: the two shapes recover it differently and it stays per-site.
>
> **Status.** Proposed. This PR applies it within `clang_c_adjust_irep2.cpp` via a
> file-local `as_call`; the pattern generalises to other passes that touch calls.

*(An ADR is only **proposed** here — this autonomous run does not write ADRs. No
`CONTEXT.md` exists in this repo, so no glossary term was added; the concept is
documented on the `call_view`/`as_call` doc-comments instead.)*

## Note on the audit report

pm-deepen normally commits its full report and backlog under `.architecture/`, but that
directory is **gitignored in this repo** (`.gitignore:48`, added by commit #7485, which
names this skill). Per the run's autonomy contract this run does **not** force-add it
(that would reverse a maintainer's deliberate decision), so the report/backlog live as
local working docs and their content is mirrored into this PR body. Cross-firing backlog
dedup will not persist through the repo until a maintainer chooses to track
`.architecture/` — that is the maintainer's call, not this run's.
