### PR TITLE
[python] Support compound assign and unary minus on tagged scalars

### DIFF
--- a/regression/python/dynamic_type_func_arg_unsupported/main.py
+++ b/regression/python/dynamic_type_func_arg_unsupported/main.py
@@ -1,0 +1,9 @@
+def f(v):
+    return v == 1
+
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+assert f(x)

--- a/regression/python/dynamic_type_func_arg_unsupported/test.desc
+++ b/regression/python/dynamic_type_func_arg_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: passing a dynamically-typed variable to a function is not yet supported$

--- a/regression/python/dynamic_type_scalar_tag_augassign_num/main.py
+++ b/regression/python/dynamic_type_scalar_tag_augassign_num/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+else:
+    x = "a"
+if cond:
+    x += 1
+    assert x == 6

--- a/regression/python/dynamic_type_scalar_tag_augassign_num/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_augassign_num/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_augassign_num_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_augassign_num_fail/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+else:
+    x = "a"
+if cond:
+    x += 1
+    assert x == 7

--- a/regression/python/dynamic_type_scalar_tag_augassign_num_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_augassign_num_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_augassign_str/main.py
+++ b/regression/python/dynamic_type_scalar_tag_augassign_str/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+if not cond:
+    x += "b"
+    assert x == "ab"

--- a/regression/python/dynamic_type_scalar_tag_augassign_str/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_augassign_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_augassign_str_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_augassign_str_fail/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+if not cond:
+    x += "b"
+    assert x == "ac"

--- a/regression/python/dynamic_type_scalar_tag_augassign_str_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_augassign_str_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_augassign_typeerror/main.py
+++ b/regression/python/dynamic_type_scalar_tag_augassign_typeerror/main.py
@@ -1,0 +1,7 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+else:
+    x = "a"
+if not cond:
+    x += 1

--- a/regression/python/dynamic_type_scalar_tag_augassign_typeerror/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_augassign_typeerror/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+^.*unsupported operand type.*for \+.*$

--- a/regression/python/dynamic_type_scalar_tag_augassign_unsupported/main.py
+++ b/regression/python/dynamic_type_scalar_tag_augassign_unsupported/main.py
@@ -1,0 +1,7 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+else:
+    x = "a"
+if cond:
+    x *= 2

--- a/regression/python/dynamic_type_scalar_tag_augassign_unsupported/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_augassign_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: operator 'Mult' on a dynamically-typed variable is not yet supported$

--- a/regression/python/dynamic_type_scalar_tag_neg_num/main.py
+++ b/regression/python/dynamic_type_scalar_tag_neg_num/main.py
@@ -1,0 +1,7 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+else:
+    x = "a"
+if cond:
+    assert -x == -5

--- a/regression/python/dynamic_type_scalar_tag_neg_num/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_neg_num/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_neg_num_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_neg_num_fail/main.py
@@ -1,0 +1,7 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+else:
+    x = "a"
+if cond:
+    assert -x == -6

--- a/regression/python/dynamic_type_scalar_tag_neg_num_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_neg_num_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_neg_typeerror/main.py
+++ b/regression/python/dynamic_type_scalar_tag_neg_typeerror/main.py
@@ -1,0 +1,7 @@
+cond = nondet_bool()
+if cond:
+    x = 5
+else:
+    x = "a"
+if not cond:
+    assert -x == 0

--- a/regression/python/dynamic_type_scalar_tag_neg_typeerror/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_neg_typeerror/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$
+^.*unsupported operand type.*for -.*$

--- a/regression/python/dynamic_type_while_cond_unsupported/main.py
+++ b/regression/python/dynamic_type_while_cond_unsupported/main.py
@@ -1,0 +1,7 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+while x:
+    break

--- a/regression/python/dynamic_type_while_cond_unsupported/test.desc
+++ b/regression/python/dynamic_type_while_cond_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: truthiness of a dynamically-typed variable is not yet supported$

--- a/src/c2goto/library/python/scalar.c
+++ b/src/c2goto/library/python/scalar.c
@@ -192,6 +192,20 @@ __ESBMC_HIDE:;
   return (a->size > b->size) - (a->size < b->size);
 }
 
