### PR TITLE
[esbmc] Warn when an option value names another option

### DIFF
--- a/regression/csmith/csmith01/test.desc
+++ b/regression/csmith/csmith01/test.desc
@@ -1,4 +1,4 @@
 THOROUGH
 main.c
---no-standard-checks --partial-loops --no-align-check --smtlib-solver-prog --error-label --tuple-node-flattener --all-claims --bv --witness-output --show-loops --unwind 1
+--no-standard-checks --partial-loops --no-align-check --tuple-node-flattener --all-claims --bv --unwind 1
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_7525_option_value/main.c
+++ b/regression/esbmc/github_7525_option_value/main.c
@@ -1,0 +1,10 @@
+// A value-taking option swallows the next --flag as its value (#7525).
+int main(void)
+{
+  int x = __VERIFIER_nondet_int();
+  if (x > 5)
+    goto ERROR;
+  return 0;
+ERROR:
+  return 1;
+}

--- a/regression/esbmc/github_7525_option_value/test.desc
+++ b/regression/esbmc/github_7525_option_value/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--smtlib-solver-prog --all-claims --unwind 1
+^WARNING: .--smtlib-solver-prog. takes a value, so .--all-claims. was read as that value
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_7525_option_value_abbrev/main.c
+++ b/regression/esbmc/github_7525_option_value_abbrev/main.c
@@ -1,0 +1,9 @@
+/* #7525: the parser runs with boost's allow_guessing, so an abbreviated
+ * option is still an option. `--show-loo` reaches --show-loops and is
+ * swallowed as --smtlib-solver-prog's value; an exact-match check would let
+ * this spelling through unwarned. */
+int main(void)
+{
+  int x = 0;
+  return x;
+}

--- a/regression/esbmc/github_7525_option_value_abbrev/test.desc
+++ b/regression/esbmc/github_7525_option_value_abbrev/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--smtlib-solver-prog --show-loo --unwind 1
+^WARNING: .--smtlib-solver-prog. takes a value, so .--show-loo. was read as that value
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_7525_option_value_fail/main.c
+++ b/regression/esbmc/github_7525_option_value_fail/main.c
@@ -1,0 +1,10 @@
+// Correctly spelled, --error-label still fires: the pair for #7525.
+int main(void)
+{
+  int x = __VERIFIER_nondet_int();
+  if (x > 5)
+    goto ERROR;
+  return 0;
+ERROR:
+  return 1;
+}

--- a/regression/esbmc/github_7525_option_value_fail/main.c
+++ b/regression/esbmc/github_7525_option_value_fail/main.c
@@ -1,10 +1,11 @@
-// Correctly spelled, --error-label still fires: the pair for #7525.
+/* The failing pair for #7525. `--no-assertions` is swallowed as
+ * --smtlib-solver-prog's value, so assertions stay on and this reports FAILED.
+ * Honoured, it would report SUCCESSFUL -- the verdict is what pins the
+ * swallowing, not just the warning text. */
+#include <assert.h>
 int main(void)
 {
-  int x = __VERIFIER_nondet_int();
-  if (x > 5)
-    goto ERROR;
+  int x = 0;
+  assert(x == 1);
   return 0;
-ERROR:
-  return 1;
 }

--- a/regression/esbmc/github_7525_option_value_fail/test.desc
+++ b/regression/esbmc/github_7525_option_value_fail/test.desc
@@ -1,4 +1,5 @@
 CORE
 main.c
---error-label ERROR --unwind 1
+--smtlib-solver-prog --no-assertions --unwind 1
+^WARNING: .--smtlib-solver-prog. takes a value, so .--no-assertions. was read as that value
 ^VERIFICATION FAILED$

--- a/regression/esbmc/github_7525_option_value_fail/test.desc
+++ b/regression/esbmc/github_7525_option_value_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--error-label ERROR --unwind 1
+^VERIFICATION FAILED$

