### PR TITLE
[om] Return a reference from vector::back and string front/back

### DIFF
--- a/regression/esbmc-cpp/string/string_front_back_reference/main.cpp
+++ b/regression/esbmc-cpp/string/string_front_back_reference/main.cpp
@@ -1,0 +1,23 @@
+// [string.access] pairs charT& front() with const charT& front() const, and
+// likewise for back(); only the const by-value forms existed (#7537).
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s = "abc";
+
+  s.front() = 'y';
+  s.back() = 'z';
+  assert(s[0] == 'y');
+  assert(s[2] == 'z');
+
+  char &r = s.back();
+  r = 'w';
+  assert(s[2] == 'w');
+
+  const std::string &c = s;
+  assert(c.front() == 'y');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/string/string_front_back_reference/test.desc
+++ b/regression/esbmc-cpp/string/string_front_back_reference/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/string/string_front_back_reference_fail/main.cpp
+++ b/regression/esbmc-cpp/string/string_front_back_reference_fail/main.cpp
@@ -1,0 +1,23 @@
+// [string.access] pairs charT& front() with const charT& front() const, and
+// likewise for back(); only the const by-value forms existed (#7537).
+#include <cassert>
+#include <string>
+
+int main()
+{
+  std::string s = "abc";
+
+  s.front() = 'y';
+  s.back() = 'z';
+  assert(s[0] == 'y');
+  assert(s[2] == 'q');
+
+  char &r = s.back();
+  r = 'w';
+  assert(s[2] == 'w');
+
+  const std::string &c = s;
+  assert(c.front() == 'y');
+
+  return 0;
+}

--- a/regression/esbmc-cpp/string/string_front_back_reference_fail/test.desc
+++ b/regression/esbmc-cpp/string/string_front_back_reference_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++11 --incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/vector/vector_back_reference/main.cpp
+++ b/regression/esbmc-cpp/vector/vector_back_reference/main.cpp
@@ -1,0 +1,25 @@
+// [sequence.reqmts] gives non-const back() the return type reference, so the
+// last element is writable in place (#7537).
+#include <cassert>
+#include <vector>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(1);
+  v.push_back(2);
+  v.push_back(3);
+
+  v.back() = 42;
+  assert(v.back() == 42);
+  assert(v[2] == 42);
+
+  int &r = v.back();
+  r = 7;
+  assert(v[2] == 7);
+
+  v.front() = 5;
+  assert(v[0] == 5);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/vector_back_reference/test.desc
+++ b/regression/esbmc-cpp/vector/vector_back_reference/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++11 --incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/vector/vector_back_reference_fail/main.cpp
+++ b/regression/esbmc-cpp/vector/vector_back_reference_fail/main.cpp
@@ -1,0 +1,25 @@
+// [sequence.reqmts] gives non-const back() the return type reference, so the
+// last element is writable in place (#7537).
+#include <cassert>
+#include <vector>
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(1);
+  v.push_back(2);
+  v.push_back(3);
+
+  v.back() = 42;
+  assert(v.back() == 42);
+  assert(v[2] == 43);
+
+  int &r = v.back();
+  r = 7;
+  assert(v[2] == 7);
+
+  v.front() = 5;
+  assert(v[0] == 5);
+
+  return 0;
+}

--- a/regression/esbmc-cpp/vector/vector_back_reference_fail/test.desc
+++ b/regression/esbmc-cpp/vector/vector_back_reference_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++11 --incremental-bmc
+^VERIFICATION FAILED$

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -499,8 +499,10 @@ public:
   void push_back(char c);
   void reserve(size_t n = 0);
   char at(size_t pos) const;
-  char front() const;
-  char back() const;
+  char &front();
+  const char &front() const;
+  char &back();
+  const char &back() const;
   bool empty() const;
   void clear();
   size_t length() const;
@@ -1538,7 +1540,7 @@ char basic_string<CharT, Traits, Alloc>::at(size_t pos) const
 }
 
 template <typename CharT, typename Traits, typename Alloc>
-char basic_string<CharT, Traits, Alloc>::front() const
+char &basic_string<CharT, Traits, Alloc>::front()
 {
   __ESBMC_assert(
     this->length() > 0, "basic_string::front() failed: basic_string is empty");
@@ -1547,7 +1549,25 @@ char basic_string<CharT, Traits, Alloc>::front() const
 }
 
 template <typename CharT, typename Traits, typename Alloc>
-char basic_string<CharT, Traits, Alloc>::back() const
+const char &basic_string<CharT, Traits, Alloc>::front() const
+{
+  __ESBMC_assert(
+    this->length() > 0, "basic_string::front() failed: basic_string is empty");
+
+  return this->str[0];
+}
+
+template <typename CharT, typename Traits, typename Alloc>
+char &basic_string<CharT, Traits, Alloc>::back()
+{
+  __ESBMC_assert(
+    this->length() > 0, "basic_string::back() failed: basic_string is empty");
+
+  return this->str[this->length() - 1];
+}
+
+template <typename CharT, typename Traits, typename Alloc>
+const char &basic_string<CharT, Traits, Alloc>::back() const
 {
   __ESBMC_assert(
     this->length() > 0, "basic_string::back() failed: basic_string is empty");

--- a/src/cpp/library/vector
+++ b/src/cpp/library/vector
@@ -768,7 +768,7 @@ public:
     return buf[0];
   }
 
-  value_type back()
+  reference back()
   {
     return buf[_size - 1];
   }


### PR DESCRIPTION
`vector::back()` returned `value_type` where [sequence.reqmts] requires
`reference`, and `basic_string` had only the const by-value `front()`/`back()`
where [string.access] pairs `charT&` with `const charT&`. Writing through any of
them was a false `PARSING ERROR` on code clang++/libstdc++ accepts.

Both fixes mirror shapes already in the same files: `vector::front()` for the
first, `basic_string::operator[]`'s const/non-const pair for the second.

Fixes #7537
