### PR TITLE
[python] Accept PEP 515 underscores in int() and float()

### DIFF
--- a/regression/python/github_7558_pep515_underscores/main.py
+++ b/regression/python/github_7558_pep515_underscores/main.py
@@ -1,0 +1,24 @@
+# PEP 515: the int()/float() constructors accept a single underscore between
+# digits, and after a base specifier; never leading, trailing or doubled.
+def main() -> None:
+    assert int("1_00") == 100
+    assert int("0_100") == 100
+    assert int("1_0_0") == 100
+    assert int("1_00", 3) == 9
+    assert int("0x_1f", 16) == 31
+    assert float("1_0.5") == 10.5
+    assert float("1_0e1_0") == 100000000000.0
+
+    # The same strings held in a variable fold through a separate path.
+    i = "1_00"
+    assert int(i) == 100
+    f = "1_0.5"
+    assert float(f) == 10.5
+
+    # Unchanged forms.
+    assert int("100") == 100
+    assert int("  100  ") == 100
+    assert int("+100") == 100
+
+
+main()

--- a/regression/python/github_7558_pep515_underscores/test.desc
+++ b/regression/python/github_7558_pep515_underscores/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7558_pep515_underscores_fail/main.py
+++ b/regression/python/github_7558_pep515_underscores_fail/main.py
@@ -1,0 +1,7 @@
+# A trailing underscore is not a separator, so int() must still raise.
+def main() -> None:
+    x = int("100_")
+    assert x == 100
+
+
+main()

--- a/regression/python/github_7558_pep515_underscores_fail/test.desc
+++ b/regression/python/github_7558_pep515_underscores_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/string.c
+++ b/src/c2goto/library/python/string.c
@@ -1105,6 +1105,20 @@ __ESBMC_HIDE:;
 // in the frontend (type_handler::get_typet("int")), so a 32-bit return here
 // makes the result symbol 32-bit and truncates a string pointer that is later
 // rebound through it (e.g. `a, b = s.split('-'); a = int(a)`). See issue #5159.
