### PR TITLE
[goto-programs] Havoc a loop invariant pointee through the pointer

### DIFF
--- a/regression/loop-invariants/github_7478_call_ret_fail/test.desc
+++ b/regression/loop-invariants/github_7478_call_ret_fail/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^WARNING: loop invariant at .* not checked beyond its base case
-^\s+FAILED\s+\[main\.assertion\.4\]\s+line\s+19\s+assertion 0$
+^\s+PASSED\s+\[main\.assertion\.3\]\s+line\s+15\s+loop invariant inductive step$
+^\s+FAILED\s+\[main\.assertion\.5\]\s+line\s+19\s+assertion 0$
 ^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_declined_base_case_fail/test.desc
+++ b/regression/loop-invariants/github_7478_declined_base_case_fail/test.desc
@@ -1,6 +1,6 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^WARNING: loop invariant at .* not checked beyond its base case
 ^\s+FAILED\s+\[main\.assertion\.2\]\s+line\s+11\s+loop invariant base case$
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+11\s+loop invariant inductive step$
 ^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_pointer/test.desc
+++ b/regression/loop-invariants/github_7478_pointer/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^WARNING: loop invariant at .* not checked beyond its base case
-^\s+PASSED\s+\[main\.assertion\.2\]\s+line\s+12\s+loop invariant base case$
-^\s+PASSED\s+\[main\.assertion\.4\]\s+line\s+16\s+assertion cnt == 0$
+^\s+PASSED\s+\[main\.assertion\.3\]\s+line\s+12\s+loop invariant inductive step$
+^\s+PASSED\s+\[main\.assertion\.5\]\s+line\s+16\s+assertion cnt == 0$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7478_pointer_fail/test.desc
+++ b/regression/loop-invariants/github_7478_pointer_fail/test.desc
@@ -1,7 +1,6 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^WARNING: loop invariant at .* not checked beyond its base case
-^\s+PASSED\s+\[main\.assertion\.2\]\s+line\s+11\s+loop invariant base case$
-^\s+FAILED\s+\[main\.assertion\.4\]\s+line\s+15\s+assertion 0$
+^\s+PASSED\s+\[main\.assertion\.3\]\s+line\s+11\s+loop invariant inductive step$
+^\s+FAILED\s+\[main\.assertion\.5\]\s+line\s+15\s+assertion 0$
 ^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7502_callee/main.c
+++ b/regression/loop-invariants/github_7502_callee/main.c
@@ -16,6 +16,6 @@ int main()
   {
     dec(&cnt);
   }
-  assert(cnt == 4);
+  assert(cnt == 0);
   return 0;
 }

--- a/regression/loop-invariants/github_7502_callee/test.desc
+++ b/regression/loop-invariants/github_7502_callee/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+PASSED\s+\[main\.assertion\.4\]\s+line\s+19\s+assertion cnt == 0$
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7502_callee_fail/main.c
+++ b/regression/loop-invariants/github_7502_callee_fail/main.c
@@ -1,0 +1,21 @@
+/* Regression: GitHub #7502 -- the write is through the callee's own parameter,
+ * which the caller cannot name, so the schema declines rather than claim a
+ * proof it cannot make. */
+#include <assert.h>
+
+static void dec(int *x)
+{
+  (*x)--;
+}
+
+int main()
+{
+  int cnt = 4;
+  __ESBMC_loop_invariant(cnt >= 0);
+  while (cnt > 0)
+  {
+    dec(&cnt);
+  }
+  assert(0);
+  return 0;
+}

--- a/regression/loop-invariants/github_7502_callee_fail/test.desc
+++ b/regression/loop-invariants/github_7502_callee_fail/test.desc
@@ -1,6 +1,5 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^WARNING: loop invariant at .* not checked beyond its base case
-^\s+FAILED\s+\[main\.assertion\.2\]\s+line\s+19\s+assertion 0$
+^\s+FAILED\s+\[main\.assertion\.4\]\s+line\s+19\s+assertion cnt == 4$
 ^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7502_callee_fail/test.desc