+// Bounded strlen for a runtime string pointer -- a plain strlen never
+// finishes unwinding over a symbolic buffer.
+size_t __python_scalar_strlen_bounded(const char *s)
+{
+__ESBMC_HIDE:;
+  for (size_t i = 0; i < ESBMC_PY_STRNLEN_BOUND; ++i)
+  {
+    if (s[i] == '\0')
+      return i;
+  }
+  __ESBMC_assert(0, "tagged str exceeds the modelled bound");
+  return ESBMC_PY_STRNLEN_BOUND;
+}
+
 // Models a runtime type mismatch (e.g. `x + 1` where `x` holds a str) as a
 // Python TypeError, the same way IndexError/KeyError are modeled elsewhere
 // in this library: an assert on the path that would have raised.
@@ -230,12 +244,18 @@ __ESBMC_HIDE:;
   char *tagged_dst = tagged_is_left ? buffer : buffer + value_len;
   char *value_dst = tagged_is_left ? buffer + tagged_len : buffer;
 
-  // Zero-fill the tagged side on a mismatch instead of skipping it, so
-  // the buffer keeps the same shape either way.
-  if (type_matches)
-    __python_scalar_bytes_copy(tagged_dst, tagged->value, tagged_len);
-  else
-    memset(tagged_dst, 0, tagged_len);
+  // `tagged_len` can be symbolic after a branch join, so use a bounded
+  // loop instead of memcpy/memset, which never finish unwinding over it.
+  __ESBMC_assert(
+    tagged_len <= ESBMC_PY_STRNLEN_BOUND,
+    "tagged str exceeds the modelled bound");
+  for (size_t i = 0; i < ESBMC_PY_STRNLEN_BOUND; ++i)
+  {
+    if (i >= tagged_len)
+      break;
+    // Zero-fill on a mismatch so the buffer keeps the same shape either way.
+    tagged_dst[i] = type_matches ? ((const char *)tagged->value)[i] : 0;
+  }
   __python_scalar_bytes_copy(value_dst, value, value_len);
 
   buffer[tagged_len + value_len] = '\0';

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -6676,6 +6676,35 @@ void python_converter::get_compound_assign(
       ast_node["target"]["_type"].get<std::string>());
   }
 
+  // Desugar `x op= v` into `x = x op v`, reusing get_var_assign's tagged
+  // dispatch instead of duplicating it here.
+  if (type_handler_.is_tagged_scalar_type(lhs.type()))
+  {
+    std::string op_type = ast_node["op"]["_type"].get<std::string>();
+    if (op_type != "Add" && op_type != "Sub" && op_type != "Div")
+      throw std::runtime_error(
+        "operator '" + op_type +
+        "' on a dynamically-typed variable is not yet supported");
+
+    nlohmann::json binop;
+    binop["_type"] = "BinOp";
+    binop["left"] = ast_node["target"];
+    binop["op"] = ast_node["op"];
+    binop["right"] = ast_node["value"];
+    copy_location_fields_from_decl(ast_node, binop);
+
+    nlohmann::json synthetic;
+    synthetic["_type"] = "Assign";
+    synthetic["targets"] = nlohmann::json::array({ast_node["target"]});
+    synthetic["value"] = binop;
+    copy_location_fields_from_decl(ast_node, synthetic);
+
+    is_converting_lhs = false;
+    is_converting_rhs = false;
+    get_var_assign(synthetic, target_block);
+    return;
+  }
+
   // For attribute assignments, use the type from the LHS expression
   // For other assignments, resolve the variable type
   if (!lhs.type().is_nil() && !lhs.type().id().empty())
@@ -7111,6 +7140,12 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
       return cond;
     }
 
+    // A tagged value has no defined truthiness; refuse instead of building
+    // an ill-typed struct-to-bool node.
+    if (type_handler_.is_tagged_scalar_type(value_expr.type()))
+      throw std::runtime_error(
+        "truthiness of a dynamically-typed variable is not yet supported");
+
     exprt bool_expr = typecast_exprt(value_expr, bool_type());
     bool_expr.location() = get_location_from_decl(value_node);
     return bool_expr;
