### PR TITLE
[regression] Let a test require a long per-test budget

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -105,6 +105,15 @@ if(ESBMC_SIZEOF_LONG EQUAL 8)
     list(APPEND ESBMC_TEST_CAPABILITIES lp64_host)
 endif()
 
+# The per-test budget is long enough for a test that takes minutes to solve.
+# ESBMC_REGRESS_TIMEOUT is one global number, so a test needing more than a
+# short leg allows has no way to ask for more; without this it is reported as
+# a hard timeout on every PR. The PR workflow sets 120 (build-unix.yml), the
+# default is 1200.
+if(ESBMC_REGRESS_TIMEOUT GREATER_EQUAL 600)
+    list(APPEND ESBMC_TEST_CAPABILITIES long_timeout)
+endif()
+
 string(REPLACE ";" "," ESBMC_TEST_CAPABILITIES_ARG "${ESBMC_TEST_CAPABILITIES}")
 message(STATUS "Regression capabilities: ${ESBMC_TEST_CAPABILITIES_ARG}")
 

--- a/regression/floats-regression/nn-logistic_5_unsafe/test.desc
+++ b/regression/floats-regression/nn-logistic_5_unsafe/test.desc
@@ -1,4 +1,5 @@
 THOROUGH
 logistic_5_unsafe.c-amalgamation.c
 -I . --boolector
+REQUIRES long_timeout
 ^VERIFICATION FAILED$

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -242,6 +242,10 @@ STATIC_CAPABILITIES = {
     # materialised through it, so a negative offset is a different constant --
     # and draws the opposite out-of-bounds verdict -- on LLP64 hosts.
     "lp64_host",
+    # The per-test budget (ESBMC_REGRESS_TIMEOUT) is at least 600s. For tests
+    # whose solve genuinely takes minutes: the PR leg caps every test at 120s,
+    # where such a test can only ever report a timeout.
+    "long_timeout",
 }
 
 # Capabilities of the frontend itself, which the build system cannot answer:


### PR DESCRIPTION
`ESBMC_REGRESS_TIMEOUT` is a single global number, so a test whose solve takes
minutes cannot ask for more than a short leg allows. The PR workflow caps every
test at 120s (`build-unix.yml`), and `nn-logistic_5_unsafe` needs far longer, so
it reports a hard timeout on every PR regardless of what that PR changed -- most
recently on #7490 and #7562, two unrelated changes that failed on it identically.

Add a `long_timeout` capability, present when the budget is at least 600s, and
have that test require it: skipped on the PR leg, run in full on push and
locally, where the budget is 1200s.