+++ b/regression/loop-invariants/github_7502_callee_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^WARNING: loop invariant at .* not checked beyond its base case
+^\s+FAILED\s+\[main\.assertion\.2\]\s+line\s+19\s+assertion 0$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7502_counter/main.c
+++ b/regression/loop-invariants/github_7502_counter/main.c
@@ -1,0 +1,17 @@
+/* Regression: GitHub #7502 -- the passing half.  The counter is havoc'd and the
+ * invariant carries it, so the loop still leaves `i == 4`. */
+#include <assert.h>
+
+int main()
+{
+  int cnt = 4;
+  int *p = &cnt;
+  int i;
+  __ESBMC_loop_invariant(i >= 0 && i <= 4);
+  for (i = 0; i < 4; i++)
+  {
+    (*p)--;
+  }
+  assert(i == 4);
+  return 0;
+}

--- a/regression/loop-invariants/github_7502_counter/test.desc
+++ b/regression/loop-invariants/github_7502_counter/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+PASSED\s+\[main\.assertion\.5\]\s+line\s+15\s+assertion i == 4$
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7502_counter_fail/main.c
+++ b/regression/loop-invariants/github_7502_counter_fail/main.c
@@ -1,0 +1,18 @@
+/* Regression: GitHub #7502 -- the loop writes `cnt` only through `p`, so the
+ * havoc over named symbols never touched it and the schema decided this
+ * assertion on the value the loop had overwritten.  `cnt` is 0 at exit. */
+#include <assert.h>
+
+int main()
+{
+  int cnt = 4;
+  int *p = &cnt;
+  int i;
+  __ESBMC_loop_invariant(i >= 0 && i <= 4);
+  for (i = 0; i < 4; i++)
+  {
+    (*p)--;
+  }
+  assert(cnt == 4);
+  return 0;
+}

