### PR TITLE
[c++] Give each lambda in a function template its own method symbols

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template/main.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+
+template <unsigned long N>
+int non_capturing_first(int x)
+{
+  auto a = [](int i) -> int { return i; };
+  auto b = [&](int i) -> int { return i + x; };
+  return a(1) + b(1);
+}
+
+template <unsigned long N>
+int capturing_first(int x)
+{
+  auto b = [&](int i) -> int { return i + x; };
+  auto a = [](int i) -> int { return i; };
+  return b(1) + a(1);
+}
+
+int main()
+{
+  assert(non_capturing_first<2>(5) == 1 + (1 + 5));
+  assert(capturing_first<3>(5) == (1 + 5) + 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template/main.cpp
@@ -16,9 +16,32 @@ int capturing_first(int x)
   return b(1) + a(1);
 }
 
+template <unsigned long N>
+int per_instantiation(int x)
+{
+  auto b = [&](int i) -> int { return i + x + (int)N; };
+  auto a = [](int i) -> int { return i; };
+  return b(1) + a(1);
+}
+
+/* Captureless siblings collide through their __invoke and conversion-operator
+ * USRs too, not just operator(). */
+template <unsigned long N>
+int via_function_pointer(int x)
+{
+  int (*p)(int) = [](int i) -> int { return i + 1; };
+  int (*q)(int) = [](int i) -> int { return i * 2; };
+  return p(x) + q(x);
+}
+
 int main()
 {
   assert(non_capturing_first<2>(5) == 1 + (1 + 5));
   assert(capturing_first<3>(5) == (1 + 5) + 1);
+
+  assert(per_instantiation<2>(5) == (1 + 5 + 2) + 1);
+  assert(per_instantiation<3>(5) == (1 + 5 + 3) + 1);
+
+  assert(via_function_pointer<2>(5) == (5 + 1) + (5 * 2));
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template_fail/main.cpp
@@ -1,0 +1,16 @@
+#include <cassert>
+
+template <unsigned long N>
+int f(int x)
+{
+  auto b = [&](int i) -> int { return i + x; };
+  auto a = [](int i) -> int { return i; };
+  return b(1) + a(1);
+}
+
+int main()
+{
+  /* 2 is what the capturing lambda returns when it loses its capture. */
+  assert(f<2>(5) == 2);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7499_lambda_in_function_template_fail/test.desc
@@ -2,3 +2,4 @@ CORE
 main.cpp
 --std c++17
 ^VERIFICATION FAILED$
+^ +FAILED +\[main\.assertion\.1\] +line +14 +assertion f<2>\(5\) == 2$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -255,6 +255,18 @@ void clang_cpp_convertert::get_decl_name(
 
   default:
     clang_c_convertert::get_decl_name(nd, name, id);
+    /* clang's USR for a member of a closure declared in a function template
+     * names the specialisation but not the closure, so sibling lambdas in one
+     * instantiation share an id and the last body converted wins (#7499). The
+     * closure's own id is already unique per lambda and per instantiation
+     * (#6976), so qualify with it. */
+    if (const auto *md = llvm::dyn_cast<clang::CXXMethodDecl>(&nd))
+      if (md->getParent()->isLambda())
+      {
+        std::string closure_name, closure_id;
+        get_decl_name(*md->getParent(), closure_name, closure_id);
+        id += "@" + closure_id;
+      }
     return;
   }
 

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -255,18 +255,18 @@ void clang_cpp_convertert::get_decl_name(
 
   default:
     clang_c_convertert::get_decl_name(nd, name, id);
-    /* clang's USR for a member of a closure declared in a function template
-     * names the specialisation but not the closure, so sibling lambdas in one
-     * instantiation share an id and the last body converted wins (#7499). The
-     * closure's own id is already unique per lambda and per instantiation
-     * (#6976), so qualify with it. */
-    if (const auto *md = llvm::dyn_cast<clang::CXXMethodDecl>(&nd))
-      if (md->getParent()->isLambda())
-      {
-        std::string closure_name, closure_id;
-        get_decl_name(*md->getParent(), closure_name, closure_id);
-        id += "@" + closure_id;
-      }
+    /* A lambda's operator(), __invoke and conversion-operator USRs name the
+     * enclosing specialisation but not the closure, so siblings in one
+     * instantiation share an id and the last body converted wins (#7499); the
+     * closure's own id is already unique (#6976). Constructors take the case
+     * above and need none -- their USR spells the class "(lambda at f:l:c)". */
+    if (const auto *md = llvm::dyn_cast<clang::CXXMethodDecl>(&nd);
+        md && md->getParent()->isLambda())
+    {
+      std::string closure_name, closure_id;
+      get_decl_name(*md->getParent(), closure_name, closure_id);
+      id += "@" + closure_id;
+    }
     return;
   }
 


### PR DESCRIPTION
clang's USR for a lambda's `operator()`, `__invoke` or conversion operator names the enclosing specialisation but not the closure, so two lambdas in one instantiation shared an id and the last body converted won. Non-capturing then capturing aborted in `member2t`, then read the capture field off an empty closure; the reverse order silently dropped the capture and reported a false alarm on a program g++ accepts.

Qualifying with the closure's own id, already unique per lambda and instantiation since #6976, keeps them apart. Constructors and destructors need no qualifier — their USR spells the class `(lambda at file:line:col)` — so routing them past the new code is deliberate.

Both regression verdicts invert without the patch: the passing test reports FAILED and the failing test reports SUCCESSFUL.

Fixes #7499
