### PR TITLE
[python] Add dynamic-typing ordering between two tagged scalars

### DIFF
--- a/regression/python/dynamic_type_eq_tagged_bool_int/main.py
+++ b/regression/python/dynamic_type_eq_tagged_bool_int/main.py
@@ -1,0 +1,10 @@
+# bool and int compare equal to each other in real Python.
+cond = nondet_bool()
+if cond:
+    x = True
+    y = 1
+else:
+    x = "a"
+    y = "b"
+if cond:
+    assert x == y

--- a/regression/python/dynamic_type_eq_tagged_bool_int/test.desc
+++ b/regression/python/dynamic_type_eq_tagged_bool_int/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_eq_tagged_bool_int_fail/main.py
+++ b/regression/python/dynamic_type_eq_tagged_bool_int_fail/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = True
+    y = 2
+else:
+    x = "a"
+    y = "b"
+if cond:
+    assert x == y

--- a/regression/python/dynamic_type_eq_tagged_bool_int_fail/test.desc
+++ b/regression/python/dynamic_type_eq_tagged_bool_int_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_ordered_dyn_bound_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_ordered_dyn_bound_fail/main.py
@@ -1,0 +1,9 @@
+# A tagged str this long is beyond what ESBMC models.
+cond = nondet_bool()
+if cond:
+    x = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    y = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+else:
+    x = 1
+    y = 2
+assert x < y

--- a/regression/python/dynamic_type_scalar_tag_ordered_dyn_bound_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_ordered_dyn_bound_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+^.*tagged str exceeds the modelled bound.*$

--- a/regression/python/dynamic_type_scalar_tag_ordered_dyn_typeerror/main.py
+++ b/regression/python/dynamic_type_scalar_tag_ordered_dyn_typeerror/main.py
@@ -1,0 +1,11 @@
+# x/y diverge in opposite polarity, so x < y is a num/str mismatch
+# either way, an uncaught TypeError regardless of cond.
+cond = nondet_bool()
+if cond:
+    x = 5
+    y = "b"
+else:
+    x = "a"
+    y = 3
+
+assert x < y

--- a/regression/python/dynamic_type_scalar_tag_ordered_dyn_typeerror/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_ordered_dyn_typeerror/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_ordered_num_dyn/main.py
+++ b/regression/python/dynamic_type_scalar_tag_ordered_num_dyn/main.py
@@ -1,0 +1,11 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+    y = 5
+    assert not (x < y)
+    assert x <= y
+    assert not (y > x)
+    assert y >= x
+else:
+    x = "a"
+    y = "a"

--- a/regression/python/dynamic_type_scalar_tag_ordered_num_dyn/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_ordered_num_dyn/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_ordered_num_dyn_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_ordered_num_dyn_fail/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+    y = 5
+    assert x < y
+else:
+    x = "a"
+    y = "a"

--- a/regression/python/dynamic_type_scalar_tag_ordered_num_dyn_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_ordered_num_dyn_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_ordered_str_dyn/main.py
+++ b/regression/python/dynamic_type_scalar_tag_ordered_str_dyn/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = "ab"
+    y = "abc"
+    assert x < y
+    assert not (y < x)
+else:
+    x = 1
+    y = 1

--- a/regression/python/dynamic_type_scalar_tag_ordered_str_dyn/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_ordered_str_dyn/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_ordered_str_dyn_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_ordered_str_dyn_fail/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = "ab"
+    y = "abc"
+    assert y < x
+else:
+    x = 1
+    y = 1

--- a/regression/python/dynamic_type_scalar_tag_ordered_str_dyn_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_ordered_str_dyn_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/scalar.c
+++ b/src/c2goto/library/python/scalar.c
@@ -58,39 +58,6 @@ __ESBMC_HIDE:;
   return *(const long long *)tagged->value == value;
 }
 
