### PR TITLE
[docs] Sync the website with user-facing changes since #7347

### DIFF
--- a/website/content/docs/c-cpp/limitations.md
+++ b/website/content/docs/c-cpp/limitations.md
@@ -28,6 +28,16 @@ should not, or vice versa.
   correctly, and `push_back` converges under `--incremental-bmc`, but the
   element copy-constructor loop that `insert`'s shift runs unwinds indefinitely.
   Use a bounded `--unwind N` run for that case.
+- **`list` and `deque` have no allocator-taking constructors.** Both take the
+  `Allocator` template parameter and expose `get_allocator()`, but a constructor
+  that is *passed* an allocator is not modelled, so `std::list<int, A> c(a)` is
+  a parse error — the same gap `basic_string` has, though not `vector`, whose
+  constructors do take a trailing allocator
+  ([#7493](https://github.com/esbmc/esbmc/issues/7493)).
+- **Comparing two `std::list` iterators with `<` is rejected**, as it is against
+  libc++: a list iterator is not random-access, so the ordering has to come from
+  a user-declared `operator<`. What changed is that such a user-declared
+  operator is now *found* by argument-dependent lookup.
 - Some STL container regression tests remain marked `KNOWNBUG`
   ([#4400](https://github.com/esbmc/esbmc/issues/4400)); the `regression/esbmc-cpp`
   suites are the authoritative record of which specific cases fail.
@@ -78,6 +88,14 @@ call shape works.
   library ([#965](https://github.com/esbmc/esbmc/issues/965)). They are written
   for verification tractability, so their performance characteristics and
   internal representations do not match a production standard library.
+- `std::filesystem::directory_iterator` yields a bounded, nondeterministic
+  number of synthesised entries — nothing reads a real filesystem, so symbolic
+  execution terminates. The cap is an *assumption* rather than an assertion, so
+  a defect needing more entries than it allows is excluded silently, where the
+  container models assert instead and report `capacity exceeded`.
+- `std::ilogb`, `std::logb` and `std::nexttoward` resolve as overloads but have
+  no model in ESBMC's libc, so they return a nondeterministic value rather than
+  the C99 result.
 
 ## Time and clocks
 

--- a/website/content/docs/c-cpp/supported-features.md
+++ b/website/content/docs/c-cpp/supported-features.md
@@ -245,12 +245,12 @@ by regression tests under `regression/esbmc-cpp*`.
 
 | Header | Notes |
 | --- | --- |
-| `<vector>` | Including `data()`, `emplace_back`, `shrink_to_fit`, `cbegin`/`cend`; the destructor frees its buffer. Elements are constructed into the raw buffer, so a vector of a non-trivial element type works |
-| `<list>`, `<forward_list>` | Const `front`/`back`/`rbegin`/`rend`, `cbegin`/`cend`; `emplace`, `emplace_back`, `emplace_front`; `reverse_iterator::base()`; the iterator carries its `iterator_traits` typedefs. Both may hold an incomplete element type, so a node that points back at its own container compiles |
-| `<deque>` | Const iteration; lexicographic `<`/`<=`/`>`/`>=` with const-qualified comparators |
+| `<vector>` | Including `data()`, `emplace_back`, `shrink_to_fit`, `cbegin`/`cend`; the destructor frees its buffer. Elements are constructed into the raw buffer, so a vector of a non-trivial element type works. `reserve()` grows the buffer in place, which keeps `size()` and `capacity()` decidable, so a `push_back` after it costs the same at any `--unwind` |
+| `<list>`, `<forward_list>` | Const `front`/`back`/`rbegin`/`rend`, `cbegin`/`cend`; `emplace`, `emplace_back`, `emplace_front`; `reverse_iterator::base()`; the iterator carries its `iterator_traits` typedefs. Both may hold an incomplete element type, so a node that points back at its own container compiles. `list`'s iterator lives at namespace scope, as libc++ spells it, so [basic.lookup.argdep] associates the element type and a user-declared `operator<` over a `list<T>::iterator` is found |
+| `<deque>` | Const iteration; lexicographic `<`/`<=`/`>`/`>=` with const-qualified comparators; `back()` returns `reference`, so `d.back() = x` is a write through the container, and `const_iterator` converts from `iterator` |
 | `<map>` | Const `at`, `emplace`, `try_emplace`, `insert_or_assign`, C++20 `contains`; const `find`/`count`/`lower_bound`/`upper_bound`/`equal_range`. Const iterators compare by position rather than by a cached pair, so two iterators into equal-keyed entries stay distinct. `mapped_type` may be incomplete |
 | `<set>` | Const-correct const iterators, `emplace`, C++20 `contains` |
-| `<unordered_map>`, `<unordered_set>` | `<unordered_set>` provides `std::unordered_multiset` too |
+| `<unordered_map>`, `<unordered_set>` | `<unordered_map>` provides `std::unordered_multimap` and `<unordered_set>` `std::unordered_multiset`. Per [unord.multimap] the multimap's `insert` never rejects an equivalent key, `erase(k)` removes every match and returns how many, and there is no `operator[]`/`at` |
 | `<array>` | `iterator` / `const_iterator` typedefs; usable in C++11 |
 | `<queue>`, `<stack>`, `<bitset>` | Includes `std::priority_queue` |
 | `<iterator>` | `iterator_traits` and the iterator tags; `advance`, `distance`, `next`, `prev` — stepped one element at a time for an iterator that is not random-access, instead of requiring `+=`; the range accessors including the reverse forms `rbegin` / `rend` / `crbegin` / `crend` and the free `size` / `empty` / `data` |
@@ -259,11 +259,17 @@ by regression tests under `regression/esbmc-cpp*`.
 `std::multimap` and `std::multiset` track `std::map` and `std::set`, including
 `contains` and `cbegin`/`cend`.
 
-The ordered and unordered containers take their `Allocator` template
-parameter, so a container spelled with an explicit allocator names the same
-type it does in a host build. `size_type` is unsigned, iterator dereference is
-const-qualified, and `vector`'s iterator-pair constructor is constrained so it
-does not hijack `vector<int>(3, 0)`.
+`list`, `set`, `multiset`, `map` and `multimap` gained the
+[container.requirements] relational operators, comparing lexicographically over
+any element type as `vector` and `deque` already did, so `{2} < {1, 3}` is
+false. `forward_list` still has none.
+
+The containers take their `Allocator` template parameter — the ordered and
+unordered ones, and `list` and `deque` alongside `vector` and `basic_string` —
+so a container spelled with an explicit allocator names the same type it does in
+a host build, and `get_allocator()` is available. `size_type` is unsigned,
+iterator dereference is const-qualified, and `vector`'s iterator-pair
+constructor is constrained so it does not hijack `vector<int>(3, 0)`.
 
 ### Strings and streams
 
@@ -283,7 +289,7 @@ members are `constexpr`, and `char_traits<char>` compares as `unsigned char`
 
 | Header | Notes |
 | --- | --- |
-| `<type_traits>` | Classification traits and the `_t` / `_v` forms, including `is_trivial`, `is_standard_layout`, `is_aggregate`, `is_assignable` and the copy/move/destructible variants, `remove_cvref`, `aligned_storage`, `invoke_result`, and the logical traits `conjunction` / `disjunction` / `negation`. Also `is_object`, `is_scalar`, `is_compound`, `is_fundamental`, `rank`, `add_cv`, `add_volatile`, `has_virtual_destructor`, `is_member_object_pointer`, `is_member_function_pointer`, `is_default_constructible`, `is_move_constructible` / `is_move_assignable`, and the `is_nothrow_*` and `is_trivially_*_constructible` families. `is_convertible` is defined by copy-initialization rather than `static_cast`, so an explicit constructor no longer makes it `true` ([meta.rel]) |
+| `<type_traits>` | Classification traits and the `_t` / `_v` forms, including `is_trivial`, `is_standard_layout`, `is_aggregate`, `is_assignable` and the copy/move/destructible variants, `remove_cvref`, `aligned_storage`, `invoke_result`, and the logical traits `conjunction` / `disjunction` / `negation`. Also `is_object`, `is_scalar`, `is_compound`, `is_fundamental`, `rank`, `add_cv`, `add_volatile`, `has_virtual_destructor`, `is_member_object_pointer`, `is_member_function_pointer`, `is_default_constructible`, `is_move_constructible` / `is_move_assignable`, and the `is_nothrow_*` and `is_trivially_*_constructible` families. `is_convertible` is defined by copy-initialization rather than `static_cast`, so an explicit constructor no longer makes it `true` ([meta.rel]). The `_t` aliases that were missing from [meta.trans] are there — `add_volatile_t`, `add_cv_t` and `add_rvalue_reference_t` alongside the traits themselves — and `remove_all_extents` is modelled, with `type_identity` gated on C++20 as P0887R1 specifies |
 | `<utility>` | Including `index_sequence_for` and C++23 `std::unreachable` |
 | `<functional>`, `<memory>`, `<initializer_list>` | `<functional>` has the transparent operation functors (`plus<>`, `less<>`, …), `std::reference_wrapper` with `ref`/`cref` and its call operator, `std::placeholders`, and a `std::function` whose call target is templated on its signature; `<memory>` has `std::allocate_shared`, a correct default-constructed `unique_ptr`, the `uninitialized_copy` / `uninitialized_fill` family, and an `allocator_traits` that works with a minimal allocator — `rebind_alloc`, the nothrow copy traits, and `construct`/`destroy` templated on the pointee |
 | `<tuple>` | `std::tie`, `std::ignore`, structured binding over a tuple, `tuple_size_v` |
@@ -294,7 +300,7 @@ members are `constexpr`, and `char_traits<char>` compares as `unsigned char`
 | `<source_location>`, `<span>`, `<bit>` | C++20 |
 | `<typeinfo>`, `<exception>`, `<stdexcept>`, `<system_error>`, `<new>` | |
 | `<limits>` | Works under `--std c++11` and `c++14` |
-| `<filesystem>` | `filesystem::u8path`, `path::u8string`, `path::generic_string`; `std::error_code` is visible through the header |
+| `<filesystem>` | `filesystem::u8path`, `path::u8string`, `path::generic_string`; the [fs.path.decompose] members `filename` / `parent_path` / `extension` / `stem`, matching libc++ on the dot-dot, separator-run (`a//b` → `a`, `//b` → `//`) and trailing-period cases; `directory_entry` and `directory_iterator`, which yield a nondeterministic, bounded number of entries synthesised under the base path rather than reading a real filesystem; `std::error_code` is visible through the header |
 
 ### Algorithms and numerics
 
@@ -302,7 +308,7 @@ members are `constexpr`, and `char_traits<char>` compares as `unsigned char`
 | --- | --- |
 | `<algorithm>` | Including the C++11 algorithms and `move_backward` |
 | `<numeric>` | `iota`, `gcd`, `lcm`, `reduce` |
-| `<cmath>` | The floating-point classifiers `std::isnan`, `std::isinf`, `std::isfinite`, `std::isnormal` and `std::signbit` are re-declared as `std::` overloads lowered to ESBMC's native FP intrinsics. `fmod`, `remainder` and `remquo` lower to the solver's exact FP remainder rather than being computed as `x - y*(int)(x/y)`, which double-rounded and overflowed the cast for a large quotient |
+| `<cmath>` | The C99 `<cmath>` functions resolve in namespace `std`, as [cmath.syn] requires: the classifiers `std::isnan`, `std::isinf`, `std::isfinite`, `std::isnormal` and `std::signbit` are re-declared as `std::` overloads lowered to ESBMC's native FP intrinsics, and `std::ilogb`, `logb`, `scalbn`, `scalbln`, `fma`, `remquo`, `lround`, `llround`, `lrint`, `llrint`, `nexttoward` and `nan` resolve as well (`ilogb`, `logb` and `nexttoward` have no model in ESBMC's libc and return a nondeterministic value). `fmod`, `remainder` and `remquo` lower to the solver's exact FP remainder rather than being computed as `x - y*(int)(x/y)`, which double-rounded and overflowed the cast for a large quotient |
 | `<complex>`, `<random>` | |
 
 ### Time

--- a/website/content/docs/constructs.md
+++ b/website/content/docs/constructs.md
@@ -320,21 +320,30 @@ int main() {
 __SIZE_TYPE__ __ESBMC_get_object_size(const void *p);
 ```
 
-`__ESBMC_get_object_size(p)` yields the size in bytes of the whole object `p`
-points into, regardless of `p`'s offset. GCC's `__builtin_object_size(p, type)`
+`__ESBMC_get_object_size(p)` yields the number of *elements* in the array object
+`p` points into, regardless of `p`'s offset. GCC's `__builtin_object_size(p, type)`
 is rewritten to `__ESBMC_builtin_object_size` and answered from the same model
 rather than from a compile-time approximation, so it stays exact for heap
-objects:
+objects. It counts **bytes**, and it measures the object addressed rather than
+`sizeof(*p)`: a scalar reached through a `void *` or a `char *` reports the
+scalar's own size, not `0` or `1`. The two therefore agree only where the
+element is one byte wide:
 
 ```c
 #include <assert.h>
 #include <stdlib.h>
 int main() {
     char a[10];
+    int n[4];
     char *d = malloc(8);
     assert(__ESBMC_get_object_size(a) == 10);
     assert(__builtin_object_size(a, 0) == 10);
+    assert(__ESBMC_get_object_size(n) == 4);    /* elements */
+    assert(__builtin_object_size(n, 0) == 16);  /* bytes */
     assert(__ESBMC_get_object_size(d) == 8);
+
+    void *v = &n[0];
+    assert(__builtin_object_size(v, 0) == 16);  /* the object, not sizeof(void) */
     return 0;
 }
 ```
@@ -419,7 +428,7 @@ against havoc'd values ([#2457](https://github.com/esbmc/esbmc/issues/2457)):
 | `__CPROVER_POINTER_OBJECT(p)` | Object component of `p` |
 | `__CPROVER_POINTER_OFFSET(p)` | Byte offset component of `p` |
 | `__CPROVER_same_object(p, q)` | `p` and `q` address the same object |
-| `__CPROVER_OBJECT_SIZE(p)` | Size of the object (`0` for `NULL`) |
+| `__CPROVER_OBJECT_SIZE(p)` | Size in bytes of the object addressed, whatever `p`'s own type (`0` for `NULL`) |
 | `__CPROVER_DYNAMIC_OBJECT(p)` | `p` points into heap-allocated memory |
 | `__CPROVER_LIVE_OBJECT(p)` | The object is still allocated |
 | `__CPROVER_WRITEABLE_OBJECT(p)` | Coincides with `__CPROVER_LIVE_OBJECT` |

--- a/website/content/docs/function-contracts.md
+++ b/website/content/docs/function-contracts.md
@@ -95,11 +95,27 @@ or a value reachable through a pointer.
 It also works under a quantifier, as `__ESBMC_old(r->coeffs[j])` inside an
 `__ESBMC_forall` over `j`. A quantified index cannot be snapshotted one element
 at a time — the snapshot is taken once, before the body runs, while `j` still
-ranges — so the whole region is copied at entry and indexed afterwards. That
-needs a named object to copy: an array wrapped in a struct, or an array named
-directly, both work. A bare `int r[N]` parameter (which is a pointer, with its
-extent stated only in an `__ESBMC_is_fresh` clause the rewrite never sees) and
-an `int (*r)[N]` parameter are declined, and say so
+ranges — so the whole region is copied at entry and indexed afterwards. An array
+wrapped in a struct and an array named directly both work, and so does a bare
+`int r[N]` parameter under `--enforce-contract`: the region's extent is taken
+from the pointer's own `__ESBMC_requires(__ESBMC_is_fresh(r, N * sizeof(int)))`
+clause and copied element-wise at entry, which is what makes an element-wise
+postcondition such as
+
+```c
+__ESBMC_ensures(__ESBMC_forall(&j, !(j < N) || (r[j] == __ESBMC_old(r[j]) + 1)));
+```
+
+expressible on a function that takes its array the usual way.
+
+Four shapes are declined with a diagnostic naming the reason: an extent that is
+not stated by an unconditional, direct `__ESBMC_is_fresh` on the parameter; a
+zero-size element type, from which no element count can be derived; the same
+pointer used both as `__ESBMC_old(ptr)` and as a per-element
+`__ESBMC_old(ptr[j])` in one contract; and `--replace-call-with-contract`, which
+has no extent tracking at a call site. An `int (*r)[N]` parameter is a separate
+gap — it reaches the dereference layer and aborts there rather than being
+declined, and is pinned as `KNOWNBUG`
 ([#7057](https://github.com/esbmc/esbmc/issues/7057)).
 
 ## What a function may modify: `__ESBMC_assigns`
@@ -144,6 +160,12 @@ stronger guarantees.
 | `__ESBMC_assigns(p->sub->field)`            | A path through more than one pointer, rooted at a parameter |
 | `__ESBMC_assigns(x, y, z)`                  | Multiple targets (up to 5)         |
 | `__ESBMC_assigns()` or `__ESBMC_assigns(0)` | Nothing — declares a pure function |
+
+An index in an assigns target is read **in the pre-state**: `__ESBMC_assigns(buf[head], head)`
+grants the element `head` denoted on entry, so the ring-buffer idiom that writes
+`buf[head]` and then advances `head` complies, while a body that advances `head`
+first and writes the next element does not. This holds for a global array and
+for a pointer parameter alike.
 
 ### What happens when there is no `assigns` clause?
 
@@ -413,6 +435,15 @@ shares no object with any other pointer argument, and that the object it points
 into really does extend `size` bytes past it. Both halves are obligations on
 the caller, so a program that passed a smaller object than the contract asked
 for now reports a violated `requires` where it previously verified.
+
+Which object the argument names decides the extent, not how the call site spells
+it: `buf`, `&buf[0]`, a local `int *q = buf`, and a pointer forwarded through a
+parameter all reach the same object, and all have their extent checked — it is
+no longer skipped for automatic or static storage, so a call handing the
+contract a smaller object than it demands is rejected there rather than passing
+silently. The separation half is a separate obligation and is unaffected: a
+correctly-sized global still fails the aliasing check if another pointer
+argument can name it.
 
 Two consequences worth knowing:
 
@@ -767,6 +798,15 @@ to `o->x` is caught. It does not extend through the inner pointer — a write to
 — because the pointee of `o->sub` is not a parameter and has nothing to root a
 snapshot at. A path rooted at a *global* pointer (`__ESBMC_assigns(g->sub->a)`)
 still generates no verification conditions at all.
+
+**A `requires` over a global is evaluated at program start under enforce.** The
+enforce harness begins where every global still holds its static initialiser, so
+`__ESBMC_requires(other == 1)` on a global that `main` sets to `1` before the
+call cannot be satisfied there: the precondition lowers to a false assumption,
+the body is never reached, and the run reports `VERIFICATION SUCCESSFUL` over
+zero verification conditions. Parameters are unaffected, being nondeterministic,
+so state the precondition over a parameter where the choice exists
+([#7356](https://github.com/esbmc/esbmc/issues/7356)).
 
 **Quantifiers require Z3.** `__ESBMC_forall` and `__ESBMC_exists` are not
 supported by Boolector or other backends. Pass `--z3` when using quantified

--- a/website/content/docs/loop-invariants.md
+++ b/website/content/docs/loop-invariants.md
@@ -95,12 +95,46 @@ cost does not grow with the loop bound. It is the only mode that performs exit
 reasoning (`invariant && !condition` at the loop exit), which makes it the
 required choice for the second row of [Choosing a Mode](#choosing-a-mode).
 
-Two caveats:
+Three caveats:
 
-- It **may produce spurious counterexamples** for invariants that are correct
-  but too weak, because the havoc step can assign values outside the expected
-  program state without proper constraint propagation. Strengthen the invariant
-  until it entails the property you are proving.
+- A claim after the loop is checked against the abstraction, not against the
+  program, so a **correct but too weak invariant admits states the program
+  cannot reach**. Such a claim is reported `UNKNOWN` rather than `FAILED`, with
+  the reason attached — an over-approximation can prove a claim, never refute
+  it:
+
+  ```
+  ** Results:
+  main.c, function main
+    PASSED   [main.assertion.1]  line 11  loop invariant base case
+    PASSED   [main.assertion.2]  line 11  loop invariant inductive step
+    UNKNOWN  [main.assertion.3]  line 16  assertion s == 3 (loop invariant too
+             weak to prove this claim: the counterexample is against the havoc
+             abstraction, not a reachable state of the program)
+
+  ** 0 of 3 properties failed, 2 passed, 1 unknown
+  WARNING: every violated claim lies downstream of a loop invariant havoc, so
+  its counterexample is against the abstraction rather than the program;
+  strengthen the invariant to decide the claim
+
+  VERIFICATION UNKNOWN
+  ```
+
+  Strengthen the invariant until it entails the property. **This mode cannot
+  report a bug after an annotated loop**; plain BMC and `--k-induction`, whose
+  base case keeps the original loop, remain the modes that refute. What keeps
+  reporting `FAILED` is a claim *ahead* of every havoc, the invariant's own
+  inductive step and its assigns-compliance check, and a loop the schema
+  declined. An **outermost** loop's base case does too, since no havoc precedes
+  it; an inner loop's base case sits inside the outer body, downstream of the
+  outer havoc, so it is downgraded with everything else there.
+- The schema **declines a loop it cannot havoc soundly** instead of claiming a
+  proof: a body (or a callee) that writes only through a pointer, where the
+  guard reads nothing the havoc covers, leaves nothing for the modified-variable
+  analysis to record. Such a loop is left to the unwinder, with a warning —
+  `loop invariant at <location> not checked beyond its base case: the loop
+  writes through a pointer the havoc cannot cover` — and its base case is still
+  checked, since that runs from the concrete pre-loop state.
 - Cutting the loop establishes **partial correctness** only: termination is not
   proved. Use `--termination` separately if you need it.
 
@@ -201,21 +235,26 @@ loops requires further refinement.
 **Manual Invariant Specification:** Users must manually specify correct loop
 invariants. ESBMC will not infer or validate invariants before verification. An
 incorrect invariant will lead to a failed base-case assertion in
-`--loop-invariant` mode, or potentially a spurious result in
-`--loop-invariant-check` mode.
+`--loop-invariant` mode, or an undecided claim in `--loop-invariant-check` mode.
 
 > **Note:** `--loop-invariant-check` havocs every loop-modified variable, so an
-> invariant that does not constrain them enough can yield a false positive
-> (commonly an integer-overflow report). `--loop-invariant` does not have this
-> failure mode. If you hit it, either strengthen the invariant or, when the
-> property follows from the invariant alone, switch to `--loop-invariant`.
+> invariant that does not constrain them enough leaves the claims after the loop
+> undecided (commonly an integer-overflow report), and they are reported
+> `UNKNOWN`. `--loop-invariant` does not have this failure mode. If you hit it,
+> either strengthen the invariant or, when the property follows from the
+> invariant alone, switch to `--loop-invariant`.
+
+**`--k-induction-parallel` still reports a downgraded claim as `FAILED`.** The
+downgrade is recorded in the parallel driver but the verdict does not follow it
+back across the fork
+([#7516](https://github.com/esbmc/esbmc/issues/7516)).
 
 ## Mode Summary
 
 |                          | Unrolls the loop | Exit reasoning | Weak invariant           |
 | ------------------------ | ---------------- | -------------- | ------------------------ |
 | `--loop-invariant`       | yes              | no             | falls back to unrolling  |
-| `--loop-invariant-check` | no               | yes            | may report false positive |
+| `--loop-invariant-check` | no               | yes            | reports `UNKNOWN`        |
 
 Programs without loop invariant annotations continue to use the standard
 k-induction unwinding approach under either flag.

--- a/website/content/docs/python/limitations.md
+++ b/website/content/docs/python/limitations.md
@@ -14,8 +14,11 @@ weight: 4
 
 ## Lists
 
-- `list.sort()` does not support the `key` keyword argument; `reverse` is supported.
-- `sorted()` does not support the `key` keyword argument; `reverse` is supported.
+- `list.sort()` supports `reverse`. `xs.sort(key=...)` is rewritten to
+  `xs = sorted(xs, key=...)`, so it carries `sorted()`'s restrictions — and the
+  rewrite needs a bare name as the receiver and no positional argument.
+- `sorted()` supports `reverse`, and applies `key=` only where the iterable's
+  shape is known at conversion time — see [Built-in Functions](#built-in-functions).
 
 ## Sets
 
@@ -32,10 +35,10 @@ weight: 4
 
 ## Built-in Functions
 
-- `min()` and `max()` support two-argument form and single-list form only (`default` is supported). The `key` keyword argument is honoured only over **constant** lists for the `lambda x: x[K]`, `key=abs`, and `key=len` forms; any other key (symbolic elements, a user function, a non-constant key) is refused with a named error rather than silently answered in natural order.
+- `min()` and `max()` support two-argument form and single-list form only (`default` is supported). `key=` is folded over **constant** lists for the `lambda x: x[K]`, `key=abs` and `key=len` forms, and otherwise lowered to a linear scan that really applies the key, including over a list literal whose elements are symbolic *scalars*. Ties keep the first occurrence (as CPython does), and an empty iterable raises `IndexError` where CPython raises `ValueError`. A shape the scan cannot lower — a list literal containing tuples, a dict view call (`d.keys()`/`.values()`/`.items()`), a bound method as the key, an element the key subscripts arriving as a subscripted parameter — is refused with a named error rather than answered with the key dropped.
 - `any()` and `all()` currently support only list literals as arguments. `any()` rejects other iterables with a parse-time error; `all()` may trigger a dereference failure on non-list iterables.
 - `sum()` supports `int` and `float` element types only.
-- `sorted()` supports `int`, `float`, and `str` element types, plus a homogeneous list of tuples (the element types are carried through, so `for u, v in sorted(pairs)` unpacks). `reverse=` is supported; a `key=` is honoured only where the preprocessor can constant-fold the call, and is otherwise refused with a named error.
+- `sorted()` supports `int`, `float`, and `str` element types, plus a homogeneous list of tuples (the element types are carried through, so `for u, v in sorted(pairs)` unpacks). `reverse=` is supported. `key=` is applied over a list literal whose elements are symbolic scalars, and over a constant list or dict literal — the latter read through `d.__getitem__` — with a lambda or an undecorated, never-rebound module-level `def` as the key, including when the call is a `for` loop's iterable. A list *of tuples* has only the constant-fold path: with symbolic tuple elements the scan declines it. A dict with a symbolic value, a bound method other than `__getitem__` (`key=d.get`), or any other shape the preprocessor cannot fold is refused with `sorted() with key= is only supported over a constant iterable` rather than sorted in natural order.
 - `input()` is modelled as a nondeterministic string with a maximum length of 256 characters (under-approximation).
 - `print()` evaluates each argument expression once (so safety checks and call side effects reach the GOTO program) but produces no actual output during verification.
 - `enumerate()` supports the iterable + `start` keyword forms; nested or unusually-shaped iterables are not exercised by the regression suite and may surface edge cases.
@@ -48,8 +51,12 @@ weight: 4
 
 ## Lambda Expressions
 
-- Return type inference is naive and defaults to `double`.
-- Parameter types are assumed to be `double` for simplicity.
+- Return type inference is naive and defaults to `float`.
+- A parameter's type is recovered from the calls made through the bound name
+  when every call agrees on it, and when a subscripted parameter's argument is
+  bound to a list literal. Anything less certain keeps the `float` default, so a
+  lambda whose parameter is neither annotated nor pinned by its call sites is
+  still assumed to be a float.
 
 ## F-Strings
 
@@ -69,7 +76,8 @@ value (see [Supported Features — Dynamic Typing](./supported-features#dynamic-
 within these bounds:
 
 - A tag holds one of `bool`, `int`, `float` or `str`. `isinstance` against an aggregate or a user class is therefore answered `False`, not consulted.
-- Arithmetic (`+`, `-`, `*`, `/`) is supported against a **literal** operand, and `-` and `/` between two tagged operands; `+` additionally concatenates strings. A non-numeric operand raises `TypeError`.
+- Arithmetic (`+`, `-`, `*`, `/`) is supported against a **literal** operand, and `+`, `-` and `/` between two tagged operands; `+` additionally concatenates strings. A non-numeric operand raises `TypeError`.
+- Ordered comparisons (`<`, `<=`, `>`, `>=`) work against a literal and between two tagged operands, raising `TypeError` on a type mismatch. `==` treats `bool` and `int` as the same type, so `True == 1`.
 - Divergence is detected across an `if`/`elif`/`else` chain only when every branch assigns the name; a chain with a branch that leaves it unassigned is not tagged.
 - `x is None` is folded only against a literal `None`. A computed operand is not folded, since that would drop its side effects.
 - Rebinding a tagged variable to a list, tuple or class instance is refused inside a loop or a conditional body, where the join of the retyped aliases is not modelled.
@@ -131,6 +139,7 @@ within these bounds:
 - Only the NumPy functions listed in [Supported Features — NumPy](./supported-features#numpy-module-numpy) have executable support.
 - The reductions (`sum`/`prod`/`min`/`max`/`mean`/`argmin`/`argmax`), comparison/logical ufuncs (`greater`/`less`/`equal`/`logical_*`/`where`), and constructors (`arange`/`full`/`eye`/`identity`/`linspace`) are constant-folded over list-backed (1D/2D) inputs and constant shapes; runtime-constructed inputs and higher-rank shapes are rejected with deterministic frontend errors.
 - `np.arange()` materialises its result at conversion time, so its arguments must be constant — a name bound to a literal is resolved first, but a function parameter is rejected with `TypeError: numpy.arange() currently supports constant numeric inputs only` rather than routed through the operational model's while loop, which did not terminate in practice. A range past 10000 elements is declined for the same reason, and `step=0` raises `ValueError`.
+- A returned array keeps its metadata only for the shapes listed under [Supported Features — NumPy](./supported-features#numpy-module-numpy). An unannotated **2-D array parameter** is typed as flat 1-D inside the callee's own body, so `numpy.transpose`'s "1-D is a no-op" fallback can return it unchanged where caller-side inlining does not mask it — the one shape here that yields a wrong value rather than an explicit rejection. An unannotated function that builds an array through a local before returning it, and a captured list mutated without a `global` declaration, are pinned as `KNOWNBUG`.
 - A view onto the base array needs literal bounds and a fixed-shape 1-D or 2-D source: 1-D slices (any step, including reversed), 2-D row and column views, `np.diagonal`, `np.ravel` and `a.flat[i]` alias the buffer; a symbolic bound or index, or a 3-D source, still produces an independent copy. `np.diagonal` is read-only, and a diagonal used inline (`np.diagonal(a)[i]`) rather than bound to a name is declined. `np.fill_diagonal` requires a value whose length matches the diagonal exactly.
 - `np.arccos`, `np.fmod`, `np.transpose`, `np.dot`, and `np.matmul` now lower to executable models (they were previously type-inference-only stubs), each under a stated restriction: `np.arccos` rejects runtime 2D arrays; `np.fmod` rejects `np.array(...)`-wrapped operands (`Unsupported operation: numpy.fmod on array operands`); `np.transpose` is limited to 2D and rejects higher rank; `np.dot`/`np.matmul` cover 1D/2D integer and float inputs.
 - `numpy.linalg.det` supports constant numeric 2x2 and 3x3 matrices. Other `numpy.linalg` operations, complex determinants, runtime-constructed matrices, and larger matrix sizes are not supported.
@@ -177,6 +186,17 @@ within these bounds:
 - **`Thread` subclassing is supported** (see [Supported Features](/docs/python/supported-features#thread-subclassing)), with these shapes refused at parse time: multiple inheritance, a class below module scope, a missing `run`, an overridden `start`, a non-bare `super().__init__()`, a class defined after its constructing function, instance reassignment, binding by anything other than a simple assignment, construction inside a loop, and assignment to a `global`/`nonlocal` name from a function.
 - **Other `threading` primitives are not supported**: `RLock`, `Semaphore`, `Condition`, `Event`, `Barrier`, `Timer` are refused at parse time. The `queue` module now has a single-threaded model (`queue.Queue`/`LifoQueue`; see [Supported Features — Queue](./supported-features#queue-module-queue)), but its blocking `put()`/`get()` semantics are not modelled, so it does not provide thread synchronisation.
 - **The CPython Global Interpreter Lock (GIL) is not modelled** ([#4579](https://github.com/esbmc/esbmc/issues/4579)). Translated programs execute under sequentially-consistent POSIX semantics rather than GIL-serialised bytecode execution, so the analysis over-approximates the set of feasible interleavings compared to actual CPython execution. This preserves safety but may produce spurious concurrency counterexamples.
+
+## Unittest Module
+
+- The model covers the assertion vocabulary listed under
+  [Supported Features — Unittest](./supported-features#unittest-module-unittest);
+  `assertRaises`, `assertAlmostEqual`, the `subTest` context manager and the
+  class-level `setUpClass` / `tearDownClass` hooks are not modelled.
+- `unittest.main()` runs the tests *discovered in the file being verified*.
+  `test.support` and `sys.path`-aware module resolution — what a CPython
+  regression test relies on — are not implemented
+  ([#6745](https://github.com/esbmc/esbmc/issues/6745)).
 
 ## Module System
 

--- a/website/content/docs/python/supported-features.md
+++ b/website/content/docs/python/supported-features.md
@@ -39,7 +39,7 @@ This page is a reference of all Python language constructs, data structures, and
 - **Closures**: a nested `def` may read a scalar of the enclosing function and write through a captured list (`c[0] += 1`), provided nothing rebinds the captured name after the `def`; a nested `c = [9]` binds its own local rather than the enclosing list
 - **`Callable[[A], R]` annotations** on a return type or a variable carry the spelled signature, so a call through the value returns `R` rather than a nondeterministic value; a bare `Callable` takes its signature from the assigned function
 - **Dunder spellings of operators**: `d.__getitem__(k)`, `xs.__len__()` and `d.__contains__(k)` are rewritten to `d[k]`, `len(xs)` and `k in d`, and dispatch to a user class's own dunder as the operators do
-- **Lambda expressions**: Single-expression lambdas with multiple parameters; converted to regular functions and stored as function pointers; can be assigned to variables and called indirectly
+- **Lambda expressions**: Single-expression lambdas with multiple parameters; converted to regular functions and stored as function pointers; can be assigned to variables and called indirectly. A parameter's type is taken from the calls made through the bound name when they all agree, so a lambda whose body subscripts its parameter (`f = lambda p: p[0]`) is typed as the list it is called with instead of defaulting to `float` and reporting `'float' object is not subscriptable`
 
 ## Object-Oriented Programming
 
@@ -85,7 +85,7 @@ This page is a reference of all Python language constructs, data structures, and
 - `copy()`: Return a shallow copy
 - `extend(iterable)`: Append all elements from an iterable (list, string, tuple, or function-call result)
 - `reverse()`: Reverse in place
-- `sort()`: Sort in place (no arguments; key/reverse parameters not supported)
+- `sort()`: Sort in place, with `reverse=`. `xs.sort(key=...)` on a bare name is rewritten to `xs = sorted(xs, key=...)`, so it is supported exactly where `sorted()`'s `key=` is (see [Built-in Functions](#built-in-functions))
 - `insert(i, x)`: Insert at position; handles index at/beyond end, within bounds, and empty lists
 - `count(x)`: Return the number of occurrences of a value
 - `index(x[, start[, end]])`: Return the position of the first occurrence of a value; the optional `start`/`end` bounds search the slice `l[start:end]` and return the absolute index (CPython slice-clamping semantics), raising `ValueError` if not found
@@ -105,9 +105,9 @@ This page is a reference of all Python language constructs, data structures, and
 
 **Case conversion**: `lower()`, `upper()`, `capitalize()`, `title()`, `swapcase()`, `casefold()`
 
-**Search**: `find()`, `rfind()`, `index()`, `rindex()`, `count()` (with optional range arguments). `index()`/`rindex()` are the raising forms of `find()`/`rfind()` — they return the first/last position and raise `ValueError` when the substring is absent (rather than returning `-1`).
+**Search**: `find()`, `rfind()`, `index()`, `rindex()`, `count()` (with optional range arguments). `index()`/`rindex()` are the raising forms of `find()`/`rfind()` — they return the first/last position and raise `ValueError` when the substring is absent (rather than returning `-1`). All four are constant-folded when receiver and argument are both constants, so the answer is exact and independent of `--unwind`; `index`/`rindex` decline the fold on a miss, leaving the model to raise.
 
-**Modification**: `replace()`, `strip()`, `lstrip()`, `rstrip()`, `removeprefix()`, `removesuffix()`, `translate(str.maketrans(...))` (constant-folded over ASCII operands; the two- and three-argument `maketrans` forms map and delete characters, matching CPython)
+**Modification**: `replace()` (constant-folded when receiver, needle and replacement are all constants, whatever spelling the receiver has; otherwise a single-scan runtime model), `strip()`, `lstrip()`, `rstrip()`, `removeprefix()`, `removesuffix()`, `translate(str.maketrans(...))` (constant-folded over ASCII operands; the two- and three-argument `maketrans` forms map and delete characters, matching CPython)
 
 **Splitting/joining**: `split()`, `rsplit()`, `splitlines()`, `partition()`, `rpartition()`, `join()`
 
@@ -199,7 +199,7 @@ Byte sequences and integer class methods:
 
 - **`bytes(...)` constructor** — `bytes(iterable-of-ints)` (e.g. `bytes([1, 2, 3])`) and `bytes(n)` (`n` zero bytes) build a real byte array, like a `b"..."` literal, so `len()` and indexing work; byte literals (`b"abc"`) are also supported
 - **`int.from_bytes(bytes_data, byteorder, *, signed=False)`** — converts a byte sequence to an integer; supports big- and little-endian, signed and unsigned. Endianness may be given positionally (`int.from_bytes(b, "big")`) or as the `byteorder=` keyword (`int.from_bytes(b, byteorder="big")`)
-- **`int.to_bytes(length=1, byteorder='big', *, signed=False)`** — converts an integer to a byte sequence. `length` and `byteorder` may each be passed positionally or by keyword, and both default (CPython 3.11+: `(5).to_bytes()` → one big-endian byte). A non-constant `byteorder` is rejected with a clean error rather than silently defaulting to big-endian
+- **`int.to_bytes(length=1, byteorder='big', *, signed=False)`** — converts an integer to a byte sequence. `length` and `byteorder` may each be passed positionally or by keyword, and both default (CPython 3.11+: `(5).to_bytes()` → one big-endian byte). `byteorder` may also be a variable bound to a constant; only a genuinely non-constant one is rejected, with a clean error rather than a silent default to big-endian
 - **`bytes.hex([sep[, bytes_per_sep]])`** — constant-folds a literal `bytes` object to its hex string. With the optional one-character `sep` (and optional `bytes_per_sep` group size) it reproduces CPython grouping exactly: `bytes([1, 2, 3]).hex("-")` → `"01-02-03"`, `bytes([0xb9, 0x01, 0x9e, 0xf3]).hex("_", 2)` → `"b901_9ef3"` (positive group size counts from the right, negative from the left)
 - **`bytes.fromhex(s)`** — constant-folds a hex string to a `bytes` object (the inverse of `.hex()`); accepts upper/lowercase digits and ASCII whitespace *between* byte pairs, and raises CPython's `ValueError` on odd-length or non-hex input
 - **`bytes.startswith`/`endswith`/`find`/`rfind` over literal operands** — folded directly over the byte-array representation when the receiver (and affix/sub argument) are literal `bytes([...])` constructors, so `bytes([1,2,3]).endswith(bytes([2,3]))` is `True` and `bytes([1,2,3]).find(bytes([2,3]))` is `1`. `find`/`rfind` also accept a single integer byte. Non-literal receivers, `b"..."` literals, and the position-argument forms fall through to the existing dispatch unchanged
@@ -217,7 +217,7 @@ Byte sequences and integer class methods:
 
 - **`try`/`except`** blocks with multiple handlers and `except ExceptionType as var` binding
 - **`try`/`finally`** blocks: the `finally` body runs on normal completion, after a caught exception, when an exception propagates uncaught (run `finally`, then re-raise), and on the `return` / `break` / `continue` edges that escape the `try`, a handler, or the `finally` itself. A returned expression is spilled to a temporary before the `finally` runs, as CPython evaluates it first. Bare `try`/`finally` (no `except`) is supported. Shapes that cannot be lowered soundly are refused with a clean diagnostic (see [Limitations](./limitations#exception-handling))
-- **`raise`** statements with exception instantiation and custom messages; bare `raise` re-raises the active exception inside an `except` handler
+- **`raise`** statements with exception instantiation and custom messages, including an f-string message that interpolates a symbolic value (`raise ValueError(f"bad {x}")`); bare `raise` re-raises the active exception inside an `except` handler
 - **`assert`** statements for property verification
 - **`__ESBMC_assume`** for constraining non-deterministic inputs
 - **`ImportError` guards**: Imports inside `try/except ImportError` are handled statically
@@ -355,10 +355,18 @@ Supported on a tagged variable:
 - **`x is None`**, folded against a literal `None` — a tagged variable never
   holds one.
 - **`==` between two tagged variables**, dispatched on the tag, with the numeric
-  arm fixed-width and the `str` arm under a compile-time bound.
+  arm fixed-width and the `str` arm under a compile-time bound. `bool` and
+  `int` compare equal, so `True == 1` holds as it does in CPython.
+- **`<`, `<=`, `>`, `>=`** against a literal and between two tagged variables,
+  dispatched through a shared three-way result and composed against zero with
+  the operator asked for. Comparing a tagged variable with a string literal
+  reuses the literal's own length as the loop bound, so it stays a compile-time
+  constant. A type mismatch between two tagged operands raises `TypeError`.
 - **`+`, `-`, `*`, `/` against a literal**, numeric, plus string concatenation
-  for `+`; **`-` and `/` between two tagged operands**, raising `TypeError`
-  when either turns out non-numeric.
+  for `+`; **`+`, `-` and `/` between two tagged operands**, raising `TypeError`
+  when either turns out non-numeric. The result of `+` is itself tagged, since
+  whether it added or concatenated is not known until run time — and an
+  untagged target assigned such an addition becomes tagged with it.
 - **Rebinding to a container** — a list, tuple or class instance assigned to a
   tagged variable gets its own slot, as Python rebinds the name outright.
 - **Function return values**: a function whose `return` statements diverge in
@@ -381,6 +389,7 @@ The `--strict-types` flag enables type compatibility validation for function arg
 - **Imports**: Standard `import` and `from ... import ...` styles validated at verification time. Module-level and function-local imports are also processed when verifying a single function with `--function`, so calls through imported modules (including operational models such as `math` and `random`) resolve there too
 - **Multiple files on the command line**: `esbmc a.py b.py` converts each file as its own translation unit of the same program — its own imports, its own global pre-registration, its own `__name__`/`__file__` — and appends each into `python_user_main`, mirroring how the C frontend merges several `.c` files. (Earlier releases kept only the last file, so a violated assertion in `a.py` silently dropped out of verification.)
 - **Relative imports**: `from .module import X` resolves as before. The no-module forms `from . import X` and `from .. import X` are treated as *unresolved* — the importing module still converts and verifies — instead of aborting
+- **Base classes bound by `from ... import`**: a class spelled `class T(Base)` after `from module import Base` resolves its inherited methods and `__init__` against the imported module, as the dotted `module.Base` spelling already did. The last binding of the name wins, and a local binding that shadows the import is respected
 - **Local bindings shadow imported modules**: When a name is both an imported module and a local binding (e.g. a parameter `node` while `from node import Node` is in scope), attribute access such as `node.value` resolves to the local binding, following Python's LEGB rule, rather than to a module member.
 - **Selective imports preserve module-level constants**: `from M import f, C` retains plain `Assign` bindings such as `INT_BOUND = 1024` in addition to `AnnAssign` ones. Tuple-unpacking targets are treated atomically.
 - **Parser package layout**: The Python parser ships as a package under `src/python-frontend/parser/` (entrypoint `parser/__main__.py`, public facade `parser/__init__.py`, import resolution in `parser/import_resolver.py`). The resolver emits deterministic, review-friendly diagnostics for missing modules, cyclic imports, and relative-import rewrites.
@@ -398,10 +407,10 @@ The `--strict-types` flag enables type compatibility validation for function arg
 | `len` | Works on lists, sets, strings, tuples. On a class instance it dispatches to `__len__`, walking the ancestry so an inherited one is found; a class that defines none raises `TypeError` as CPython does, rather than measuring the struct with `strlen` and answering 0 |
 | `range` | Used in `for` loops |
 | `min(a, b)`, `max(a, b)` | Two-argument form only; promotes `int` to `float` |
-| `min([...])`, `max([...])` | Single-list form; supports `int`, `float`, and `str` element types. The `key=` argument is honoured over **constant** lists for the `lambda x: x[K]`, `key=abs`, and `key=len` forms (the winning element is returned; ties break toward the first occurrence); any other `key=` is refused rather than dropped |
+| `min([...])`, `max([...])` | Single-list form; supports `int`, `float`, and `str` element types. `key=` is folded over **constant** lists for the `lambda x: x[K]`, `key=abs`, and `key=len` forms, and otherwise lowered to an explicit linear scan, so a lambda or a named function applies to a list literal of symbolic scalars too (`max([a, a + 1], key=neg)`). Ties keep the first occurrence, as CPython does; an empty iterable raises `IndexError` where CPython raises `ValueError`. A shape the scan cannot lower is refused rather than answered with the key dropped |
 | `sum([...])` | Sum of list elements; supports `int` and `float` |
 | `sum(range(EXPR))` | Single-arg `sum` of a single-arg `range` is rewritten to the Gauss closed form `EXPR * (EXPR - 1) // 2 if EXPR > 0 else 0`, yielding an exact value (and `0` for `EXPR <= 0`) instead of a nondet result |
-| `sorted(iterable)` | Returns a new sorted list; supports `int`, `float`, and `str` elements and homogeneous lists of tuples, whose element types are carried through (as `reversed()` and `list()` also do). `key=` is honoured only where the call constant-folds and is refused otherwise |
+| `sorted(iterable)` | Returns a new sorted list; supports `int`, `float`, and `str` elements and homogeneous lists of tuples, whose element types are carried through (as `reversed()` and `list()` also do). `key=` is applied wherever the iterable's shape is known at conversion time: a list literal of symbolic scalars, a constant list literal, and a constant dict literal ordered by value through `d.__getitem__`; the key itself may be a lambda or an undecorated, never-rebound module-level `def`. A list of *tuples* has only the constant-fold path — the scan declines it, so its elements must be constants. This holds when the call is a `for` loop's iterable (`for edge in sorted(w, key=w.__getitem__):`) as well. A dict with a symbolic value, a bound method other than `__getitem__` such as `d.get`, and any other unfoldable shape are refused with `sorted() with key= is only supported over a constant iterable` rather than silently sorted in natural order |
 | `any([...])` | List literals only; short-circuit OR logic |
 | `all([...])` | List literals only; short-circuit AND logic |
 | `enumerate(iterable, start=0)` | Tuple unpacking and single-variable forms; optional `start` |
@@ -510,6 +519,45 @@ The blocking semantics of `put()`/`get()` (the `block`/`timeout` arguments) are 
 
 A queue held in an instance field (`self.q = queue.Queue()`, then `self.q.get()`) dispatches correctly, as does any other imported class held in a field.
 
+## Unittest Module (`unittest`)
+
+A `unittest.TestCase` subclass is verified rather than merely parsed: each
+assertion method lowers to an ESBMC claim, so a test that can fail is a violated
+property with a counterexample rather than a red test run on one input.
+
+**Assertions**: `assertEqual`, `assertNotEqual`, `assertTrue`, `assertFalse`,
+`assertIs`, `assertIsNot`, `assertIsNone`, `assertIsNotNone`, `assertIn`,
+`assertNotIn`, `assertLess`, `assertLessEqual`, `assertGreater`,
+`assertGreaterEqual`, and `fail()`. A `msg=` argument is accepted and ignored —
+the claim carries the location.
+
+**`unittest.main()`** runs the tests it discovers, following CPython's discovery
+order: test methods in alphabetical order, a fresh instance per test, `setUp`
+before and `tearDown` after each one, and a test method inherited from a base
+class re-run under the subclass's own `setUp`. A method is discovered when its
+name starts with `test`, it takes only `self`, and it carries no decorator —
+`@unittest.skip` and `@unittest.expectedFailure` therefore exclude it, since
+under the real runner neither counts a failure from that method.
+
+```python
+import unittest
+
+
+class T(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.base = 2
+
+    def test_add(self) -> None:
+        self.assertEqual(self.base + 1, 3)
+
+
+unittest.main()
+```
+
+The base class may be spelled either way: `class T(unittest.TestCase)`, or
+`from unittest import TestCase` followed by `class T(TestCase)`.
+
 ## Datetime Module (`datetime`)
 
 - **`datetime.datetime(year, month, day)`**: Constructs a datetime object with fields `year`, `month`, `day`, `hour` (0), `minute` (0), `second` (0), `microsecond` (0)
@@ -569,9 +617,15 @@ Partial executable support for list-backed arrays, element-wise arithmetic, sele
 
 **Views**: a slice or selection with literal bounds assigned to a bare name is a real **view** onto `a`'s own buffer, so writes through either side are observed by the other, and `len(v)`, `v.shape` and `v.ndim` report the view's own extent: 1-D slices with any step (`a[1:3]`, `a[::2]`, `a[::-1]`), 2-D row views (`a[0]`, `a[-1]`) and column views (`a[:, j]`), `np.ravel(a)` / `a.ravel()` / `a.flat[i]` (writable, contiguous), and `np.diagonal(a, offset=k)` / `a.diagonal()` (read-only). `np.trace(a)` and `np.fill_diagonal(a, v)` reuse the same offset arithmetic as a reduction and an in-place write. Rebinding the base array detaches its live views. A slice with a symbolic bound still copies
 
+**Shape/stride descriptors**: a fixed-shape view carries its own shape and strides, so 2-D `np.transpose(a)` / `a.T`, `np.swapaxes` and `np.moveaxis`, a contiguous `np.reshape`, `np.squeeze` / `np.expand_dims` and a read-only `np.broadcast_to` are views over the base buffer rather than copies. A descriptor iterates with `np.nditer`, materialises through `np.copy(v)` / `v.copy()` / `np.array(v)` / `v.tolist()`, and answers the flattened reducers `sum`, `mean`, `min`, `max` plus `v.any()` / `v.all()`. Shapes outside that set — escaping a view into a container, advanced indexing — are rejected explicitly rather than silently copied
+
 **Shape manipulation**: `np.reshape(a, shape)` (2-D and 3-D targets; an incompatible element count is rejected), `np.flatten(a)` / `np.ravel(a)` (row-major 1-D view), `np.squeeze(a)` (drop unit-length axes; a non-unit axis is rejected), `np.stack([a, b, ...])` (join arrays along a new leading axis, e.g. 1-D → 2-D), `np.concatenate([a, b, ...])` (join along the existing axis), and `a.astype(dtype)` (dtype conversion; `astype` to a complex dtype is rejected)
 
 **Reductions**: `np.sum(a)`, `np.prod(a)`, `np.min(a)`, `np.max(a)`, `np.mean(a)`, `np.std(a)`, `np.var(a)`, `np.argmin(a)`, `np.argmax(a)` over list-backed arrays. The reductions, `transpose` and `flatten` accept arrays built by any constructor (`zeros`, `ones`, `full`, `eye`, `identity`, `linspace`, `arange`), not only `np.array(<literal>)`. The method spellings (`a.sum()`, `a.min()`, `a.prod()`, `a.transpose()`, `a.flatten()`, …) are rewritten to the module form in any expression context — e.g. `assert a.min() == 0` — not just on the right-hand side of an assignment
+
+**Arrays returned from user functions**: a function may return a concrete `np.array` / `np.zeros` / `np.ones` / `np.full`, a bare array parameter, a subarray or view, or a supported descriptor call over a parameter (`np.transpose(a)`), and the result keeps its metadata — reducers, `argmin`/`argmax` and the method forms below all work on it. Statements before the `return` and calls in its arguments execute exactly once; an incompatible-type branch, and a view or descriptor that escapes into a container, are rejected explicitly
+
+**`ndarray` methods on a concrete variable**: `a.tolist()`, `a.any()` / `a.all()`, `a.sum()` / `a.mean()` / `a.min()` / `a.max()`, `a.argmin()` / `a.argmax()` (flattened and `axis=0`/`axis=1`), the in-place `a.sort()` and `a.argsort()`, and `np.sort` / `np.argsort` / `np.searchsorted` / `a.searchsorted()` accept an array *variable* — including one returned by a pure user function — not only an inline literal
 
 **Comparison and logical ufuncs**: `np.greater`, `np.greater_equal`, `np.less`, `np.less_equal`, `np.equal`, `np.not_equal`, `np.logical_and`, `np.logical_or`, `np.logical_not`, and `np.where(cond, a, b)` (element-wise select; also the scalar-condition form `np.where(False, 1, 2)`). One of these may be **chained** as another numpy call's argument, nested directly or through an intermediate variable, instead of the inner result being silently substituted
 

--- a/website/content/docs/theory/memory-model.md
+++ b/website/content/docs/theory/memory-model.md
@@ -48,6 +48,16 @@ flagged. This can be tuned:
   permits; the non-`NULL` alternative stays reachable, and the object it yields
   can be freed but not accessed
 
+Every path that sizes an object — `malloc`, `calloc`, `realloc`, `alloca` and a
+variable-length array declaration — is capped at `PTRDIFF_MAX`, as glibc 2.30
+and later do. Above that an object's offset reads negative in the bounds checks,
+in pointer subtraction and in the relational comparator, so one-past-the-end
+would sort below the base. A constant request past the cap is *reported*; a
+symbolic one is bounded by assumption where the path has no failure outcome to
+report, and `realloc` joins the cap to its failure condition so C17 7.22.3.5
+still holds. Two flags opt out: `--force-realloc-success` skips the `realloc`
+cap and `--no-vla-size-check` the VLA bound.
+
 ## Properties checked
 
 From the model above, ESBMC derives the standard spatial and temporal
@@ -68,7 +78,11 @@ non-dynamic storage.
 
 Memory-leak detection is enabled with `--memory-leak-check`: a dynamic object
 that is still reachable-but-unfreed (or unreachable, "forgotten memory") at the
-end of `main` is reported.
+end of `main` is reported. `--no-reachable-memory-leak` keeps only the
+unreachable half, and the reachability walk follows the object's contents as
+well as its type, so an object held only through an allocation that was never
+cast at the site — a `void *` returned by a `safe_malloc`-style wrapper, which
+is modelled as a flat byte array — is not mistaken for forgotten memory.
 
 ## Why formulas are pointer-heavy
 

--- a/website/content/docs/usage.md
+++ b/website/content/docs/usage.md
@@ -294,6 +294,15 @@ esbmc main.c --witness-output main.graphml
     
 We recommend reading [Exchange Format for Violation Witnesses and Correctness Witnesses](https://github.com/sosy-lab/sv-witnesses) to obtain further information about violation and correctness witnesses in graphml format.
 
+A GraphML trace step that comes from a header or from one of ESBMC's operational
+models is emitted with an `originfile` naming the file it came from, and keeps
+that file's own line numbers instead of having them resolved against the
+verified file. `originfile` is not a key the exchange format defines, so a
+conforming validator ignores it; the edges it appears on were unmatchable to a
+validator before, either way. YAML witnesses have no equivalent, so there a
+waypoint is hoisted to its innermost call site inside an input file and one that
+cannot name an input file is dropped, as `README-YAML.md` requires.
+
 ## Unwinding Assertions
 
 In ESBMC, all loops are "unwound", i.e., replaced by several guarded copies of the loop body; the same happens for backward "gotos" and recursive functions. Soundness requires that ESBMC insert a so-called `unwinding assertion` at the end of the loop. As an example, consider the simple C code fragment illustrated below:
@@ -355,6 +364,19 @@ file file.c line 5 function main
 unwinding assertion loop
 ```
 
+`--no-unwinding-assertions` removes that assertion, so paths past the bound are
+assumed away rather than reported. A proof obtained that way holds only up to
+the bound, and a run whose loops were cut short says so above the verdict:
+
+```
+** 0 of 1 properties failed, 1 passed
+WARNING: the unwinding bound cut a loop short while unwinding checks were
+disabled, so paths past the bound were assumed away rather than verified; this
+result holds only up to that bound
+
+VERIFICATION SUCCESSFUL
+```
+
 ## Verification Strategies
 
 ESBMC offers several incremental strategies that control how loops are unwound
@@ -370,6 +392,17 @@ algorithm works, see
 
 `--max-k-step N` caps the unwind bound (default 50); `--k-step N` changes the
 increment granularity.
+
+## Reusing common subexpressions
+
+`--gcse` precomputes a subexpression shared between assignments into an
+intermediate variable, so symbolic execution builds it once rather than at every
+use. Whether a rewrite is safe depends on what the program's pointers can
+address, which comes from an inclusion-based (Andersen) whole-program points-to
+analysis over the GOTO program. The analysis is deliberately imprecise —
+symbolic execution supplies the real precision — and abstains on any expression
+whose targets it cannot determine, in which case the rewrite is not made. The
+flag is off by default.
 
 ## Selecting the floating-point rounding mode
 
@@ -735,6 +768,25 @@ It hides genuine API misuse the models report, so it is off by default. It also
 leaves the checks ESBMC *generates* inside model code (those are controlled by
 `--no-standard-checks`), renumbers `--claim` indices, and is unsupported for
 Python.
+
+## When ESBMC itself crashes
+
+A SIGSEGV or SIGBUS inside ESBMC is an internal error, not a verification
+result, and is reported as one rather than leaving the exit status as its only
+trace:
+
+```
+ESBMC caught SIGSEGV: this is an internal error, not a verification result.
+Re-run with --segfault-handler for a backtrace.
+Please report it at https://github.com/esbmc/esbmc/issues
+```
+
+The report needs no flag and runs on an alternate signal stack, so a crash from
+stack exhaustion is reported too. A handler installed by someone else is left
+alone, so an AddressSanitizer build keeps its own richer report.
+`--segfault-handler` *replaces* this reporter with one that prints a backtrace
+and the process memory map, and covers `SIGABRT` as well — asking for the
+backtrace is explicit intent, so that one does not defer to a foreign handler.
 
 ## Supported SMT backends {#smt-backends}
 

--- a/website/content/news/development-update-early-september-2026.md
+++ b/website/content/news/development-update-early-september-2026.md
@@ -1,0 +1,252 @@
+---
+title: "Development Update: Early September 2026"
+date: 2026-09-04T09:00:00+01:00
+draft: false
+tags:
+  - ESBMC
+  - FormalVerification
+  - ModelChecking
+  - OpenSource
+---
+
+Following the [end-of-August update](/news/development-update-end-of-august-2026),
+about 120 pull requests landed on `master` between 26 August and 4 September.
+ESBMC is now at **v8.5** ([#7379](https://github.com/esbmc/esbmc/pull/7379)).
+Here are the changes a user will notice.
+
+**A Linux ARM64 release asset.**
+[#7229](https://github.com/esbmc/esbmc/pull/7229) adds `esbmc-linux-armv8.zip`
+as a fourth canonical release asset, built statically against LLVM 22, so it
+runs on any aarch64 Linux userspace. An armv8 leg now runs per PR as well. Four
+features are unavailable on that build — `--32`, Solidity, CVC5 and
+`--goto-contractor` — and interval analysis differs from x86_64; the
+[Setup](/docs/setup#arm64-builds) page lists each with its tracking issue.
+
+**`--loop-invariant-check` stops reporting proofs it never made.**
+The mode replaced a loop with `havoc; assume(I)` and then dropped every claim
+after the loop, so programs with real bugs verified. A sweep of the guard and
+loop shapes found three causes, each fixed
+([#7482](https://github.com/esbmc/esbmc/pull/7482)): the havoc landed after a
+guard's own side effects, a `do`-`while` back edge was cut with `assume(false)`,
+and a loop whose only writes go through a pointer left the modified-variable
+analysis with nothing to havoc. Six loop shapes that reported `VERIFICATION
+SUCCESSFUL` on a false post-loop assertion now reach a verdict instead — three
+more came out of review — and a loop the schema cannot havoc soundly is left to
+the unwinder rather than proved. Which verdict depends on the next change.
+
+**A weak invariant is `UNKNOWN`, not `FAILED`.**
+Every claim downstream of that havoc is checked against an over-approximation,
+so a correct but weak invariant produced a counterexample that no execution can
+reach. Such a claim is now reported as unknown, with the reason attached
+([#7491](https://github.com/esbmc/esbmc/pull/7491)):
+
+```
+  PASSED   [main.assertion.1]  line 11  loop invariant base case
+  PASSED   [main.assertion.2]  line 11  loop invariant inductive step
+  UNKNOWN  [main.assertion.3]  line 16  assertion s == 3 (loop invariant too
+           weak to prove this claim: the counterexample is against the havoc
+           abstraction, not a reachable state of the program)
+
+** 0 of 3 properties failed, 2 passed, 1 unknown
+VERIFICATION UNKNOWN
+```
+
+`FAILED` is kept for a claim ahead of every havoc, for the invariant's own
+inductive step and assigns-compliance check, for a declined loop, and for an
+outermost loop's base case — an inner loop's base case sits downstream of the
+outer havoc and is downgraded with the rest. The consequence is worth stating:
+this mode can no longer report a bug after an annotated loop; plain BMC and
+`--k-induction` remain the modes that refute.
+
+**Andersen points-to replaces the GOTO-level value-set analysis.**
+[#6623](https://github.com/esbmc/esbmc/pull/6623) moves GCSE and k-induction's
+pointer-array-write resolver onto an inclusion-based whole-program points-to
+analysis that abstains per query instead of disabling itself wholesale. Making
+those consumers actually run surfaced four latent bugs, the worst of which was
+not GCSE-specific: a pass that inserts instructions handed loop analysis stale
+location numbers, so a forward branch could be misread as a back edge and
+rewritten to `assume(!guard)`. Under `--gcse` that silently turned failing
+programs into proofs; on ReachSafety-ECA it accounted for 48 wrong answers,
+now zero.
+
+**Two more soundness fixes.** The LD front end collected networks only from
+ladder bodies, so a POU written in `ST`, `FBD`, `SFC` or `IL` left the scan cycle
+empty and every property held vacuously; such a body is now rejected
+([#7365](https://github.com/esbmc/esbmc/pull/7365)). And `__int128` escaped the
+usual arithmetic conversions on the default clang-c path, while its rank sat
+above pointers and every floating type, so `pointer + __int128` and
+`float + __int128` flattened the wrong operand
+([#7343](https://github.com/esbmc/esbmc/pull/7343)).
+
+**Loops that never terminated under default flags now decide.**
+A census of trip-count spellings found clusters where the bound never folded, so
+the loop unwound forever: a bound spelled `&a[4]` rather than `a + 4`
+([#7346](https://github.com/esbmc/esbmc/pull/7346),
+[#7391](https://github.com/esbmc/esbmc/pull/7391),
+[#7394](https://github.com/esbmc/esbmc/pull/7394)), a descending pointer walk
+where the ascending twin folded ([#7395](https://github.com/esbmc/esbmc/pull/7395)),
+`(char *)&a[4] - (char *)&a[0]` and `&p.b - &p.a`
+([#7392](https://github.com/esbmc/esbmc/pull/7392)), a bound from `offsetof`
+([#7393](https://github.com/esbmc/esbmc/pull/7393)), `sizeof(a) / sizeof(a[0])`
+under `--no-simplify` ([#7400](https://github.com/esbmc/esbmc/pull/7400)), a null
+guard on the address of an object ([#7441](https://github.com/esbmc/esbmc/pull/7441)),
+a struct written through a nested member
+([#7463](https://github.com/esbmc/esbmc/pull/7463)), a constant element of a
+multi-dimensional array ([#7341](https://github.com/esbmc/esbmc/pull/7341)), and a
+union carrying a nondeterministic symbol or read across same-width members
+([#7446](https://github.com/esbmc/esbmc/pull/7446),
+[#7447](https://github.com/esbmc/esbmc/pull/7447)). A callee that re-checks a
+condition the caller's path already decided no longer forks both sides
+([#7450](https://github.com/esbmc/esbmc/pull/7450)), and an index a struct field
+carries stays on the constant-offset path instead of degenerating to a
+whole-object `byte_extract` — 242 s of symex on the issue's reproducer becomes
+0.001 s ([#7317](https://github.com/esbmc/esbmc/pull/7317)).
+
+**Operational-model cost that no longer grows with `--unwind`.**
+A screening test — hold the program constant and raise the bound — found six
+models paying for paths that cannot execute. `len()` now folds
+([#7440](https://github.com/esbmc/esbmc/pull/7440)), `list.extend()` and list
+slicing copy at the frontend's constant element width
+([#7435](https://github.com/esbmc/esbmc/pull/7435),
+[#7436](https://github.com/esbmc/esbmc/pull/7436)), `list.remove()` splits its
+search from its shift ([#7361](https://github.com/esbmc/esbmc/pull/7361)),
+`list.sort()` dispatches on the type flag rather than a field read
+([#7432](https://github.com/esbmc/esbmc/pull/7432)), `std::vector::reserve()`
+reallocates in place so `size()` and `capacity()` stay decidable
+([#7437](https://github.com/esbmc/esbmc/pull/7437)), and a `memcpy` whose length
+is not constant is bounded by the operands' own widths instead of falling into a
+byte loop ([#7438](https://github.com/esbmc/esbmc/pull/7438)). `str.replace()`,
+`find`, `rfind`, `index` and `rindex` constant-fold on constant operands, which
+also removed a spurious `VERIFICATION FAILED`
+([#7373](https://github.com/esbmc/esbmc/pull/7373),
+[#7374](https://github.com/esbmc/esbmc/pull/7374),
+[#7375](https://github.com/esbmc/esbmc/pull/7375)).
+
+**Python: `key=`, dynamic typing and `unittest`.**
+`min()` and `max()` with a `key=` the preprocessor cannot fold now lower to an
+explicit scan, so the key is really applied over a list with symbolic elements
+([#7314](https://github.com/esbmc/esbmc/pull/7314)); `sorted()` folds a key
+spelled as a module-level function or `d.__getitem__`
+([#7348](https://github.com/esbmc/esbmc/pull/7348)) and is lowered when it is a
+`for` loop's iterable ([#7322](https://github.com/esbmc/esbmc/pull/7322),
+[#7368](https://github.com/esbmc/esbmc/pull/7368)); shapes neither route can
+lower keep the refusal rather than dropping the key
+([#7358](https://github.com/esbmc/esbmc/pull/7358)). Dynamic typing gained
+addition between two tagged scalars
+([#7329](https://github.com/esbmc/esbmc/pull/7329)) and ordered comparisons
+against a literal and between two tagged operands, with `True == 1` now holding
+([#7364](https://github.com/esbmc/esbmc/pull/7364),
+[#7513](https://github.com/esbmc/esbmc/pull/7513)). `unittest.main()` runs the
+tests it discovers, in CPython's order, instead of being a no-op that reached
+verification with zero claims ([#7390](https://github.com/esbmc/esbmc/pull/7390)),
+and a base class bound by `from module import Base` resolves its inherited
+methods ([#7396](https://github.com/esbmc/esbmc/pull/7396)). Also: a lambda
+parameter is typed from its call site
+([#7385](https://github.com/esbmc/esbmc/pull/7385)), a function name in a list
+literal decays to a pointer rather than dumping core
+([#7387](https://github.com/esbmc/esbmc/pull/7387)), a string method's result is
+no longer sized by the call's first argument
+([#7382](https://github.com/esbmc/esbmc/pull/7382)), a nested-list subscript stays
+an lvalue ([#7367](https://github.com/esbmc/esbmc/pull/7367)), and a tuple element
+type crosses the call boundary
+([#7370](https://github.com/esbmc/esbmc/pull/7370)). A new consensus suite runs
+ESBMC over the Ethereum specification functions `ethcheck` checks
+([#7444](https://github.com/esbmc/esbmc/pull/7444)); it immediately caught two
+crashes ([#7471](https://github.com/esbmc/esbmc/pull/7471)).
+
+**NumPy: descriptors and returned arrays.**
+A fixed-shape view now carries its own shape and strides, so 2-D transpose,
+`swapaxes`/`moveaxis`, contiguous reshape, squeeze/expand_dims and a read-only
+`broadcast_to` alias the base buffer, iterate with `np.nditer`, and materialise
+through `np.copy` or `tolist()` ([#7323](https://github.com/esbmc/esbmc/pull/7323)). A user function
+may return an array — a constructor result, a parameter, a view, or a descriptor
+call over a parameter — and the remaining `ndarray` methods (`tolist`, `any`,
+`all`, the reductions, `argmin`/`argmax`, `sort`, `argsort`, `searchsorted`)
+accept a concrete variable rather than only an inline literal
+([#7386](https://github.com/esbmc/esbmc/pull/7386)).
+
+**C++ operational models.**
+`std::unordered_multimap` ([#7334](https://github.com/esbmc/esbmc/pull/7334)),
+`std::filesystem::directory_iterator` with the `[fs.path.decompose]` members
+([#7350](https://github.com/esbmc/esbmc/pull/7350)), the container-level
+relational operators for `list`, `set`, `multiset`, `map` and `multimap`
+([#7340](https://github.com/esbmc/esbmc/pull/7340)), the `Allocator` template
+parameter on `list` and `deque`
+([#7492](https://github.com/esbmc/esbmc/pull/7492)), `deque::back()` returning a
+reference ([#7330](https://github.com/esbmc/esbmc/pull/7330)), the missing
+`[meta.trans]` aliases and `remove_all_extents`
+([#7337](https://github.com/esbmc/esbmc/pull/7337)), and the remaining C99 math
+functions in namespace `std` ([#7339](https://github.com/esbmc/esbmc/pull/7339)).
+`list`'s iterator moved to namespace scope so argument-dependent lookup reaches
+the element type, as libc++ spells it
+([#7342](https://github.com/esbmc/esbmc/pull/7342)).
+
+**Contracts.**
+`__ESBMC_old(ptr[j])` under a quantifier works on a bare `int r[N]` parameter
+when the extent comes from the pointer's own `__ESBMC_is_fresh` clause, which is
+what an element-wise array postcondition needs
+([#7255](https://github.com/esbmc/esbmc/pull/7255)). An index in an `assigns`
+target is read in the pre-state, so the ring-buffer idiom complies and the
+off-by-one write is caught — both verdicts were inverted before
+([#7206](https://github.com/esbmc/esbmc/pull/7206)). A replace-side
+`__ESBMC_is_fresh` is decided by which object the argument names rather than how
+the call site spells it, and the extent check is no longer skipped for stack
+storage ([#7465](https://github.com/esbmc/esbmc/pull/7465)).
+
+**Diagnostics.**
+A run that proved a property with `--no-unwinding-assertions` after cutting a
+loop short now says the result holds only up to the bound
+([#7338](https://github.com/esbmc/esbmc/pull/7338)). A SIGSEGV or SIGBUS inside
+ESBMC is reported as an internal error without needing `--segfault-handler`,
+which still selects the fuller backtrace and memory map in its place
+([#7404](https://github.com/esbmc/esbmc/pull/7404)). A witness step from a header
+or an operational model carries an `originfile` instead of placing model line
+numbers on the user's source ([#7457](https://github.com/esbmc/esbmc/pull/7457)),
+uncaught-exception properties are anchored on the raise site rather than printed
+at line 0 ([#7445](https://github.com/esbmc/esbmc/pull/7445)), and each log line
+is written in one call, so a `--k-induction-parallel` child can no longer splice
+itself into the middle of a verdict
+([#7384](https://github.com/esbmc/esbmc/pull/7384)).
+
+**Memory model.**
+Every allocation path is capped at `PTRDIFF_MAX`, as glibc does, since above it
+an object's offset reads negative in the bounds checks and the pointer
+comparator ([#7306](https://github.com/esbmc/esbmc/pull/7306)). The
+reachable-leak walk follows an object's contents as well as its type, so an
+allocation that was never cast at the site no longer reads as forgotten memory
+([#7506](https://github.com/esbmc/esbmc/pull/7506)). Two false alarms went with
+them: a pointer written through one union arm is now found when read through
+another ([#7369](https://github.com/esbmc/esbmc/pull/7369)), and a `memcpy` into
+a one-pointer struct keeps the pointer instead of dropping it to invalid
+([#7380](https://github.com/esbmc/esbmc/pull/7380)).
+
+**CBMC goto binaries.**
+`__CPROVER_OBJECT_SIZE` no longer crashes ESBMC during SMT encoding, and both it
+and `__builtin_object_size` size the object addressed rather than `sizeof(*p)` —
+a scalar reached through a `void *` or the `signed char *` CPROVER's write-set
+checks cast to used to report 0 or 1
+([#7410](https://github.com/esbmc/esbmc/pull/7410),
+[#7417](https://github.com/esbmc/esbmc/pull/7417)). A `__CPROVER_is_fresh`
+precondition allocates the object it promises rather than leaving the parameter
+unconstrained ([#7405](https://github.com/esbmc/esbmc/pull/7405)), and
+`__CPROVER_rounding_mode` and `fesetround` are connected to the model that reads
+them ([#7428](https://github.com/esbmc/esbmc/pull/7428),
+[#7456](https://github.com/esbmc/esbmc/pull/7456)).
+
+**Solver.**
+Bitvector `%` is encoded as `a - (a / b) * b`, its SMT-LIB defining identity, so
+a formula containing both `/` and `%` shares one division circuit and proving a
+`%` implementation against the C99 6.5.5 identity collapses from a timeout to
+0.001 s ([#7449](https://github.com/esbmc/esbmc/pull/7449)). Under `--ir-ieee` a
+float symbol is constrained to a representable magnitude, which had let a
+counterexample report `r = 0.000000` while denying `r == 0`
+([#7336](https://github.com/esbmc/esbmc/pull/7336)). Separately, the
+simplifier's equivalence checker now proves every per-node rewrite rather than
+only the outermost one, which turned up two unsound folds
+([#7327](https://github.com/esbmc/esbmc/pull/7327),
+[#7351](https://github.com/esbmc/esbmc/pull/7351)).
+
+The website documentation has been updated to match. As always, the full list is
+in the [commit history](https://github.com/esbmc/esbmc/commits/master/) — and if
+you hit a bug or a missing feature, we would love an
+[issue report](https://github.com/esbmc/esbmc/issues).


### PR DESCRIPTION
Adds an early-September news post covering the ~120 pull requests merged between
#7327 and #7513, and updates the pages they affect: the `--loop-invariant-check`
verdict changes, `--gcse` on Andersen points-to, the `PTRDIFF_MAX` allocation cap
and object-size semantics, the C++ operational models, and Python's `key=`,
`unittest` and NumPy support.

Follow-up to #7347.
