### PR TITLE
[python] Resolve a base class reached through an import

### DIFF
--- a/regression/python/github_7398_imported_grandparent/main.py
+++ b/regression/python/github_7398_imported_grandparent/main.py
@@ -1,0 +1,20 @@
+import shapes
+from shapes import Shape
+
+
+class Square(Shape):
+
+    def get(self) -> int:
+        return self.total()
+
+
+class Grid(shapes.Panel):
+
+    def get(self) -> int:
+        return self.total()
+
+
+s = Square()
+g = Grid()
+assert s.get() == 4
+assert g.get() == 4

--- a/regression/python/github_7398_imported_grandparent/shapes.py
+++ b/regression/python/github_7398_imported_grandparent/shapes.py
@@ -1,0 +1,15 @@
+class Root:
+
+    def __init__(self) -> None:
+        self.sides: int = 4
+
+    def total(self) -> int:
+        return self.sides
+
+
+class Shape(Root):
+    pass
+
+
+class Panel(Shape):
+    pass

--- a/regression/python/github_7398_imported_grandparent/test.desc
+++ b/regression/python/github_7398_imported_grandparent/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7398_imported_grandparent_fail/main.py
+++ b/regression/python/github_7398_imported_grandparent_fail/main.py
@@ -1,0 +1,20 @@
+import shapes
+from shapes import Shape
+
+
+class Square(Shape):
+
+    def get(self) -> int:
+        return self.total()
+
+
+class Grid(shapes.Panel):
+
+    def get(self) -> int:
+        return self.total()
+
+
+s = Square()
+g = Grid()
+assert s.get() == 5
+assert g.get() == 4

--- a/regression/python/github_7398_imported_grandparent_fail/shapes.py
+++ b/regression/python/github_7398_imported_grandparent_fail/shapes.py
@@ -1,0 +1,15 @@
+class Root:
+
+    def __init__(self) -> None:
+        self.sides: int = 4
+
+    def total(self) -> int:
+        return self.sides
+
+
+class Shape(Root):
+    pass
+
+
+class Panel(Shape):
+    pass

--- a/regression/python/github_7398_imported_grandparent_fail/test.desc
+++ b/regression/python/github_7398_imported_grandparent_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7399_star_import_base/base.py
+++ b/regression/python/github_7399_star_import_base/base.py
@@ -1,0 +1,4 @@
+class B:
+
+    def __init__(self) -> None:
+        self.v: int = 7

--- a/regression/python/github_7399_star_import_base/main.py
+++ b/regression/python/github_7399_star_import_base/main.py
@@ -1,0 +1,11 @@
+from base import *
+
+
+class D(B):
+
+    def get(self) -> int:
+        return self.v
+
+
+d = D()
+assert d.get() == 7

--- a/regression/python/github_7399_star_import_base/test.desc
+++ b/regression/python/github_7399_star_import_base/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7399_star_import_base_fail/base.py
+++ b/regression/python/github_7399_star_import_base_fail/base.py
@@ -1,0 +1,4 @@
+class B:
+
+    def __init__(self) -> None:
+        self.v: int = 7

--- a/regression/python/github_7399_star_import_base_fail/main.py
+++ b/regression/python/github_7399_star_import_base_fail/main.py
@@ -1,0 +1,11 @@
+from base import *
+
+
+class D(B):
+
+    def get(self) -> int:
+        return self.v
+
+
+d = D()
+assert d.get() == 8

--- a/regression/python/github_7399_star_import_base_fail/test.desc
+++ b/regression/python/github_7399_star_import_base_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7399_star_import_precedence/main.py
+++ b/regression/python/github_7399_star_import_precedence/main.py
@@ -1,0 +1,12 @@
+from one import B
+from two import *
+
+
+class D(B):
+
+    def get(self) -> int:
+        return self.v
+
+
+d = D()
+assert d.get() == 1

--- a/regression/python/github_7399_star_import_precedence/one.py
+++ b/regression/python/github_7399_star_import_precedence/one.py
@@ -1,0 +1,4 @@
+class B:
+
+    def __init__(self) -> None:
+        self.v: int = 1

--- a/regression/python/github_7399_star_import_precedence/test.desc
+++ b/regression/python/github_7399_star_import_precedence/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7399_star_import_precedence/two.py
+++ b/regression/python/github_7399_star_import_precedence/two.py
@@ -1,0 +1,4 @@
+class C:
+
+    def __init__(self) -> None:
+        self.v: int = 2

--- a/src/python-frontend/converter/converter_symbols.cpp
+++ b/src/python-frontend/converter/converter_symbols.cpp
@@ -104,7 +104,7 @@ void python_converter::update_symbol(const exprt &expr) const
 static std::pair<std::string, std::string>
 from_import_binding(const nlohmann::json &ast, const std::string &bound)
 {
-  std::pair<std::string, std::string> binding;
+  std::pair<std::string, std::string> binding, wildcard;
 
   for (const auto &stmt : ast["body"])
   {
@@ -117,6 +117,13 @@ from_import_binding(const nlohmann::json &ast, const std::string &bound)
     for (const auto &alias : stmt["names"])
     {
       const std::string name = alias.value("name", "");
+      // `from m import *` binds every name m defines, this one included, but
+      // an explicit import of the name still wins over it (#7399).
+      if (name == "*")
+      {
+        wildcard = {stmt["full_path"].get<std::string>(), bound};
+        continue;
+      }
       const bool aliased =
         alias.contains("asname") && !alias["asname"].is_null();
       if ((aliased ? alias["asname"].get<std::string>() : name) == bound)
@@ -124,7 +131,7 @@ from_import_binding(const nlohmann::json &ast, const std::string &bound)
     }
   }
 
-  return binding;
+  return binding.first.empty() ? wildcard : binding;
 }
 
 /// Class name a `bases` entry denotes. A qualified base (`module.Class`)