+/// Value of @p c as an alphanumeric digit (0-9, a-z, A-Z), or -1 when it is
+/// not one. The caller applies the base bound.
+static int __python_digit_value(unsigned char c)
+{
+__ESBMC_HIDE:;
+  if (c >= '0' && c <= '9')
+    return c - '0';
+  if (c >= 'a' && c <= 'z')
+    return c - 'a' + 10;
+  if (c >= 'A' && c <= 'Z')
+    return c - 'A' + 10;
+  return -1;
+}
+
 long long __python_int(const char *s, int base)
 {
 __ESBMC_HIDE:;
@@ -1137,6 +1151,8 @@ __ESBMC_HIDE:;
   {
     s++;
   }
+
+  const char *number_begin = s;
 
   if (base == 0)
   {
@@ -1186,34 +1202,41 @@ __ESBMC_HIDE:;
     return 0;
   }
 
+  const _Bool prefix_consumed = (s != number_begin);
+
   long long result = 0;
   _Bool found_digit = 0;
 
   while (*s)
   {
-    int digit_value = -1;
     unsigned char c = (unsigned char)*s;
 
-    if (c >= '0' && c <= '9')
+    /* PEP 515: in the int() constructor a single underscore may separate
+     * digits and may follow a base specifier, but may not lead, trail, or
+     * double. */
+    if (c == '_')
     {
-      digit_value = c - '0';
-    }
-    else if (c >= 'a' && c <= 'z')
-    {
-      digit_value = c - 'a' + 10;
-    }
-    else if (c >= 'A' && c <= 'Z')
-    {
-      digit_value = c - 'A' + 10;
-    }
-    else if (
-      c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r')
-    {
+      const int next = __python_digit_value((unsigned char)*(s + 1));
+      if ((!found_digit && !prefix_consumed) || next < 0 || next >= base)
+      {
+        __ESBMC_assert(0, "invalid literal for int() - invalid character");
+        return 0;
+      }
       s++;
       continue;
     }
-    else
+
+    int digit_value = __python_digit_value(c);
+
+    if (digit_value < 0)
     {
+      if (
+        c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' ||
+        c == '\r')
+      {
+        s++;
+        continue;
+      }
       __ESBMC_assert(0, "invalid literal for int() - invalid character");
       return 0;
     }
@@ -1260,6 +1283,37 @@ __ESBMC_HIDE:;
   return sign * result;
 }
 
+/// Scan a run of decimal digits starting at s[*i], folding them into *value and
+/// advancing *i past the run. PEP 515 allows a single underscore between two
+/// digits of the run; a leading, trailing or doubled one is rejected. Returns
+/// the digit count, or -1 on a misplaced underscore.
+static int
+__python_scan_digit_run(const char *s, size_t len, size_t *i, double *value)
+{
+__ESBMC_HIDE:;
+  int digits = 0;
+
+  while (*i < len)
+  {
+    if (s[*i] == '_')
+    {
+      if (digits == 0 || *i + 1 >= len || s[*i + 1] < '0' || s[*i + 1] > '9')
+        return -1;
+      (*i)++;
+      continue;
+    }
+
+    if (s[*i] < '0' || s[*i] > '9')
+      break;
+
+    *value = *value * 10.0 + (double)(s[*i] - '0');
+    digits++;
+    (*i)++;
+  }
+
+  return digits;
+}
+
 // Shared core for float(str): validates `s` as a Python float literal and, when
 // valid, writes the parsed value to *out. Returns 1 on success, 0 otherwise.
 // The accepted grammar is a subset of CPython's float(): optional surrounding
@@ -1297,28 +1351,23 @@ __ESBMC_HIDE:;
   // accumulating with a repeatedly-scaled 0.1 weight compounds rounding error.
   double value = 0.0;
   double divisor = 1.0;
-  _Bool any_digit = 0;
 
-  while (i < len && s[i] >= '0' && s[i] <= '9')
-  {
-    value = value * 10.0 + (double)(s[i] - '0');
-    any_digit = 1;
-    i++;
-  }
+  const int int_digits = __python_scan_digit_run(s, len, &i, &value);
+  if (int_digits < 0)
+    return 0;
 
+  int frac_digits = 0;
   if (i < len && s[i] == '.')
   {
     i++;
-    while (i < len && s[i] >= '0' && s[i] <= '9')
-    {
-      value = value * 10.0 + (double)(s[i] - '0');
+    frac_digits = __python_scan_digit_run(s, len, &i, &value);
+    if (frac_digits < 0)
+      return 0;
+    for (int k = 0; k < frac_digits; k++)
       divisor *= 10.0;
-      any_digit = 1;
-      i++;
-    }
   }
 
-  if (!any_digit)
+  if (int_digits == 0 && frac_digits == 0)
     return 0;
 
   while (i < len && (s[i] == ' ' || s[i] == '\t' || s[i] == '\n' ||

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -901,9 +901,13 @@ exprt function_call_expr::build_constant_from_arg() const
       // Try to parse as regular float
       {
         const std::string raw_val = arg["value"].get<std::string>();
+        // strtod does not know PEP 515, so drop the separators first (#7558).
+        std::string digits;
+        const bool separators_ok =
+          type_utils::strip_pep515_underscores(raw_val, digits);
         char *end = nullptr;
-        double dval = std::strtod(raw_val.c_str(), &end);
-        if (!end || end != raw_val.c_str() + raw_val.size())
+        double dval = separators_ok ? std::strtod(digits.c_str(), &end) : 0.0;
+        if (!separators_ok || !end || end != digits.c_str() + digits.size())
         {
           std::string m =
             "could not convert string to float : '" + raw_val + "'";

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -1252,9 +1252,12 @@ exprt function_call_expr::handle_str_symbol_to_float(const symbolt *sym) const
     return from_double(0.0, type_handler_.get_typet("float", 0));
 
   {
+    std::string digits;
+    const bool separators_ok =
+      type_utils::strip_pep515_underscores(*value_opt, digits);
     char *end = nullptr;
-    double dval = std::strtod(value_opt->c_str(), &end);
-    if (!end || end != value_opt->c_str() + value_opt->size())
+    double dval = separators_ok ? std::strtod(digits.c_str(), &end) : 0.0;
+    if (!separators_ok || !end || end != digits.c_str() + digits.size())
     {
       log_error(
         "Failed float conversion from string \"{}\": invalid argument",
@@ -1272,7 +1275,10 @@ exprt function_call_expr::handle_str_symbol_to_int(const symbolt *sym) const
     return from_integer(0, type_handler_.get_typet("int", 0));
 
   const std::string &value = *value_opt;
-  if (value.empty() || !std::all_of(value.begin(), value.end(), ::isdigit))
+  std::string digits;
+  if (
+    !type_utils::strip_pep515_underscores(value, digits) || digits.empty() ||
+    !std::all_of(digits.begin(), digits.end(), ::isdigit))
   {
     log_error("Invalid string for integer conversion: \"{}\"", value);
     return from_integer(0, type_handler_.get_typet("int", 0));
@@ -1280,7 +1286,7 @@ exprt function_call_expr::handle_str_symbol_to_int(const symbolt *sym) const
 
   try
   {
-    int int_val = std::stoi(value);
+    int int_val = std::stoi(digits);
     return from_integer(int_val, type_handler_.get_typet("int", 0));
   }
   catch (const std::exception &e)

--- a/src/python-frontend/type/type_utils.h
+++ b/src/python-frontend/type/type_utils.h
@@ -7,6 +7,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <cctype>
 #include <map>
 #include <string>
 
@@ -323,6 +324,30 @@ public:
       "complex",
       "frozenset"};
     return type_identifiers.find(name) != type_identifiers.end();
+  }
+
+  /// Copies @p s to @p out with PEP 515 underscore separators removed.
+  /// Returns false when one is misplaced: a numeric string may carry a single
+  /// underscore between two digits, never leading, trailing or doubled.
+  static bool strip_pep515_underscores(const std::string &s, std::string &out)
+  {
+    out.clear();
+    out.reserve(s.size());
+    for (std::size_t i = 0; i < s.size(); i++)
+    {
+      if (s[i] != '_')
+      {
+        out.push_back(s[i]);
+        continue;
+      }
+      const bool between_digits =
+        i > 0 && i + 1 < s.size() &&
+        isdigit(static_cast<unsigned char>(s[i - 1])) &&
+        isdigit(static_cast<unsigned char>(s[i + 1]));
+      if (!between_digits)
+        return false;
+    }
+    return true;
   }
 
 private:


### PR DESCRIPTION
CPython has accepted a single underscore between digits, and after a base
specifier, in the `int()`/`float()` constructors since 3.6; the models rejected
it as an invalid character.

The rule reaches four places, so all four are fixed: the runtime `int` and
`float` parsers in the operational model, and the frontend's two compile-time
folds, which hand the string to `strtod`/`stoi` — neither of which knows PEP
515. The two fold sites cover both a literal argument and a string held in a
variable; the variable form silently folded to `0` rather than rejecting.

The accepted and rejected sets were taken from CPython 3.12 rather than from
the PEP's prose, and the test pins both.

Fixes #7558
