### PR TITLE
[simplifier] Exclude the infinities from isnormal

### DIFF
--- a/regression/floats/isnormal_infinity/main.c
+++ b/regression/floats/isnormal_infinity/main.c
@@ -1,0 +1,23 @@
+// C11 7.12.3.5: isnormal is false for zero, subnormal, infinite and NaN (#7320).
+#include <assert.h>
+#include <float.h>
+#include <math.h>
+
+int main(void)
+{
+  double inf = 1.0 / 0.0;
+
+  assert(!__builtin_isnormal(inf));
+  assert(!__builtin_isnormal(-inf));
+  assert(!__builtin_isnormal(DBL_MAX * 2.0));
+  assert(!__builtin_isnormal(-DBL_MAX * 2.0));
+  assert(!__builtin_isnormal(0.0 / 1.0));
+  assert(!__builtin_isnormal(DBL_MIN / 2.0));
+  assert(!__builtin_isnormal(0.0 / 0.0));
+
+  assert(__builtin_isnormal(1.0));
+  assert(__builtin_isnormal(DBL_MAX));
+  assert(__builtin_isnormal(DBL_MIN));
+
+  return 0;
+}

--- a/regression/floats/isnormal_infinity/test.desc
+++ b/regression/floats/isnormal_infinity/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--floatbv
+^VERIFICATION SUCCESSFUL$

--- a/regression/floats/isnormal_infinity_fail/main.c
+++ b/regression/floats/isnormal_infinity_fail/main.c
@@ -1,0 +1,10 @@
+// The failing dual of ../isnormal_infinity (#7320).
+#include <assert.h>
+#include <math.h>
+
+int main(void)
+{
+  double inf = 1.0 / 0.0;
+  assert(__builtin_isnormal(inf));
+  return 0;
+}

--- a/regression/floats/isnormal_infinity_fail/test.desc
+++ b/regression/floats/isnormal_infinity_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--floatbv
+^VERIFICATION FAILED$

--- a/src/util/arith/ieee_float.cpp
+++ b/src/util/arith/ieee_float.cpp
@@ -359,7 +359,9 @@ void ieee_floatt::unpack(const BigInt &i)
 
 bool ieee_floatt::is_normal() const
 {
-  return !NaN_flag && fraction >= power(2, spec.f);
+  // align() and operator/= set infinity_flag without clearing fraction, so
+  // the hidden-bit test alone leaves infinities in (C11 7.12.3.5; #7320).
+  return is_finite() && fraction >= power(2, spec.f);
 }
 
 BigInt ieee_floatt::pack() const

--- a/unit/util/ieee_float.test.cpp
+++ b/unit/util/ieee_float.test.cpp
@@ -46,3 +46,72 @@ TEST_CASE("ieee float converts zero to double", "[core][util][ieee_floatt]")
   REQUIRE_FALSE(std::isnormal(ieee_zero.to_double()));
   REQUIRE(ieee_zero.to_double() == 0.0);
 }
+
+TEST_CASE("ieee float classifies infinities", "[core][util][ieee_floatt]")
+{
+  // #7320: the division-by-zero and overflow sections are the ones that bite;
+  // the others pin the rest of the classification.
+  const ieee_float_spect spec(52, 11);
+
+  ieee_floatt one(spec);
+  one.from_integer(1);
+  REQUIRE(one.is_normal());
+
+  SECTION("division by zero")
+  {
+    ieee_floatt zero(spec);
+    zero.from_integer(0);
+
+    ieee_floatt inf = one;
+    inf /= zero;
+
+    REQUIRE(inf.is_infinity());
+    REQUIRE_FALSE(inf.is_normal());
+  }
+
+  SECTION("overflow")
+  {
+    ieee_floatt max(spec);
+    max.make_fltmax();
+    REQUIRE(max.is_normal());
+
+    ieee_floatt two(spec);
+    two.from_integer(2);
+
+    ieee_floatt inf = max;
+    inf *= two;
+
+    REQUIRE(inf.is_infinity());
+    REQUIRE_FALSE(inf.is_normal());
+  }
+
+  SECTION("explicit infinity and NaN")
+  {
+    ieee_floatt inf(spec);
+    inf.make_plus_infinity();
+    REQUIRE_FALSE(inf.is_normal());
+
+    inf.make_minus_infinity();
+    REQUIRE_FALSE(inf.is_normal());
+
+    ieee_floatt nan(spec);
+    nan.make_NaN();
+    REQUIRE_FALSE(nan.is_normal());
+  }
+
+  SECTION("subnormal stays subnormal")
+  {
+    ieee_floatt min_normal(spec);
+    min_normal.make_fltmin();
+    REQUIRE(min_normal.is_normal());
+
+    ieee_floatt two(spec);
+    two.from_integer(2);
+
+    ieee_floatt subnormal = min_normal;
+    subnormal /= two;
+
+    REQUIRE(subnormal.is_finite());
+    REQUIRE_FALSE(subnormal.is_normal());
+  }
+}


### PR DESCRIPTION
`ieee_floatt::is_normal()` tested only the hidden bit, but `align()` and
`operator/=` set `infinity_flag` while leaving the operand's fraction in place,
so the simplifier folded `isnormal(1.0/0.0)` to true — proving an assertion that
fails on real hardware, and reporting a false positive on its negation.

Fixes #7320