@@ -168,7 +175,7 @@ symbolt *python_converter::find_function_in_imported_base_classes(
   if (!module_ast)
     return nullptr;
 
-  const nlohmann::json class_node =
+  nlohmann::json class_node =
     json_utils::find_class((*module_ast)["body"], class_name);
 
   for (const auto &base_class_node : class_node["bases"])

--- a/src/python-frontend/converter/converter_symbols.cpp
+++ b/src/python-frontend/converter/converter_symbols.cpp
@@ -127,6 +127,70 @@ from_import_binding(const nlohmann::json &ast, const std::string &bound)
   return binding;
 }
 
+/// Class name a `bases` entry denotes. A qualified base (`module.Class`)
+/// parses as an Attribute carrying `attr` instead of `id` -- reading `id`
+/// unconditionally aborted on any model-provided base such as
+/// unittest.TestCase (#6745). The symbol id uses the bare name either way.
+static std::string base_class_name(const nlohmann::json &base_class_node)
+{
+  return base_class_node.contains("id")
+           ? base_class_node["id"].get<std::string>()
+           : base_class_node.value("attr", "");
+}
+
+std::pair<const nlohmann::json *, std::string>
+python_converter::find_imported_class_module(
+  const std::string &class_name) const
+{
+  std::pair<const nlohmann::json *, std::string> found{nullptr, {}};
+
+  for (const auto &[module_name, module_ast] : module_ast_pool_)
+  {
+    const std::string path = get_imported_module_path(module_name);
+    if (path.empty())
+      continue;
+    if (json_utils::find_class(module_ast["body"], class_name).is_null())
+      continue;
+    if (found.first)
+      return {nullptr, {}}; // defined in 2+ modules -- don't guess
+    found = {&module_ast, path};
+  }
+
+  return found;
+}
+
+symbolt *python_converter::find_function_in_imported_base_classes(
+  const std::string &class_name,
+  const std::string &method_name,
+  bool is_ctor) const
+{
+  const auto [module_ast, module_path] = find_imported_class_module(class_name);
+  if (!module_ast)
+    return nullptr;
+
+  const nlohmann::json class_node =
+    json_utils::find_class((*module_ast)["body"], class_name);
+
+  for (const auto &base_class_node : class_node["bases"])
+  {
+    const std::string base_class = base_class_name(base_class_node);
+    if (base_class.empty())
+      continue;
+
+    class symbol_id base_id(
+      module_path, base_class, is_ctor ? base_class : method_name);
+    if (symbolt *func = symbol_table_.find_symbol(base_id.to_string()))
+      return func;
+
+    if (
+      symbolt *func = find_function_in_imported_base_classes(
+        base_class, method_name, is_ctor))
+      return func;
+  }
+
+  return nullptr;
+}
+
 /// A base reached through an import lives in that module's file, so an id
 /// rewritten against the current file cannot name it. Both spellings reach
 /// here: `module.Base` names its module at the use site, while
@@ -190,13 +254,7 @@ symbolt *python_converter::find_function_in_base_classes(
   // Python enforces acyclic inheritance, so this recursion terminates.
   for (const auto &base_class_node : class_node["bases"])
   {
-    /* A qualified base (`module.Class`) parses as an Attribute, which carries
-     * `attr` instead of `id` -- reading `id` unconditionally aborted on any
-     * model-provided base such as unittest.TestCase (#6745). The symbol id
-     * uses the bare class name either way. */
-    const std::string base_class = base_class_node.contains("id")
-                                     ? base_class_node["id"].get<std::string>()
-                                     : base_class_node.value("attr", "");
+    const std::string base_class = base_class_name(base_class_node);
     if (base_class.empty())
       continue;
 
@@ -219,6 +277,13 @@ symbolt *python_converter::find_function_in_base_classes(
     if (
       symbolt *func = find_function_in_base_classes(
         base_class, sym_id, base_func_name, is_ctor))
+      return func;
+
+    // The base itself is defined in an imported module, whose classes this
+    // AST does not hold, so that descent stopped one level too early (#7398).
+    if (
+      symbolt *func = find_function_in_imported_base_classes(
+        base_class, method_name, is_ctor))
       return func;
   }
 

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -860,6 +860,20 @@ private:
     std::string method_name,
     bool is_ctor) const;
 
+  /// @p method_name reached by walking the bases of @p class_name inside the
+  /// imported module that defines it. Ids are spelled against that module,
+  /// which an id rewritten against this file cannot name (#7398).
+  symbolt *find_function_in_imported_base_classes(
+    const std::string &class_name,
+    const std::string &method_name,
+    bool is_ctor) const;
+
+  /// AST and file path of the imported module that defines @p class_name, or
+  /// a null AST when no single imported module does. Ambiguity across modules
+  /// is declined rather than guessed.
+  std::pair<const nlohmann::json *, std::string>
+  find_imported_class_module(const std::string &class_name) const;
+
   /// @p method_name under @p base_class, as the module that defines the base
   /// spells it, or null when the base is not imported.
   symbolt *find_method_in_imported_base(


### PR DESCRIPTION
Two base-class lookups that failed when the base came through an import.

`find_function_in_base_classes` searched only the entry file's AST, so the walk
stopped at any class defined in an imported module and a method inherited from
that class's own base never resolved. `from_import_binding` never matched the
`*` of a wildcard import, so such a base bound to nothing and its `__init__`
never ran.

Fixes #7398
Fixes #7399