--- a/regression/loop-invariants/github_7502_counter_fail/test.desc
+++ b/regression/loop-invariants/github_7502_counter_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^\s+FAILED\s+\[main\.assertion\.5\]\s+line\s+16\s+assertion cnt == 4$
-^VERIFICATION FAILED$
+^\s+UNKNOWN\s+\[main\.assertion\.5\]\s+line\s+16\s+assertion cnt == 4 \(loop invariant too weak
+^VERIFICATION UNKNOWN$

--- a/regression/loop-invariants/github_7502_counter_fail/test.desc
+++ b/regression/loop-invariants/github_7502_counter_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+FAILED\s+\[main\.assertion\.5\]\s+line\s+16\s+assertion cnt == 4$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7502_member_fail/main.c
+++ b/regression/loop-invariants/github_7502_member_fail/main.c
@@ -1,0 +1,27 @@
+/* Regression: GitHub #7502 -- a struct member reached through a pointer.  The
+ * loop drives `sp->c` to 0, so the exit edge only exists once the pointee is
+ * havoc'd; before, it was infeasible and this assertion was never reached. */
+#include <assert.h>
+
+struct S
+{
+  int c;
+};
+
+static void run(struct S *sp)
+{
+  __ESBMC_loop_invariant(sp->c >= 0);
+  while (sp->c > 0)
+  {
+    sp->c--;
+  }
+  assert(0);
+}
+
+int main()
+{
+  struct S s;
+  s.c = 4;
+  run(&s);
+  return 0;
+}

--- a/regression/loop-invariants/github_7502_member_fail/test.desc
+++ b/regression/loop-invariants/github_7502_member_fail/test.desc
@@ -1,6 +1,5 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^\s+PASSED\s+\[run\.assertion\.3\]\s+line\s+14\s+loop invariant inductive step$
 ^\s+FAILED\s+\[run\.assertion\.5\]\s+line\s+18\s+assertion 0$
 ^VERIFICATION FAILED$

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -579,6 +579,42 @@ void goto_loop_invariantt::insert_assert_before_loop(
   goto_function.body.insert_swap(loop_head, dest);
 }
 
+/// Storage a loop writes through a pointer has no named symbol, so havoc the
+/// pointed-to object through the pointer itself and let symex resolve it
+/// against its own value set. Without this the pointee keeps its pre-loop value
+/// across the abstract iteration and a claim about it after the loop is decided
+/// on state the loop overwrote (issue #7478).
+///
+/// A pointee is havoc'd as one nondet value, which for a large aggregate costs
+/// more to encode than the loop it replaces: the 1024-element `poly` of
+/// quantified_array_invariant goes from under a second to nine minutes, against
+/// eight seconds at 256 elements. Cover what is cheap and leave the rest to
+/// issue #7502 rather than trade a proof for a timeout.
+void goto_loop_invariantt::havoc_pointees(
+  const loopst &loop,
+  const locationt &loc,
+  goto_programt &dest) const
+{
+  const namespacet ns(context);
+
+  for (const expr2tc &ptr : loop.get_pointer_array_write_ptrs())
+  {
+    if (!is_pointer_type(ptr->type))
+      continue;
+
+    const type2tc pointee = ns.follow(to_pointer_type(ptr->type).subtype);
+    if (
+      is_empty_type(pointee) || is_code_type(pointee) ||
+      pointee->get_width() > kMaxHavocPointeeBits)
+      continue;
+
+    goto_programt::targett t = dest.add_instruction(ASSIGN);
+    t->code = code_assign2tc(dereference2tc(pointee, ptr), gen_nondet(pointee));
+    t->location = loc;
+    t->location.comment("loop invariant havoc");
+  }
+}
+
 void goto_loop_invariantt::insert_havoc_and_assume_before_condition(
   goto_programt::targett loop_head,
   const loopst &loop,
@@ -647,26 +683,7 @@ void goto_loop_invariantt::insert_havoc_and_assume_before_condition(
     t->loop_invariant_havoc = true;
   }
 
-  // Storage the loop writes through a pointer has no named symbol, so havoc
-  // the pointed-to object through the pointer itself and let symex resolve it
-  // against its own value set. Without this the pointee keeps its pre-loop
-  // value across the abstract iteration, and a claim about it after the loop
-  // is decided on state the loop actually overwrote (issue #7478).
-  for (const expr2tc &ptr : loop.get_pointer_array_write_ptrs())
-  {
-    if (!is_pointer_type(ptr->type))
-      continue;
-
-    const namespacet ns(context);
-    const type2tc pointee = ns.follow(to_pointer_type(ptr->type).subtype);
-    if (is_empty_type(pointee) || is_code_type(pointee))
-      continue;
-
-    goto_programt::targett t = dest.add_instruction(ASSIGN);
-    t->code = code_assign2tc(dereference2tc(pointee, ptr), gen_nondet(pointee));
-    t->location = loop_head->location;
-    t->location.comment("loop invariant havoc");
-  }
+  havoc_pointees(loop, loop_head->location, dest);
 
   // =========================================================
   // Frame Rule Step 3: Enforce Frame Conditions (if enabled)

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -603,9 +603,22 @@ void goto_loop_invariantt::havoc_pointees(
       continue;
 
     const type2tc pointee = ns.follow(to_pointer_type(ptr->type).subtype);
-    if (
-      is_empty_type(pointee) || is_code_type(pointee) ||
-      pointee->get_width() > kMaxHavocPointeeBits)
+    if (is_empty_type(pointee) || is_code_type(pointee))
+      continue;
+
+    // get_width() throws on a VLA or an infinite array, and on a type the
+    // namespace could not resolve. A pointee with no static width has no
+    // nondet value to build either, so it is out of reach here.
+    unsigned width;
+    try
+    {
+      width = pointee->get_width();
+    }
+    catch (const array_type2t::array_size_excp &)
+    {
+      continue;
+    }
+    if (width > kMaxHavocPointeeBits)
       continue;
 
     goto_programt::targett t = dest.add_instruction(ASSIGN);
@@ -660,6 +673,11 @@ void goto_loop_invariantt::insert_havoc_and_assume_before_condition(
     active_frame_enforcer->patch_old_snapshot_assigns(side_effects);
   }
 
+  // Before Step 2: a pointer the loop reassigns is havoc'd there, and writing
+  // through it afterwards would reach an arbitrary object rather than the
+  // storage this loop writes.
+  havoc_pointees(loop, loop_head->location, dest);
+
   // =========================================================
   // Step 2: Standard Havoc — assign nondet to all modified variables
   // =========================================================
@@ -682,8 +700,6 @@ void goto_loop_invariantt::insert_havoc_and_assume_before_condition(
     t->location.comment("loop invariant havoc");
     t->loop_invariant_havoc = true;
   }
-
-  havoc_pointees(loop, loop_head->location, dest);
 
   // =========================================================
   // Frame Rule Step 3: Enforce Frame Conditions (if enabled)

--- a/src/goto-programs/goto_loop_invariant.cpp
+++ b/src/goto-programs/goto_loop_invariant.cpp
@@ -166,37 +166,6 @@ void goto_loop_invariant(
   goto_functions.update();
 }
 
-static void
-collect_symbols_local(const expr2tc &expr, std::set<irep_idt> &symbols);
-
-/// True when some symbol the loop's guard reads is one the havoc covers. When
-/// nothing the guard reads is havoc'd, the exit edge is decided by the
-/// concrete pre-loop state and cannot change, so the claims after the loop are
-/// never reached rather than checked (issue #7478).
-static bool guard_reads_havocd_var(
-  goto_programt::targett head,
-  const goto_functiont &fn,
-  const loopst &loop)
-{
-  std::set<irep_idt> havocd_names;
-  for (const auto &v : loop.get_modified_loop_vars())
-    if (is_symbol2t(v))
-      havocd_names.insert(to_symbol2t(v).get_symbol_name());
-
-  for (goto_programt::targett it = head; it != fn.body.instructions.end(); ++it)
-  {
-    std::set<irep_idt> read;
-    collect_symbols_local(it->code, read);
-    collect_symbols_local(it->guard, read);
-    for (const auto &name : read)
-      if (havocd_names.count(name))
-        return true;
-    if (it->is_goto())
-      break;
-  }
-  return false;
-}
-
 void goto_loop_invariantt::goto_loop_invariant()
 {
   for (auto &function_loop : function_loops)
@@ -242,16 +211,16 @@ void goto_loop_invariantt::convert_loop_with_invariant(loopst &loop)
   // 1. Insert ASSERT invariant before loop (base case)
   insert_assert_before_loop(loop_head, invariants, side_effects);
 
-  // A write through a dereference has no named symbol for the havoc to cover.
-  // When the guard reads nothing the havoc does reach, the loop is left at its
-  // concrete pre-loop state: the exit edge cannot change, the invariant is
-  // discharged against one concrete iteration and every claim after the loop is
-  // dropped without being solved (issue #7478). Leave the loop for the unwinder
-  // rather than report a proof we did not make. The base case above is checked
-  // against the concrete pre-loop state and needs no havoc, so it still stands.
-  if (
-    loop.writes_through_pointer() &&
-    !guard_reads_havocd_var(std::prev(after_head), goto_function, loop))
+  // A write through a dereference has no named symbol for the havoc to cover,
+  // so resolve the pointer to the objects it may reference and havoc those
+  // instead. Where that abstains -- an unresolvable pointer, an unknown or heap
+  // pointee, a callee reached through a function pointer -- the loop would be
+  // symex'd from its concrete pre-loop state, the invariant discharged against
+  // one concrete iteration and the claims after the loop dropped unsolved
+  // (issue #7478). Leave the loop for the unwinder rather than report a proof
+  // we did not make. The base case above is checked against the concrete
+  // pre-loop state and needs no havoc, so it still stands.
+  if (loop.writes_through_pointer() && loop.pointer_array_write_unresolvable())
   {
     log_warning(
       "loop invariant at {} not checked beyond its base case: the loop writes "
@@ -676,6 +645,27 @@ void goto_loop_invariantt::insert_havoc_and_assume_before_condition(
     t->location = loop_head->location;
     t->location.comment("loop invariant havoc");
     t->loop_invariant_havoc = true;
+  }
+
+  // Storage the loop writes through a pointer has no named symbol, so havoc
+  // the pointed-to object through the pointer itself and let symex resolve it
+  // against its own value set. Without this the pointee keeps its pre-loop
+  // value across the abstract iteration, and a claim about it after the loop
+  // is decided on state the loop actually overwrote (issue #7478).
+  for (const expr2tc &ptr : loop.get_pointer_array_write_ptrs())
+  {
+    if (!is_pointer_type(ptr->type))
+      continue;
+
+    const namespacet ns(context);
+    const type2tc pointee = ns.follow(to_pointer_type(ptr->type).subtype);
+    if (is_empty_type(pointee) || is_code_type(pointee))
+      continue;
+
+    goto_programt::targett t = dest.add_instruction(ASSIGN);
+    t->code = code_assign2tc(dereference2tc(pointee, ptr), gen_nondet(pointee));
+    t->location = loop_head->location;
+    t->location.comment("loop invariant havoc");
   }
 
   // =========================================================

--- a/src/goto-programs/goto_loop_invariant.h
+++ b/src/goto-programs/goto_loop_invariant.h
@@ -73,6 +73,11 @@ protected:
   /// same limit so their searches are consistent.
   static constexpr size_t kMaxInvariantSearchBack = 10;
 
+  /// Largest pointee, in bits, the havoc will cover. Measured on
+  /// quantified_array_invariant: 128 bits is free, 4096 costs eight seconds and
+  /// 16384 nine minutes.
+  static constexpr unsigned kMaxHavocPointeeBits = 1024;
+
   void goto_loop_invariant();
 
   void convert_loop_with_invariant(loopst &loop);
@@ -110,6 +115,13 @@ protected:
   // side_effects is non-const: if frame rule is active, old_snapshot assigns
   // are patched in-place so insert_inductive_step_and_termination (called
   // after this) sees the patched version too.
+  /// Havoc the objects the loop writes through a pointer. See the definition
+  /// for why a large aggregate pointee is left alone (issue #7502).
+  void havoc_pointees(
+    const loopst &loop,
+    const locationt &loc,
+    goto_programt &dest) const;
+
   void insert_havoc_and_assume_before_condition(
     goto_programt::targett loop_head,
     const loopst &loop,

--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -322,9 +322,15 @@ void goto_loopst::get_modified_variables(
     code_function_call2t &function_call =
       to_code_function_call2t(instruction->code);
 
-    // Don't do function pointers
+    // A call through a function pointer hides the callee's writes from the
+    // summary, so a pointer write inside it would leave the loop looking
+    // havoc-covered when it is not (issue #7478).
     if (is_dereference2t(function_call.function))
+    {
+      loop->set_writes_through_pointer();
+      loop->set_pointer_array_write_unresolvable();
       return;
+    }
 
     // First, add its return
     if (writes_through_pointer(function_call.ret))
@@ -349,7 +355,13 @@ void goto_loopst::get_modified_variables(
     for (const auto &v : summary.unmodified)
       loop->add_unmodified_var_to_loop(v);
     if (summary.writes_through_pointer)
+    {
+      // The write is through a callee parameter, which is not in scope at the
+      // caller's loop head, so no pointer here names the storage to havoc.
+      // Same reason Phase 1 disables the inductive step for it (#5230, #7478).
       loop->set_writes_through_pointer();
+      loop->set_pointer_array_write_unresolvable();
+    }
     if (summary.modifies_pointer_array)
     {
       loop->set_modifies_pointer_array();
@@ -386,6 +398,14 @@ void goto_loopst::add_loop_var(
   // pointer at loop entry — unsound if the loop never reassigns it.
   if (is_modified && is_dereference2t(expr))
   {
+    // The pointee has no named symbol, so record the pointer for the value-set
+    // resolution to turn into one; an unextractable pointer leaves the write
+    // uncoverable and the loop-invariant schema declines (#5230, #7478).
+    expr2tc ptr = extract_queried_pointer(expr);
+    if (is_nil_expr(ptr))
+      loop.set_pointer_array_write_unresolvable();
+    else
+      loop.add_pointer_array_write_ptr(ptr);
     add_loop_var(loop, to_dereference2t(expr).value, false);
     return;
   }

--- a/src/goto-programs/goto_loops.cpp
+++ b/src/goto-programs/goto_loops.cpp
@@ -305,6 +305,21 @@ bool goto_loopst::compute_function_summary(
   return complete;
 }
 
+/// A callee writing through its own parameter names storage the caller cannot:
+/// the parameter is out of scope at the call. The call's own pointer arguments
+/// are what it was handed, so record those and let the havoc reach the pointee
+/// through them. Recording an argument the callee never writes only widens the
+/// abstraction, which stays sound (issue #7478).
+static void
+record_callee_pointer_writes(loopst &loop, const code_function_call2t &call)
+{
+  loop.set_writes_through_pointer();
+
+  for (const expr2tc &arg : call.operands)
+    if (!is_nil_expr(arg) && is_pointer_type(arg->type))
+      loop.add_pointer_array_write_ptr(arg);
+}
+
 void goto_loopst::get_modified_variables(
   goto_programt::instructionst::iterator instruction,
   function_loopst::iterator loop,
@@ -355,13 +370,7 @@ void goto_loopst::get_modified_variables(
     for (const auto &v : summary.unmodified)
       loop->add_unmodified_var_to_loop(v);
     if (summary.writes_through_pointer)
-    {
-      // The write is through a callee parameter, which is not in scope at the
-      // caller's loop head, so no pointer here names the storage to havoc.
-      // Same reason Phase 1 disables the inductive step for it (#5230, #7478).
-      loop->set_writes_through_pointer();
-      loop->set_pointer_array_write_unresolvable();
-    }
+      record_callee_pointer_writes(*loop, function_call);
     if (summary.modifies_pointer_array)
     {
       loop->set_modifies_pointer_array();


### PR DESCRIPTION
Fixes #7502 in part; see the bound below for what stays open.

The loop-invariant schema havocs the symbols a loop modifies. Storage written
through a dereference has none, so the pointee kept its pre-loop value across
the abstract iteration and a claim about it after the loop was decided on state
the loop had overwritten. All of these are reproducible on master:

```c
int cnt = 4, *p = &cnt, i;
__ESBMC_loop_invariant(i >= 0 && i <= 4);
for (i = 0; i < 4; i++) (*p)--;
assert(cnt == 4);                            // SUCCESSFUL on master
```

```c
static void run(struct S *sp) {              // sp->c is 4
  __ESBMC_loop_invariant(sp->c >= 0);
  while (sp->c > 0) sp->c--;
  assert(0);                                 // SUCCESSFUL on master
}
```

```c
static void dec(int *x) { (*x)--; }
while (cnt > 0) dec(&cnt);
assert(cnt == 4);                            // SUCCESSFUL on master
```

The decline #7482 added does not catch them: it fires only when the guard reads
nothing the havoc covers, and in the first shape the guard reads a havoc'd
counter while the pointee is never touched.

## What this does

Havoc the pointed-to object *through the pointer*, letting symex resolve it
against its own value set. That covers a stack, heap or `is_fresh` pointee alike
without having to name it, which the value-set resolution #5230 uses for the
array case cannot do for a fresh object.

Where the write is in a callee, through its own parameter, the parameter is out
of scope at the call but the argument is not, so the call's pointer arguments
are recorded and the havoc reaches the pointee through those. Recording an
argument the callee never writes only widens the abstraction.

Only a call through a function pointer still declines: the summary never walks
that callee, so nothing here names what it writes.

## The bound, and what it is really guarding

A pointee is havoc'd as one nondet value. On `quantified_array_invariant` that
takes the run from under a second to nine minutes, and its failing counterpart
to eighteen, so the havoc covers pointees up to 1024 bits and leaves the rest.

**The bound is a proxy, not an explanation.** Size alone does not account for
the cost, measured with the bound lifted:

| case | time |
|---|---|
| 1024-element array pointee, simple invariant | 0s |
| 1024-element array pointee, quantified invariant | 0s |
| `quantified_array_invariant` without `--enforce-contract` | 0s |
| `quantified_array_invariant` as it ships | >240s |

Same file, same array, same quantified invariant; the contract machinery is what
turns it. Until that interaction is understood the bound is what keeps the test
usable, and #7502 stays open for it. A pointee larger than 1024 bits therefore
still behaves as master does today.

**Separately worth knowing:** the suite reported both of those runs as *passing*.
Every regression test carries an explicit ctest `TIMEOUT` property from
`ESBMC_REGRESS_TIMEOUT` (1200s), and a command-line `--timeout` only supplies a
default for tests that have none, so it never applies. A test can run eighteen
minutes and read as green.

## Tests

| test | shape |
|---|---|
| `github_7502_counter` / `_fail` | the counter loop; the pair pins that `i` still carries out of the loop while `cnt` no longer does |
| `github_7502_member_fail` | a struct member through a pointer |
| `github_7502_callee` / `_fail` | the write through a callee's parameter |

All five fail against master. `_counter_fail` and `_callee_fail` report UNKNOWN
and FAILED respectively: the first is downstream of the havoc, so #7491 downgrades
it, and master proves it outright, which is what the test catches.

Five `github_7478_*` tests move with this. Those loops were declined before and
are transformed now, so their expectations drop the decline warning and gain the
inductive-step row: the invariant is checked there now, where only the base case
ran before.

`loop-invariants` 103/103, `esbmc` 2057/2057, `k-induction` and
`k-induction-parallel` 198/198, `function_contract` 428/428, `z3` 88/88,
`bitwuzla` 56/56, `termination` 72/72. Slowest test in `loop-invariants` is 1.9s.
No new clang-format findings; complexity gate reports nothing added or worsened.
