### PR TITLE
[om] Give list and deque their allocator-taking constructors

### DIFF
--- a/regression/esbmc-cpp/deque/deque_allocator_ctors/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_allocator_ctors/main.cpp
@@ -1,0 +1,58 @@
+#include <deque>
+#include <cstddef>
+#include <memory>
+#include <cassert>
+
+/* A minimal conforming allocator. ESBMC's container models never call
+   allocate/deallocate -- the allocator is carried for type identity only. */
+template <class T>
+struct tracking_allocator
+{
+  typedef T value_type;
+  tracking_allocator()
+  {
+  }
+  template <class U>
+  tracking_allocator(const tracking_allocator<U> &)
+  {
+  }
+  T *allocate(std::size_t n)
+  {
+    return static_cast<T *>(::operator new(n * sizeof(T)));
+  }
+  void deallocate(T *p, std::size_t)
+  {
+    ::operator delete(p);
+  }
+};
+
+typedef tracking_allocator<int> alloc;
+typedef std::deque<int, alloc> ideque;
+
+int main()
+{
+  alloc a;
+
+  /* [deque.cons]: every constructor has an allocator-taking form. */
+  ideque empty(a);
+  assert(empty.size() == 0);
+
+  ideque n_default(2, a);
+  assert(n_default.size() == 2);
+  assert(n_default[0] == 0);
+
+  ideque n_value(3, 7, a);
+  assert(n_value.size() == 3);
+  assert(n_value[0] == 7);
+  assert(n_value[2] == 7);
+
+  ideque copied(n_value, a);
+  assert(copied.size() == 3);
+  assert(copied[1] == 7);
+
+  ideque from_init({8, 9}, a);
+  assert(from_init.size() == 2);
+  assert(from_init[0] == 8);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_allocator_ctors/test.desc
+++ b/regression/esbmc-cpp/deque/deque_allocator_ctors/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_allocator_ctors_fail/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_allocator_ctors_fail/main.cpp
@@ -1,0 +1,58 @@
+#include <deque>
+#include <cstddef>
+#include <memory>
+#include <cassert>
+
+/* A minimal conforming allocator. ESBMC's container models never call
+   allocate/deallocate -- the allocator is carried for type identity only. */
+template <class T>
+struct tracking_allocator
+{
+  typedef T value_type;
+  tracking_allocator()
+  {
+  }
+  template <class U>
+  tracking_allocator(const tracking_allocator<U> &)
+  {
+  }
+  T *allocate(std::size_t n)
+  {
+    return static_cast<T *>(::operator new(n * sizeof(T)));
+  }
+  void deallocate(T *p, std::size_t)
+  {
+    ::operator delete(p);
+  }
+};
+
+typedef tracking_allocator<int> alloc;
+typedef std::deque<int, alloc> ideque;
+
+int main()
+{
+  alloc a;
+
+  /* [deque.cons]: every constructor has an allocator-taking form. */
+  ideque empty(a);
+  assert(empty.size() == 0);
+
+  ideque n_default(2, a);
+  assert(n_default.size() == 2);
+  assert(n_default[0] == 0);
+
+  ideque n_value(3, 7, a);
+  assert(n_value.size() == 3);
+  assert(n_value[0] == 8);
+  assert(n_value[2] == 7);
+
+  ideque copied(n_value, a);
+  assert(copied.size() == 3);
+  assert(copied[1] == 7);
+
+  ideque from_init({8, 9}, a);
+  assert(from_init.size() == 2);
+  assert(from_init[0] == 8);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_allocator_ctors_fail/test.desc
+++ b/regression/esbmc-cpp/deque/deque_allocator_ctors_fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.cpp
 --std=c++11 --incremental-bmc
+FAILED.*assertion n_value\[0\] == 8$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_allocator_ctors_fail/test.desc
+++ b/regression/esbmc-cpp/deque/deque_allocator_ctors_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++11 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/deque/deque_size_value_ctor/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_size_value_ctor/main.cpp
@@ -1,0 +1,14 @@
+#include <deque>
+#include <cassert>
+
+/* deque(size_type, const T&) left _capacity uninitialised before
+   verify_capacity() doubled it, so the doubling loop had no bound and
+   verification never converged. */
+int main()
+{
+  std::deque<int> d(3, 7);
+  assert(d.size() == 3);
+  assert(d[0] == 7);
+  assert(d[2] == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_size_value_ctor/test.desc
+++ b/regression/esbmc-cpp/deque/deque_size_value_ctor/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/deque/deque_size_value_ctor_fail/main.cpp
+++ b/regression/esbmc-cpp/deque/deque_size_value_ctor_fail/main.cpp
@@ -1,0 +1,14 @@
+#include <deque>
+#include <cassert>
+
+/* deque(size_type, const T&) left _capacity uninitialised before
+   verify_capacity() doubled it, so the doubling loop had no bound and
+   verification never converged. */
+int main()
+{
+  std::deque<int> d(3, 7);
+  assert(d.size() == 3);
+  assert(d[0] == 8);
+  assert(d[2] == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/deque/deque_size_value_ctor_fail/test.desc
+++ b/regression/esbmc-cpp/deque/deque_size_value_ctor_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++11 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/list/list_allocator_ctors/main.cpp
+++ b/regression/esbmc-cpp/list/list_allocator_ctors/main.cpp
@@ -1,0 +1,67 @@
+#include <list>
+#include <cstddef>
+#include <memory>
+#include <cassert>
+
+/* A minimal conforming allocator. ESBMC's container models never call
+   allocate/deallocate -- the allocator is carried for type identity only. */
+template <class T>
+struct tracking_allocator
+{
+  typedef T value_type;
+  tracking_allocator()
+  {
+  }
+  template <class U>
+  tracking_allocator(const tracking_allocator<U> &)
+  {
+  }
+  T *allocate(std::size_t n)
+  {
+    return static_cast<T *>(::operator new(n * sizeof(T)));
+  }
+  void deallocate(T *p, std::size_t)
+  {
+    ::operator delete(p);
+  }
+};
+
+typedef tracking_allocator<int> alloc;
+typedef std::list<int, alloc> ilist;
+
+int main()
+{
+  alloc a;
+
+  /* [list.cons]: every constructor has an allocator-taking form. */
+  ilist empty(a);
+  assert(empty.size() == 0);
+
+  ilist n_default(2, a);
+  assert(n_default.size() == 2);
+  assert(n_default.front() == 0);
+
+  ilist n_value(3, 7, a);
+  assert(n_value.size() == 3);
+  assert(n_value.front() == 7);
+  assert(n_value.back() == 7);
+
+  ilist copied(n_value, a);
+  assert(copied.size() == 3);
+  assert(copied.front() == 7);
+
+  int raw[2] = {4, 5};
+  ilist from_pointers(raw, raw + 2, a);
+  assert(from_pointers.size() == 2);
+  assert(from_pointers.front() == 4);
+
+  ilist from_iterators(from_pointers.begin(), from_pointers.end(), a);
+  assert(from_iterators.size() == 2);
+  assert(from_iterators.back() == 5);
+
+  ilist from_init({8, 9}, a);
+  assert(from_init.size() == 2);
+  assert(from_init.front() == 8);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/list/list_allocator_ctors/test.desc
+++ b/regression/esbmc-cpp/list/list_allocator_ctors/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/list/list_allocator_ctors_fail/main.cpp
+++ b/regression/esbmc-cpp/list/list_allocator_ctors_fail/main.cpp
@@ -1,0 +1,67 @@
+#include <list>
+#include <cstddef>
+#include <memory>
+#include <cassert>
+
+/* A minimal conforming allocator. ESBMC's container models never call
+   allocate/deallocate -- the allocator is carried for type identity only. */
+template <class T>
+struct tracking_allocator
+{
+  typedef T value_type;
+  tracking_allocator()
+  {
+  }
+  template <class U>
+  tracking_allocator(const tracking_allocator<U> &)
+  {
+  }
+  T *allocate(std::size_t n)
+  {
+    return static_cast<T *>(::operator new(n * sizeof(T)));
+  }
+  void deallocate(T *p, std::size_t)
+  {
+    ::operator delete(p);
+  }
+};
+
+typedef tracking_allocator<int> alloc;
+typedef std::list<int, alloc> ilist;
+
+int main()
+{
+  alloc a;
+
+  /* [list.cons]: every constructor has an allocator-taking form. */
+  ilist empty(a);
+  assert(empty.size() == 0);
+
+  ilist n_default(2, a);
+  assert(n_default.size() == 2);
+  assert(n_default.front() == 0);
+
+  ilist n_value(3, 7, a);
+  assert(n_value.size() == 3);
+  assert(n_value.front() == 8);
+  assert(n_value.back() == 7);
+
+  ilist copied(n_value, a);
+  assert(copied.size() == 3);
+  assert(copied.front() == 7);
+
+  int raw[2] = {4, 5};
+  ilist from_pointers(raw, raw + 2, a);
+  assert(from_pointers.size() == 2);
+  assert(from_pointers.front() == 4);
+
+  ilist from_iterators(from_pointers.begin(), from_pointers.end(), a);
+  assert(from_iterators.size() == 2);
+  assert(from_iterators.back() == 5);
+
+  ilist from_init({8, 9}, a);
+  assert(from_init.size() == 2);
+  assert(from_init.front() == 8);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/list/list_allocator_ctors_fail/test.desc
+++ b/regression/esbmc-cpp/list/list_allocator_ctors_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++11 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -493,14 +493,8 @@ public:
     verify_capacity();
   }
 
-  explicit deque(size_type n) : _size(0), _capacity(1)
-  {
-    for (int i = 0; i < n; i++)
-      push_back(T());
-    _capacity = n;
-  }
-
-  explicit deque(size_type n, const allocator_type &) : _size(0), _capacity(1)
+  explicit deque(size_type n, const allocator_type & = allocator_type())
+    : _size(0), _capacity(1)
   {
     for (int i = 0; i < n; i++)
       push_back(T());

--- a/src/cpp/library/deque
+++ b/src/cpp/library/deque
@@ -456,8 +456,18 @@ public:
     _capacity = 1;
   }
 
+  // [deque.cons]: the allocator-taking overloads, ignored here (#7493).
+  explicit deque(const allocator_type &) : _size(0), _capacity(1)
+  {
+    buf[0] = T();
+    buf[1] = T();
+  }
+
 #if __cplusplus >= 201103L
-  deque(std::initializer_list<T> init) : _size(0), _capacity(1)
+  deque(
+    std::initializer_list<T> init,
+    const allocator_type & = allocator_type())
+    : _size(0), _capacity(1)
   {
     for (const T *it = init.begin(); it != init.end(); ++it)
       this->push_back(*it);
@@ -469,7 +479,10 @@ public:
     _size = 0;
   }
 
-  explicit deque(iterator t1, iterator t2) : _size(0)
+  /* No allocator-taking form: this constructor's size is off by one, so
+   * accepting the [deque.cons] spelling would return a wrong answer where it
+   * now gives a compile error. */
+  explicit deque(iterator t1, iterator t2) : _size(0), _capacity(1)
   {
     int n = 1;
     for (n = 1; t1 != t2; t1++)
@@ -487,6 +500,13 @@ public:
     _capacity = n;
   }
 
+  explicit deque(size_type n, const allocator_type &) : _size(0), _capacity(1)
+  {
+    for (int i = 0; i < n; i++)
+      push_back(T());
+    _capacity = n;
+  }
+
   explicit deque(void *t, void *addr) : _size(0), _capacity(1)
   {
     int i = 0;
@@ -497,9 +517,9 @@ public:
     verify_capacity();
   }
 
-  explicit deque(size_type n, const T &x)
+  deque(size_type n, const T &x, const allocator_type & = allocator_type())
+    : _size(0), _capacity(1)
   {
-    _size = 0;
     buf[0] = T();
     for (int i = 0; i < n; i++)
       push_back(x);
@@ -508,11 +528,12 @@ public:
 
   deque(const deque &x) : _size(0), _capacity(1)
   {
-    _size = 0;
-    buf[0] = T();
-    for (int i = 0; i < x.size(); i++)
-      push_back(x[i]);
-    verify_capacity();
+    _copy_from(x);
+  }
+
+  deque(const deque &x, const allocator_type &) : _size(0), _capacity(1)
+  {
+    _copy_from(x);
   }
 
   deque &operator=(const deque &x)
@@ -758,6 +779,14 @@ public:
     assert(0 <= _size);
     assert(_size < DEQUE_CAPACITY);
     insert(begin(), x);
+    verify_capacity();
+  }
+
+  void _copy_from(const deque &x)
+  {
+    buf[0] = T();
+    for (int i = 0; i < x.size(); i++)
+      push_back(x[i]);
     verify_capacity();
   }
 

--- a/src/cpp/library/list
+++ b/src/cpp/library/list
@@ -202,6 +202,25 @@ public:
     _size = 0;
   }
 
+  // Bulk pool copy bounded by x._next_free (the high-water mark — slots
+  // at indices >= _next_free have never been allocated and are
+  // unreachable through prev/next links). Copying by index instead of
+  // walking the linked list via x._storage.buf[i].next_idx lets ESBMC unroll
+  // with a concrete index bound: under a low --unwind the loop
+  // terminates naturally at x._next_free, instead of speculatively
+  // unrolling to --unwind with a fresh LIST_MAX_SIZE-way case split per
+  // step on the symbolic next_idx.
+  void _copy_from(const list &x)
+  {
+    __om_allocate();
+    _sentinel_prev = x._sentinel_prev;
+    _sentinel_next = x._sentinel_next;
+    _next_free = x._next_free;
+    _size = x._size;
+    for (size_type i = 0; i < x._next_free; i++)
+      _storage.buf[i] = x._storage.buf[i];
+  }
+
   size_type _alloc_idx(const value_type &x)
   {
     __ESBMC_assert(_next_free < LIST_MAX_SIZE, "list capacity exceeded");
@@ -361,8 +380,17 @@ public:
     _init();
   }
 
+  // [list.cons]: the allocator-taking overloads, ignored here (#7493).
+  explicit list(const allocator_type &)
+  {
+    __om_allocate();
+    _init();
+  }
+
 #if __cplusplus >= 201103L
-  list(std::initializer_list<value_type> init)
+  list(
+    std::initializer_list<value_type> init,
+    const allocator_type & = allocator_type())
   {
     __om_allocate();
     _init();
@@ -371,7 +399,10 @@ public:
   }
 #endif
 
-  list(size_type n, const value_type &value = value_type())
+  list(
+    size_type n,
+    const value_type &value = value_type(),
+    const allocator_type & = allocator_type())
   {
     __om_allocate();
     _init();
@@ -379,7 +410,18 @@ public:
       push_back(value);
   }
 
-  list(value_type *t1, value_type *t2)
+  explicit list(size_type n, const allocator_type &)
+  {
+    __om_allocate();
+    _init();
+    for (size_type i = 0; i < n; i++)
+      push_back(value_type());
+  }
+
+  list(
+    value_type *t1,
+    value_type *t2,
+    const allocator_type & = allocator_type())
   {
     __om_allocate();
     _init();
@@ -387,7 +429,10 @@ public:
       push_back(*p);
   }
 
-  list(iterator first, iterator last)
+  list(
+    iterator first,
+    iterator last,
+    const allocator_type & = allocator_type())
   {
     __om_allocate();
     _init();
@@ -395,23 +440,14 @@ public:
       push_back(*it);
   }
 
-  // Bulk pool copy bounded by x._next_free (the high-water mark — slots
-  // at indices >= _next_free have never been allocated and are
-  // unreachable through prev/next links). Copying by index instead of
-  // walking the linked list via x._storage.buf[i].next_idx lets ESBMC unroll
-  // with a concrete index bound: under a low --unwind the loop
-  // terminates naturally at x._next_free, instead of speculatively
-  // unrolling to --unwind with a fresh LIST_MAX_SIZE-way case split per
-  // step on the symbolic next_idx.
   list(const list &x)
   {
-    __om_allocate();
-    _sentinel_prev = x._sentinel_prev;
-    _sentinel_next = x._sentinel_next;
-    _next_free = x._next_free;
-    _size = x._size;
-    for (size_type i = 0; i < x._next_free; i++)
-      _storage.buf[i] = x._storage.buf[i];
+    _copy_from(x);
+  }
+
+  list(const list &x, const allocator_type &)
+  {
+    _copy_from(x);
   }
 
   list &operator=(const list &x)


### PR DESCRIPTION
[list.cons] and [deque.cons] pair every constructor with an allocator-taking
form; the models had none, so a conforming stateful allocator parsed at the
type level and then failed at construction.

`deque(size_type, const T&)` also left `_capacity` uninitialised, so
`verify_capacity()`'s doubling loop had no bound: `std::deque<int> d(3, 7)`
returned UNKNOWN before this patch and SUCCESSFUL after, with no allocator
involved.

`deque(iterator, iterator)` gets no allocator form — it has a separate
pre-existing off-by-one in its size, so accepting the standard spelling would
turn a compile error into a silently wrong answer.

Fixes #7493