@@ -7264,6 +7299,14 @@ exprt python_converter::get_conditional_stm(const nlohmann::json &ast_node)
     if (!cond.type().is_bool())
     {
       const locationt location = get_location_from_decl(ast_node["test"]);
+
+      // A tagged value has no defined truthiness; refuse instead of
+      // falling through to a struct-typed guard.
+      if (type_handler_.is_tagged_scalar_type(cond.type()))
+        throw std::runtime_error(
+          "truthiness of a dynamically-typed variable is not yet "
+          "supported");
+
       typet value_type = ns.follow(cond.type());
       if (value_type.is_pointer())
         value_type = ns.follow(value_type.subtype());

--- a/src/python-frontend/converter/converter_unop.cpp
+++ b/src/python-frontend/converter/converter_unop.cpp
@@ -1,6 +1,7 @@
 #include <python-frontend/converter/converter_internal.h>
 #include <python-frontend/python_converter.h>
 #include <python-frontend/type/type_utils.h>
+#include <python-frontend/dynamic_type/dynamic_type_handler.h>
 #include <util/lang/c_typecast.h>
 #include <util/lang/c_types.h>
 #include <util/expr/expr_util.h>
@@ -26,6 +27,17 @@ exprt python_converter::get_unary_operator_expr(const nlohmann::json &element)
 
   // Get the operand expression
   exprt unary_sub = get_expr(element["operand"]);
+
+  // A tagged operand needs runtime dispatch.
+  if (type_handler_.is_tagged_scalar_type(unary_sub.type()))
+  {
+    std::string unary_op = element["op"]["_type"].get<std::string>();
+    if (unary_op == "USub")
+      return dynamic_type_handler_.build_neg_tagged(unary_sub);
+    throw std::runtime_error(
+      "operator '" + unary_op +
+      "' on a dynamically-typed variable is not yet supported");
+  }
 
   // An unresolved method call yields a placeholder null (see
   // PYTHON_UNRESOLVED_CALL_ATTR). Reading that null as False would let

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.cpp
@@ -344,26 +344,55 @@ std::vector<codet> dynamic_type_handler::build_tag_field_assigns(
   backing_decl.location() = location;
   instructions.push_back(backing_decl);
 
-  exprt elem_size = type_handler_.tagged_scalar_byte_size(value_to_store);
+  // A runtime string has no statically known length -- measure it with
+  // the bounded-length helper, +1 for the trailing NUL.
+  exprt elem_size;
+  if (
+    value_to_store.type().is_pointer() &&
+    value_to_store.type().subtype() == char_type())
+  {
+    const symbolt *strlen_func = converter_.symbol_table().find_symbol(
+      "c:@F@__python_scalar_strlen_bounded");
+    assert(
+      strlen_func &&
+      "__python_scalar_strlen_bounded not found in symbol table");
+    exprt base_addr = converter_.get_string_handler().get_array_base_address(
+      build_symbol(backing));
+    exprt len_call = build_call_expr(*strlen_func, size_type(), {base_addr});
+    elem_size = build_add(len_call, from_integer(1, size_type()), size_type());
+  }
+  else
+    elem_size = type_handler_.tagged_scalar_byte_size(value_to_store);
 
-  // `backing` goes DEAD at the end of this branch; copy its value into
-  // non-expiring storage first so `.value` stays valid past the join.
-  const symbolt *copy_func =
-    converter_.symbol_table().find_symbol("c:@F@__python_scalar_tag_copy");
+  // A pointer `backing` already refers to non-expiring storage, so use it
+  // as `.value` directly. Anything else lives in `backing`'s own stack
+  // storage, which goes DEAD at branch exit, so it needs an explicit copy.
+  exprt tag_value;
+  if (value_to_store.type().is_pointer())
+    tag_value =
+      build_typecast(build_symbol(backing), pointer_typet(empty_typet()));
+  else
+  {
+    const symbolt *copy_func =
+      converter_.symbol_table().find_symbol("c:@F@__python_scalar_tag_copy");
+    assert(copy_func && "__python_scalar_tag_copy not found in symbol table");
+    exprt backing_addr = build_typecast(
+      build_address_of(build_symbol(backing)), pointer_typet(empty_typet()));
+    tag_value = build_call_expr(
+      *copy_func, pointer_typet(empty_typet()), {backing_addr, elem_size});
+  }
 
-  assert(copy_func && "__python_scalar_tag_copy not found in symbol table");
-
-  exprt backing_addr = build_typecast(
-    build_address_of(build_symbol(backing)), pointer_typet(empty_typet()));
-  exprt copy_call = build_call_expr(
-    *copy_func, pointer_typet(empty_typet()), {backing_addr, elem_size});
-
-  exprt type_id_value = type_handler_.tagged_scalar_type_id(rhs.type());
+  // Normalise to the canonical str type before hashing, so type_id
+  // doesn't vary with length or array-vs-pointer shape.
+  typet type_id_source = value_to_store.type();
+  if (type_handler_.is_string_type(type_id_source))
+    type_id_source = pointer_typet(char_type());
+  exprt type_id_value = type_handler_.tagged_scalar_type_id(type_id_source);
 
   exprt tag_expr = build_symbol(tag_symbol);
 
   code_assignt value_assign(
-    build_member(tag_expr, "value", pointer_typet(empty_typet())), copy_call);
+    build_member(tag_expr, "value", pointer_typet(empty_typet())), tag_value);
   value_assign.location() = location;
   instructions.push_back(value_assign);
 
@@ -721,6 +750,12 @@ exprt dynamic_type_handler::handle_arithmetic(
   assert(op == "Div" && "unexpected operator routed to handle_arithmetic");
   return lhs_tagged ? build_div_literal(lhs, rhs, true, location)
                     : build_div_literal(rhs, lhs, false, location);
+}
+
+exprt dynamic_type_handler::build_neg_tagged(const exprt &tagged)
+{
+  exprt zero = from_integer(0, signedbv_typet(config.ansi_c.int_width));
+  return build_sub_literal(tagged, zero, /*tagged_is_left=*/false);
 }
 
 exprt dynamic_type_handler::build_add_tagged(const exprt &lhs, const exprt &rhs)

--- a/src/python-frontend/dynamic_type/dynamic_type_handler.h
+++ b/src/python-frontend/dynamic_type/dynamic_type_handler.h
@@ -90,6 +90,11 @@ public:
     const locationt &location);
 
   /**
+   * @brief Builds unary minus on a tagged-scalar operand, as `0 - tagged`
+   */
+  exprt build_neg_tagged(const exprt &tagged);
+
+  /**
    * @brief Builds isinstance(tagged, type_name). `type_is_user_class` says
    * whether `type_name` names a class defined in the program, which a tag can
    * never hold

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -5937,6 +5937,12 @@ std::optional<exprt> function_call_expr::build_positional_arguments(
     exprt arg = converter_.get_expr(arg_node);
     converter_.current_lhs = saved_lhs;
 
+    // Tagged arguments aren't supported yet; refuse before goto-symex.
+    if (type_handler_.is_tagged_scalar_type(arg.type()))
+      throw std::runtime_error(
+        "passing a dynamically-typed variable to a function is not yet "
+        "supported");
+
     // A list passed to a callee may be mutated there (e.g. appended to), which
     // the caller's static length tracking does not observe. Mark the symbol so
     // later constant-index accesses fall back to the runtime bounds check


### PR DESCRIPTION
Adds support for +=/-=//= and unary -x on dynamically-typed (tagged) scalars, and replaces two internal crashes with clean refusals.

- Desugars x op= v into x = x op v, reusing get_var_assign's existing tagged dispatch instead of duplicating it.
- Adds build_neg_tagged for -x on a tagged scalar, via build_sub_literal(0, x).
- Refuses cleanly instead of crashing on: unsupported compound-assign operators, tagged truthiness in while/if, and passing a tagged value as a function argument.
- Fixes two pre-existing bugs this surfaced: wrong byte size/copy source/type_id hashing for a pointer-typed reassignment value in build_tag_field_assigns, and an unbounded-unwind memcpy in __python_scalar_add_str's tagged-side copy.