-// Tagged-vs-tagged equality. Dispatching on `type_id` before any byte compare
-// keeps the numeric arm at a fixed width, so only two tagged strings reach
-// the byte loop below, which the numeric case would otherwise pay for too.
-int __python_scalar_eq_obj(
-  const PyObject *a,
-  const PyObject *b,
-  size_t num_type_id)
-{
-__ESBMC_HIDE:;
-  // Python compares across types as unequal rather than coercing.
-  if (a->type_id != b->type_id)
-    return 0;
-  if (a->type_id == num_type_id)
-    return *(const long long *)a->value == *(const long long *)b->value;
-  if (a->size != b->size)
-    return 0;
-  // `.size` is only known at runtime, so memcmp's loop bound would be
-  // symbolic and never unwind to completion; a compile-time bound keeps this
-  // loop finite. Do not "simplify" it back to memcmp. `.size` counts the
-  // trailing NUL, so the limit here is 255 characters -- one below the length
-  // bound __python_strnlen_bounded applies.
-  __ESBMC_assert(
-    a->size <= ESBMC_PY_STRNLEN_BOUND, "tagged str exceeds the modelled bound");
-  for (size_t i = 0; i < ESBMC_PY_STRNLEN_BOUND; ++i)
-  {
-    if (i >= a->size)
-      break;
-    if (((const uint8_t *)a->value)[i] != ((const uint8_t *)b->value)[i])
-      return 0;
-  }
-  return 1;
-}
-
 int __python_scalar_eq_str(
   const PyObject *tagged,
   size_t type_id,
@@ -153,6 +120,76 @@ __ESBMC_HIDE:;
       return a < b ? -1 : 1;
   }
   return tagged->size > value_size ? 1 : 0;
+}
+
+// Tagged-vs-tagged equality. `bool` and `int` compare equal in real
+// Python (`True == 1`), so both count as numeric here.
+int __python_scalar_eq_obj(
+  const PyObject *a,
+  const PyObject *b,
+  size_t num_type_id,
+  size_t bool_type_id)
+{
+__ESBMC_HIDE:;
+  int a_num = a->type_id == num_type_id || a->type_id == bool_type_id;
+  int b_num = b->type_id == num_type_id || b->type_id == bool_type_id;
+  if (a_num || b_num)
+    return a_num && b_num &&
+           *(const long long *)a->value == *(const long long *)b->value;
+  // Python compares across types as unequal rather than coercing.
+  if (a->type_id != b->type_id || a->size != b->size)
+    return 0;
+  __ESBMC_assert(
+    a->size <= ESBMC_PY_STRNLEN_BOUND, "tagged str exceeds the modelled bound");
+  for (size_t i = 0; i < ESBMC_PY_STRNLEN_BOUND; ++i)
+  {
+    if (i >= a->size)
+      break;
+    if (((const uint8_t *)a->value)[i] != ((const uint8_t *)b->value)[i])
+      return 0;
+  }
+  return 1;
+}
+
+// Three-way compare (-1/0/1) between two tagged scalars, for Lt/LtE/Gt/GtE.
+// A type mismatch here is a genuine TypeError, unlike equality.
+int __python_scalar_cmp_obj(
+  const PyObject *a,
+  const PyObject *b,
+  size_t num_type_id,
+  size_t bool_type_id)
+{
+__ESBMC_HIDE:;
+  int a_num = a->type_id == num_type_id || a->type_id == bool_type_id;
+  int b_num = b->type_id == num_type_id || b->type_id == bool_type_id;
+  __ESBMC_assert(
+    a_num == b_num && (a_num || a->type_id == b->type_id),
+    "TypeError: comparison not supported between these types");
+  if (!(a_num == b_num && (a_num || a->type_id == b->type_id)))
+    return 0;
+  if (a_num)
+  {
+    long long av = *(const long long *)a->value;
+    long long bv = *(const long long *)b->value;
+    if (av < bv)
+      return -1;
+    if (av > bv)
+      return 1;
+    return 0;
+  }
+  __ESBMC_assert(
+    a->size <= ESBMC_PY_STRNLEN_BOUND && b->size <= ESBMC_PY_STRNLEN_BOUND,
+    "tagged str exceeds the modelled bound");
+  for (size_t i = 0; i < ESBMC_PY_STRNLEN_BOUND; ++i)
+  {
+    if (i >= a->size || i >= b->size)
+      break;
+    unsigned char av = ((const unsigned char *)a->value)[i];
+    unsigned char bv = ((const unsigned char *)b->value)[i];
+    if (av != bv)
+      return av < bv ? -1 : 1;
+  }
+  return (a->size > b->size) - (a->size < b->size);
 }
 
 // Models a runtime type mismatch (e.g. `x + 1` where `x` holds a str) as a

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
@@ -484,9 +484,7 @@ exprt dynamic_type_handler::handle_comparison(
   if (lhs_tagged && rhs_tagged)
   {
     if (ordered)
-      throw std::runtime_error(
-        "ordering two dynamically-typed variables directly is not yet "
-        "supported");
+      return build_ordered_obj(op, lhs, rhs);
 
     const symbolt *eq_obj_func =
       converter_.symbol_table().find_symbol("c:@F@__python_scalar_eq_obj");
@@ -496,7 +494,8 @@ exprt dynamic_type_handler::handle_comparison(
       int_type(),
       {build_address_of(lhs),
        build_address_of(rhs),
-       type_handler_.tagged_scalar_type_id(long_long_int_type())});
+       type_handler_.tagged_scalar_type_id(long_long_int_type()),
+       type_handler_.tagged_scalar_type_id(bool_type())});
     exprt equal = build_equal(call, from_integer(1, int_type()));
     return op == "NotEq" ? build_not(equal) : equal;
   }