--- a/src/util/config/cmdline.cpp
+++ b/src/util/config/cmdline.cpp
@@ -242,13 +242,32 @@ static void warn_option_like_values(
 {
   for (const auto &opt : parsed.options)
     for (const std::string &value : opt.value)
-      if (
-        value.rfind("--", 0) == 0 && desc.find_nothrow(value.substr(2), false))
+    {
+      if (value.rfind("--", 0) != 0)
+        continue;
+
+      /* Approximate, because the parser runs with boost's default style, which
+       * includes allow_guessing: `--show-loo` reaches --show-loops, so an exact
+       * lookup would let the abbreviated spelling through unwarned. */
+      bool names_an_option;
+      try
+      {
+        names_an_option = desc.find_nothrow(value.substr(2), true) != nullptr;
+      }
+      catch (const boost::program_options::ambiguous_option &)
+      {
+        /* A prefix several options share. find_nothrow throws rather than
+         * returning them, and a value that ambiguous is still option-like. */
+        names_an_option = true;
+      }
+
+      if (names_an_option)
         log_warning(
           "'--{}' takes a value, so '{}' was read as that value rather than as "
           "an option",
           opt.string_key,
           value);
+    }
 }
 
 bool cmdlinet::parse(

--- a/src/util/config/cmdline.cpp
+++ b/src/util/config/cmdline.cpp
@@ -233,6 +233,24 @@ std::optional<std::string> cmdlinet::get_config_file_location() const
   return std::nullopt;
 }
 
+/// Warn when a value-taking option consumed a token that names another option:
+/// `--witness-output --show-loops` silently makes "--show-loops" the witness
+/// path, and the swallowed option never runs (#7525).
+static void warn_option_like_values(
+  const boost::program_options::parsed_options &parsed,
+  const boost::program_options::options_description &desc)
+{
+  for (const auto &opt : parsed.options)
+    for (const std::string &value : opt.value)
+      if (
+        value.rfind("--", 0) == 0 && desc.find_nothrow(value.substr(2), false))
+        log_warning(
+          "'--{}' takes a value, so '{}' was read as that value rather than as "
+          "an option",
+          opt.string_key,
+          value);
+}
+
 bool cmdlinet::parse(
   int argc,
   const char **argv,
@@ -292,12 +310,13 @@ bool cmdlinet::parse(
   try
   {
     // Load commandline parameters (highest priority)
-    boost::program_options::store(
+    boost::program_options::parsed_options command_line =
       boost::program_options::command_line_parser(argc, argv)
         .options(all_cmdline_options)
         .positional(p)
-        .run(),
-      vm);
+        .run();
+    warn_option_like_values(command_line, all_cmdline_options);
+    boost::program_options::store(command_line, vm);
 
     // Config file: Check if config file should be loaded, and get location.
     std::optional<std::string> config_path = this->get_config_file_location();
@@ -328,12 +347,13 @@ bool cmdlinet::parse(
     }
 
     // Load env (lowest priority)
-    boost::program_options::store(
+    boost::program_options::parsed_options env_options =
       boost::program_options::command_line_parser(
         simple_shell_unescape(getenv("ESBMC_OPTS"), "ESBMC_OPTS"))
         .options(all_cmdline_options)
-        .run(),
-      vm);
+        .run();
+    warn_option_like_values(env_options, all_cmdline_options);
+    boost::program_options::store(env_options, vm);
   }
   // Boost throws program_options errors as boost::wrapexcept<...>, whose
   // typeinfo does not match this translation unit's std::exception across the


### PR DESCRIPTION
`--witness-output --show-loops` silently made "--show-loops" the witness path:
boost::program_options takes the next token as a value-taking option's value,
whatever it looks like. The swallowed option never runs, and the witness lands
in files literally named `--show-loops.graphml`/`.yml`.

Warn on both the command line and `ESBMC_OPTS` when a value names a registered
option. `-` (stdout) does not match, so the 45 test.desc lines using it are
unaffected.

csmith01 drops its three valueless value-taking options. `--show-loops` goes
too: once it parses, it prints the loops and exits before any verdict.

Fixes #7525
