### PR TITLE
[om] Close two C++ stream operational-model gaps

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7332_basic_stream_aliases/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7332_basic_stream_aliases/main.cpp
@@ -1,0 +1,32 @@
+#include <fstream>
+#include <iostream>
+#include <cassert>
+
+typedef std::basic_ifstream<char, std::char_traits<char>> IFStream;
+typedef std::basic_ofstream<char, std::char_traits<char>> OFStream;
+typedef std::basic_fstream<char, std::char_traits<char>> FStream;
+typedef std::basic_iostream<char, std::char_traits<char>> IOStream;
+
+int main()
+{
+  IFStream in;
+  OFStream out;
+  FStream both;
+
+  assert(!in.is_open());
+  assert(!out.is_open());
+  assert(!both.is_open());
+
+  std::ifstream *p = &in;
+  std::ofstream *q = &out;
+  std::fstream *r = &both;
+  assert(p == &in);
+  assert(q == &out);
+  assert(r == &both);
+
+  IOStream *io = 0;
+  std::iostream *s = io;
+  assert(s == 0);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7332_basic_stream_aliases/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7332_basic_stream_aliases/main.cpp
@@ -13,16 +13,14 @@ int main()
   OFStream out;
   FStream both;
 
-  assert(!in.is_open());
-  assert(!out.is_open());
-  assert(!both.is_open());
-
+  /* The conversions pin alias identity -- a distinct class would not convert --
+   * and is_open() then asserts through the alias-typed object. */
   std::ifstream *p = &in;
   std::ofstream *q = &out;
   std::fstream *r = &both;
-  assert(p == &in);
-  assert(q == &out);
-  assert(r == &both);
+  assert(!p->is_open());
+  assert(!q->is_open());
+  assert(!r->is_open());
 
   IOStream *io = 0;
   std::iostream *s = io;

--- a/regression/esbmc-cpp/cpp/github_7332_basic_stream_aliases/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7332_basic_stream_aliases/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7332_basic_stream_aliases_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7332_basic_stream_aliases_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <fstream>
+#include <cassert>
+
+typedef std::basic_ifstream<char, std::char_traits<char>> IFStream;
+
+int main()
+{
+  IFStream in;
+  assert(in.is_open());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7332_basic_stream_aliases_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7332_basic_stream_aliases_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_7333_ios_pos_type/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7333_ios_pos_type/main.cpp
@@ -6,15 +6,18 @@ int main()
   std::ios::pos_type bad = std::ios::pos_type(-1);
   assert(bad == std::ios::pos_type(-1));
 
+  /* pos_type and off_type must stay signed: the model's positions are ints and
+   * tellg()/tellp() report failure as -1. */
+  assert(std::ios::pos_type(-1) < std::ios::pos_type(0));
+  assert(std::ios::pos_type(-1) < 0);
+  assert(std::ios::off_type(0) - std::ios::off_type(1) < 0);
+
   std::ios::off_type off = std::ios::off_type(4) - std::ios::off_type(1);
   assert(off == 3);
 
   std::ios::pos_type p = std::ios::pos_type(0) + off;
   assert(p == std::ios::pos_type(3));
   assert(p != bad);
-
-  std::ios::pos_type here = std::cin.tellg();
-  assert(here == here);
 
   std::ios::char_type c = 'a';
   std::ios::int_type i = std::ios::traits_type::to_int_type(c);

--- a/regression/esbmc-cpp/cpp/github_7333_ios_pos_type/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7333_ios_pos_type/main.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <cassert>
+
+int main()
+{
+  std::ios::pos_type bad = std::ios::pos_type(-1);
+  assert(bad == std::ios::pos_type(-1));
+
+  std::ios::off_type off = std::ios::off_type(4) - std::ios::off_type(1);
+  assert(off == 3);
+
+  std::ios::pos_type p = std::ios::pos_type(0) + off;
+  assert(p == std::ios::pos_type(3));
+  assert(p != bad);
+
+  std::ios::pos_type here = std::cin.tellg();
+  assert(here == here);
+
+  std::ios::char_type c = 'a';
+  std::ios::int_type i = std::ios::traits_type::to_int_type(c);
+  assert(i == 97);
+  assert(std::ios::traits_type::to_char_type(i) == c);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7333_ios_pos_type/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7333_ios_pos_type/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7333_ios_pos_type_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7333_ios_pos_type_fail/main.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+#include <cassert>
+
+int main()
+{
+  std::ios::pos_type bad = std::ios::pos_type(-1);
+  std::ios::off_type off = std::ios::off_type(3);
+  std::ios::pos_type p = std::ios::pos_type(0) + off;
+  assert(p == bad);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7333_ios_pos_type_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7333_ios_pos_type_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/src/cpp/library/fstream
+++ b/src/cpp/library/fstream
@@ -154,6 +154,18 @@ public:
   filebuf *_m_filebuf;
 };
 
+#if __cplusplus >= 201103L
+/* [fstream.syn]: the model's file streams are plain classes, so expose the
+ * standard's template names as alias templates, as istream/ostream already do
+ * (github #6063). Only the char instantiation is meaningful. */
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_ifstream = ifstream;
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_ofstream = ofstream;
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_fstream = fstream;
+#endif
+
 //=====================fstream===================
 fstream::fstream()
 {

--- a/src/cpp/library/ios
+++ b/src/cpp/library/ios
@@ -162,6 +162,14 @@ public:
   typedef int streampos;
   typedef int streamoff;
 
+  /* [ios.overview]. pos_type/off_type follow the model's int stream positions
+   * (istream::tellg, ostream::tellp) rather than the traits' size_t/ptrdiff_t. */
+  typedef char char_type;
+  typedef char_traits<char> traits_type;
+  typedef traits_type::int_type int_type;
+  typedef streampos pos_type;
+  typedef streamoff off_type;
+
   ios()
   {
     __fill = ' ';

--- a/src/cpp/library/istream
+++ b/src/cpp/library/istream
@@ -357,6 +357,11 @@ template <class charT>
 struct char_traits;
 template <class CharT, class Traits = char_traits<CharT>>
 using basic_istream = istream;
+/* [istream.syn] declares basic_iostream here too; the model defines the class
+ * itself in <iostream>, which every use that needs it complete includes. */
+class iostream;
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_iostream = iostream;
 #endif
 
 } // namespace std


### PR DESCRIPTION
`std::ios` had none of the [ios.overview] member types, so `std::ios::pos_type` did not parse, and `<fstream>`/`<istream>` defined the char stream classes but not the class templates [fstream.syn] and [istream.syn] declare. Both were found auditing the OM against aws-sdk-cpp.

`pos_type`/`off_type` follow the model's int stream positions rather than `char_traits<char>`, so the -1 failure value `tellg()` reports stays signed; the four regression tests are mutation-checked and match real libstdc++.

Fixes #7333
Fixes #7332