@@ -534,6 +533,33 @@ exprt dynamic_type_handler::build_ordered_literal(
   if (op == "Gt")
     return build_greater_than(cmp, zero);
   assert(op == "GtE" && "unexpected operator routed to build_ordered_literal");
+  return build_greater_equal(cmp, zero);
+}
+
+exprt dynamic_type_handler::build_ordered_obj(
+  const std::string &op,
+  const exprt &lhs,
+  const exprt &rhs)
+{
+  const symbolt *cmp_obj_func =
+    converter_.symbol_table().find_symbol("c:@F@__python_scalar_cmp_obj");
+  assert(cmp_obj_func && "__python_scalar_cmp_obj not found in symbol table");
+  exprt cmp = build_call_expr(
+    *cmp_obj_func,
+    int_type(),
+    {build_address_of(lhs),
+     build_address_of(rhs),
+     type_handler_.tagged_scalar_type_id(long_long_int_type()),
+     type_handler_.tagged_scalar_type_id(bool_type())});
+
+  exprt zero = from_integer(BigInt(0), int_type());
+  if (op == "Lt")
+    return build_less_than(cmp, zero);
+  if (op == "LtE")
+    return build_less_equal(cmp, zero);
+  if (op == "Gt")
+    return build_greater_than(cmp, zero);
+  assert(op == "GtE" && "unexpected operator routed to build_ordered_obj");
   return build_greater_equal(cmp, zero);
 }
 

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.h
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.h
@@ -14,7 +14,6 @@
 class python_converter;
 class type_handler;
 
-
 class dynamic_type_handler
 {
 public:
@@ -180,6 +179,8 @@ private:
     const std::string &op,
     const exprt &tagged,
     const exprt &literal);
+  exprt
+  build_ordered_obj(const std::string &op, const exprt &lhs, const exprt &rhs);
   exprt build_add_literal(
     const exprt &tagged,
     const exprt &literal,
@@ -222,4 +223,3 @@ private:
   // point is surviving the join.
   std::unordered_map<std::string, std::string> aliases_;
 };
-


### PR DESCRIPTION
Adds <, <=, >, >= between two dynamically-typed variables, raising a `TypeError` on a type mismatch.
Also fixes equality between two dynamically-typed variables to treat bool and int as equal (True == 1); they compared as distinct types before.

Follow-up to #7018.