### PR TITLE
[python] Promote a bool operand of a unary operator to int

### DIFF
--- a/regression/python/github_7551_unary_on_bool/main.py
+++ b/regression/python/github_7551_unary_on_bool/main.py
@@ -1,0 +1,20 @@
+# bool is a subclass of int, so -True is -1 and ~True is -2. CPython 3.12 warns
+# that ~ on a bool is deprecated for removal in 3.16; the arithmetic it performs
+# is still the underlying int's (#7551).
+def main() -> None:
+    assert -True == -1
+    assert -False == 0
+    assert ~True == -2
+    assert ~False == -1
+
+    x: bool = True
+    assert -x == -1
+
+    b: bool = False
+    assert ~b == -1
+
+    assert -(1 == 1) == -1
+    assert +True == 1
+
+
+main()

--- a/regression/python/github_7551_unary_on_bool/test.desc
+++ b/regression/python/github_7551_unary_on_bool/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7551_unary_on_bool_fail/main.py
+++ b/regression/python/github_7551_unary_on_bool_fail/main.py
@@ -1,0 +1,20 @@
+# bool is a subclass of int, so -True is -1 and ~True is -2. CPython 3.12 warns
+# that ~ on a bool is deprecated for removal in 3.16; the arithmetic it performs
+# is still the underlying int's (#7551).
+def main() -> None:
+    assert -True == 1
+    assert -False == 0
+    assert ~True == -2
+    assert ~False == -1
+
+    x: bool = True
+    assert -x == -1
+
+    b: bool = False
+    assert ~b == -1
+
+    assert -(1 == 1) == -1
+    assert +True == 1
+
+
+main()

--- a/regression/python/github_7551_unary_on_bool_fail/test.desc
+++ b/regression/python/github_7551_unary_on_bool_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_unop.cpp
+++ b/src/python-frontend/converter/converter_unop.cpp
@@ -206,6 +206,17 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
   unary_sub =
     apply_bool_dunder_for_not(op, unary_sub, get_location_from_decl(element));
 
+  /* Python's bool is a subclass of int, so every unary operator but `not`
+   * yields an int: -True is -1 and ~True is -2. Without the promotion the node
+   * is built over a bool-sorted operand and the SMT backend crashes (#7551).
+   * Matches the binary bitwise path in converter_binop.cpp. */
+  if (op != "Not" && unary_sub.type().is_bool())
+  {
+    const typet int_t = type_handler::python_int_typet();
+    unary_sub = typecast_exprt(unary_sub, int_t);
+    type = int_t;
+  }
+
   const typet result_type = (op == "Not") ? bool_type() : type;
   const std::string op_id = python_frontend::map_operator(op, result_type);
 


### PR DESCRIPTION
`-x` and `~x` where `x` is a `bool` built the arithmetic node over a bool-sorted
operand, and the solver crashed on it — Bitwuzla with an `mk_term` sort error,
Z3 with SIGSEGV, both dumping core.

Python's `bool` is a subclass of `int`, so `-True` is `-1` and `~True` is `-2`.
Promote the operand exactly as the binary bitwise path already does, targeting
the frontend's own `python_int_typet()` so the result matches an ordinary
Python `int` under both the default and `--ir` encodings.

Fixes #7551
