### PR TITLE
[clang-c] Add a diagnostic that defeats the adjuster's write-back gate

### DIFF
--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -7130,18 +7130,12 @@ descriptor's own flags produce is byte-identical between the two binaries,
 131/131.
 
 The same 131 run as an A/B against the hop-off — 5 pin the flag themselves and
-are excluded, leaving 126 scored — moves no test in either direction on either
-instrument. The two instruments disagree about the level, not the delta:
-
-| instrument | control | patched |
-|---|---|---|
-| goto program | 126 SAME / 0 DIFF | 126 SAME / 0 DIFF |
-| symbol table | 41 SAME / 85 DIFF | 41 SAME / 85 DIFF |
-
-The sample carries no incomplete tag, so it measures only that nothing
-regressed; the movement is the four rows above. A goto-level sweep of this
-corpus is close to saturated and will not resolve the residue — §133.3's causes
-are symbol-table-only, which is why that is the instrument to keep using here.
+are excluded, leaving 126 scored — moves no test in either direction on the
+symbol table: 41 SAME / 85 DIFF on both binaries. The sample carries no
+incomplete tag, so it measures only that nothing regressed; the movement is the
+four rows above. §134 tags that 85 and gives the goto-level figure, which an
+earlier draft of this section quoted from a harness that was silently
+discarding the hop-off flag (§134.1).
 
 ### 133.3 Next
 
@@ -7212,3 +7206,121 @@ The control binary diverges here identically, so this predates §133 and the
 follow was never what carried it — `V`'s type is a `vector_type2t` either way.
 It is the smaller half of the same arm and wants its own test, since §90.4's
 trap is an arm no test executes.
+
+## 134. The cause census §113.4 asked for — and the harness bug it found first
+## (2026-09-05)
+
+§113.4 stopped further arm-writing until a fresh cause census: "the old one is
+stale, and §113.1 shows it was reading the wrong stage." This is that census,
+over a stride-16 list of `regression/esbmc` (131 descriptors, 5 of which pin
+the hop-off themselves and are excluded, leaving 126 scored), legacy against
+`--clang-c-irep2-adjust-only` on one binary.
+
+### 134.1 `irep2_goto_dump` accepted a fourth argument and dropped it
+
+The first run reported **126 SAME / 0 DIFF** at the goto level. That number was
+manufactured. `irep2_symtab_dump` takes an optional `$4` extra flag;
+`irep2_goto_dump`, its sibling three lines above in the same file, did not —
+and bash discards a surplus positional silently. Every "hop-off" run in that
+sweep was therefore the *default* path, compared with itself.
+
+A sweep that compares a thing with itself does not fail, it passes: the failure
+mode is a clean, plausible, completely converged result. Nothing in the output
+distinguished it from real convergence, and the number was written into §133.2
+before a single-test spot check contradicted it —
+`regression/esbmc/atexit-1` diverges at the goto level under its own flags, but
+the helper scored it SAME.
+
+`irep2_goto_dump` now takes the same `$4`, with the argv guard its sibling
+already had. The check that catches this class: run the A/B on one test where
+the divergence is known by hand, and confirm the harness reports DIFF, before
+trusting the sweep's totals.
+
+### 134.2 The goto program is at 124 / 126, and both residuals are recorded
+
+Re-run with the fixed helper:
+
+| instrument | SAME | DIFF |
+|---|---:|---:|
+| goto program | **124** | 2 |
+| symbol table | 41 | 85 |
+
+Both goto residuals are the same cause, and it is §113.3's:
+
+```
+legacy:  FUNCTION_CALL:  atexit((void (*)())(&free_g2))
+hop-off: FUNCTION_CALL:  atexit(&free_g2)
+```
+
+`arg->type == params[i]` holds in IREP2 — `migrate_type` maps `void (*)(void)`
+and `void (*)()` to the same `code_type2t` — so the legacy cast is the identity
+and no pass reading IREP2 can know it is owed. §113.3 argued that emitting it
+to match the legacy printer is §110.2's mistake with a different node, and
+closing it for real needs `code_type2t` to carry the prototyped/unprototyped
+distinction. That argument stands; what is new is that this is now the *only*
+goto-level cause left on the sample.
+
+### 134.3 The symbol-table residue is 85, and 73 of it is already argued
+
+Tagging each of the 85, with leading/trailing whitespace and empty lines
+normalised away first:
+
+| class | tests | status |
+|---|---:|---|
+| whitespace / blank-line only | 24 | printer artefact; `symtab_sweep.sh` already diffs with `-B` |
+| `(void)0` vs `0` | 40 | §110.2 — the hop-off is the faithful side |
+| qualifier only (`const`/`volatile`) | 9 | §133.3 / R9 — no representation to carry it |
+| everything else | **12** | below |
+
+Those 24 split 16 blank-line-only and 8 indentation-only, and they are the
+reason a census must state its normalisation. One run, three defensible
+numbers: **85** by string equality, **69** under `diff -B` (what
+`symtab_sweep.sh` actually does — it ignores blank lines, not indentation), and
+**61** ignoring leading whitespace as well. None is wrong; quoting one without
+the rule is.
+
+Of the 12, four are the printer set §113.4 already named — the float literal
+suffix (`1.175494e-38` vs `1.175494e-38f`, `3.000000` vs `3.000000l`) and the
+`#cformat` / `#cpp_type` attributes the round-trip drops — and two are §134.2's
+`atexit`. That leaves **six** unclassified out of 126, and they are six
+distinct causes, not one:
+
+| test | divergence |
+|---|---|
+| `memset-const` | an array in a ternary arm is left undecayed (§134.4) |
+| `github_1590` | the same, in a binary `-` |
+| `builtin_memcpy` | a `char` array literal prints as integers, not characters |
+| `github_6966` | a symbol's `Location` is empty where legacy has one |
+| `cwe_excessive_alloc_vla_pass` | a VLA size prints as the full symbol id, not the base name |
+| `union-ptr-arith-bug` | an anonymous padding member appears in a union initialiser |
+
+### 134.4 The ternary decay, reduced — and why it does not reach symex
+
+```c
+#include <string.h>
+const char b[] = "abc";
+int main(int argc, char **argv)
+{
+  char a[2];
+  char *c = argc == 1 ? a : b;
+  memset(c, 0, 1);
+}
+```
+
+```
+legacy:  signed char * c=argc == 1 ? &a[0] : &b[0];
+hop-off: signed char * c=argc == 1 ? &a[0] : b;
+```
+
+The hop-off leaves an `array` -typed arm inside a pointer-typed `if2t`. Drop
+the `memset` and both paths print `&b[0]`: the value is written back only when
+the walk changed something (§133.3), so a clean body keeps the converter's own
+decayed form and the gap is invisible. That is the general shape of this
+residue — an unported conversion shows up only in functions that are dirty for
+some other reason.
+
+It does not reach symex today. `migrate_expr`'s `if` arm gives an array branch
+of a pointer-typed conditional its C conversion (§116.2), so the round-trip
+re-decays it and the goto programs are byte-identical. The obligation is real
+all the same: the ill-typed node is what a native `goto_convert` would receive
+once the round-trip is deleted, which is B-3. It is the next arm.

--- a/docs/roadmap/scope-clang-c-irep2.md
+++ b/docs/roadmap/scope-clang-c-irep2.md
@@ -7324,3 +7324,98 @@ of a pointer-typed conditional its C conversion (§116.2), so the round-trip
 re-decays it and the goto programs are byte-identical. The obligation is real
 all the same: the ill-typed node is what a native `goto_convert` would receive
 once the round-trip is deleted, which is B-3. It is the next arm.
+
+## 135. The symbol-table A/B shows the converter's tree, not the pass's
+## (2026-09-05)
+
+§134.3 left six unclassified causes and named the ternary array decay as the
+next arm. Two of the six are not arms, and the reason generalises to the
+instrument itself.
+
+### 135.1 The reduction, and what instrumenting it said
+
+```c
+char b[4]; char *d;
+void snk(void *);
+int main(int argc, char **argv) { char *c; c = argc==1 ? b : d; snk(c); }
+```
+
+```
+legacy:   c = argc == 1 ? &b[0] : d;
+hop-off:  c = argc == 1 ? b : d;
+```
+
+Read off the dump, that is a missing array-to-pointer decay in a conditional
+arm. It is not. Instrumented, `adjust_if_expr` receives the `if2t` with **all
+three types already `pointer`** — `migrate_expr`'s `coerce_ternary_branch`
+(§116.2) decayed the branch on the way in — and the pass has nothing to do.
+
+Replace `snk(c);` with `return c[0];` and the same program prints `&b[0]` under
+the hop-off. The instrumented difference between the two is one line:
+
+| last statement | `value != before` | printed |
+|---|---|---|
+| `return c[0];` | true | `&b[0]` |
+| `snk(c);` | **false** | `b` |
+
+`adjust()` refreshes a symbol's legacy value only when the walk changed
+something (§133.3's other half). When it changed nothing, `symbolt` keeps the
+**converter's** tree — and the converter does not decay an array in a ternary
+arm; `clang_c_adjust::adjust_if` does. So the dump is showing legacy's input
+where the hop-off's output was wanted. `memset-const`'s `main` reports
+`changed=false`, which is the whole of that test's remaining divergence.
+
+### 135.2 The instrument shows two different things
+
+This is worth stating plainly because §100.1 makes the symbol table *the*
+instrument for adjuster questions, and it is:
+
+- the **pass's** output for a body the pass changed, and
+- the **converter's** output for a body it did not,
+
+with nothing in the dump to say which. The two differ wherever `migrate_expr`
+normalises — the ternary decay above, and every other coercion its arms apply.
+So a symbol-table A/B systematically reports work as unported when the only
+thing missing is a write-back nobody wanted.
+
+`--clang-c-irep2-adjust-writeback-all` defeats the gate for diagnosis. It is
+not a mode to verify in: forcing the write-back makes every body pay
+`migrate_expr_back`'s losses, and over the same stride-16 sample it takes the
+residue the wrong way, 85 DIFF to 114. Its use is per-cause, one test at a
+time — does *this* line come back when the value is refreshed?
+
+Nothing downstream is affected. `goto_convert_functions.cpp` reads a body
+through `get_value2()` (the IREP2 value, always the pass's own); the remaining
+`get_value()` uses there are `is_nil` / `is_code` / `has_operands` predicates,
+which agree either way. That is why §134.2's goto census is 124/126 while the
+symbol table reads 85 DIFF.
+
+### 135.3 The six, re-scored
+
+| test | line under `--...-writeback-all` | verdict |
+|---|---|---|
+| `memset-const` | `? &b[0] :` — matches legacy | **artefact** |
+| `github_1590` | `- &buffer[0]` — matches legacy | **artefact** |
+| `builtin_memcpy` | unchanged | real, printer |
+| `cwe_excessive_alloc_vla_pass` | unchanged | real, printer |
+| `union-ptr-arith-bug` | unchanged | real |
+| `github_6966` | unchanged | **real** |
+
+`builtin_memcpy` is a representation difference the printer exposes: legacy
+keeps `const signed char [9] src={ 't', 'e', … }`, the hop-off prints
+`signed char [9] src={ 116, 101, … }` — `migrate_expr` turns the string
+constant into a `constant_array` of integers, and the qualifier goes with
+§133.3. `cwe_excessive_alloc_vla_pass` prints a VLA's size symbol by base name
+where legacy prints its full id; the hop-off is the more readable of the two
+and neither reaches symex.
+
+### 135.4 Next
+
+`github_6966` — a symbol whose `Location` is empty under the hop-off where
+legacy has `file main.c line 13 column 14 function log_msg`. It survives
+`--clang-c-irep2-adjust-writeback-all`, so it is the pass's own output, and it
+is the only one of the six that loses information a user sees: a location is
+what a counterexample step and a witness are printed from. §110.3 and §130.3
+each closed one place a location was dropped and each recorded that the general
+fix needs `sideeffect2t` to carry a `locationt`. This is the third; take it
+next, and check first whether it is that same missing field.

--- a/regression/esbmc/irep2_only_writeback_all/main.c
+++ b/regression/esbmc/irep2_only_writeback_all/main.c
@@ -1,0 +1,16 @@
+/* The IREP2 pass changes nothing in this body: migrate_expr already decayed
+   the array in the conditional arm, and the call's argument needs no
+   conversion the converter did not emit. adjust() therefore leaves the legacy
+   value alone, and --symbol-table-only prints the converter's tree unless the
+   write-back is forced. */
+char b[4];
+char *d;
+void snk(void *p);
+
+int main(int argc, char **argv)
+{
+  char *c;
+  c = argc == 1 ? b : d;
+  snk(c);
+  return 0;
+}

--- a/regression/esbmc/irep2_only_writeback_all/test.desc
+++ b/regression/esbmc/irep2_only_writeback_all/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--symbol-table-only --clang-c-irep2-adjust-only --clang-c-irep2-adjust-writeback-all
+c = argc == 1 \? &b\[0\] : d;

--- a/regression/esbmc/irep2_only_writeback_gated/main.c
+++ b/regression/esbmc/irep2_only_writeback_gated/main.c
@@ -1,0 +1,16 @@
+/* The IREP2 pass changes nothing in this body: migrate_expr already decayed
+   the array in the conditional arm, and the call's argument needs no
+   conversion the converter did not emit. adjust() therefore leaves the legacy
+   value alone, and --symbol-table-only prints the converter's tree unless the
+   write-back is forced. */
+char b[4];
+char *d;
+void snk(void *p);
+
+int main(int argc, char **argv)
+{
+  char *c;
+  c = argc == 1 ? b : d;
+  snk(c);
+  return 0;
+}

--- a/regression/esbmc/irep2_only_writeback_gated/test.desc
+++ b/regression/esbmc/irep2_only_writeback_gated/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--symbol-table-only --clang-c-irep2-adjust-only
+c = argc == 1 \? b : d;

--- a/scripts/irep2-migration/lib.sh
+++ b/scripts/irep2-migration/lib.sh
@@ -49,8 +49,12 @@ irep2_canon() {
 # building the goto program. Goto-affecting flags (--data-races-check,
 # --k-induction, --no-pointer-check, ...) are thus honoured exactly as the
 # real suite passes them.
+# $4 (optional) is an extra flag added to the run, e.g. the hop-off under test,
+# matching irep2_symtab_dump. It used to be accepted and silently dropped, so an
+# A/B built on this helper compared the default path with itself and scored
+# every test SAME (scope-clang-c-irep2.md §134.1).
 irep2_goto_dump() {
-  local esbmc="$1" desc="$2" repo="$3"
+  local esbmc="$1" desc="$2" repo="$3" extra="${4:-}"
   local dir src args tok
   dir="$(dirname "$desc")"
   src="$(sed -n '2p' "$desc" | tr -d '[:space:]')"
@@ -62,10 +66,12 @@ irep2_goto_dump() {
     if [ -f "$dir/$tok" ]; then argv+=("$dir/$tok"); else argv+=("$tok"); fi
   done
 
+  [ -n "$extra" ] && argv+=("$extra")
+
   # esbmc's exit status is intentionally ignored: --goto-functions-only can exit
   # non-zero on some inputs, but the (deterministic) dumped text is what we diff.
-  ( "$esbmc" "${argv[@]}" --goto-functions-only "$dir/$src" 2>&1 || true ) \
-    | irep2_canon "$repo"
+  ( "$esbmc" ${argv[@]+"${argv[@]}"} --goto-functions-only "$dir/$src" 2>&1 \
+    || true ) | irep2_canon "$repo"
 }
 
 # Produce the canonical *symbol table* dump for one test.desc into stdout.

--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -54,7 +54,10 @@ bool clang_c_adjust_irep2::adjust()
       // Only write back a value this pass actually changed, so symbols it does
       // not touch never make the round trip (python_adjust takes the same care,
       // for the bitfield and alignment losses migrate_type cannot carry).
-      if (value != before)
+      // writeback_all defeats the gate for diagnosis only: an unchanged body
+      // otherwise keeps its converter tree, which is not what this pass built
+      // (§135).
+      if (writeback_all || value != before)
         s->set_value(value);
     }
   }

--- a/src/clang-c-frontend/clang_c_adjust_irep2.h
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.h
@@ -12,17 +12,18 @@
 /// in-place recursive walk over `expr2tc` rather than the converter's
 /// out-parameter seam.
 ///
-/// At this stage the walk is deliberately **read-only**: it reads each code
-/// symbol's IREP2 value and recurses, and never writes one back. That keeps the
-/// pass inert by construction rather than by argument -- there is no write path
-/// to be wrong -- while still exercising `migrate_expr` over every construct
-/// the C corpus contains, since `symbolt::get_value2()` migrates the legacy
-/// value on demand. A construct that cannot migrate aborts here instead of much
-/// later.
+/// The walk reads each code symbol's IREP2 value, recurses, and writes the
+/// result back only when it changed something. That gate keeps an untouched
+/// body clear of the round-trip losses `python_adjust` documents (a bitfield's
+/// `#bitfield` flag, an explicit alignment attribute, the C qualifiers), which
+/// C headers are exactly the place to hit -- and it exercises `migrate_expr`
+/// over every construct the C corpus contains either way, since
+/// `symbolt::get_value2()` migrates on demand and a construct that cannot
+/// migrate aborts here rather than much later.
 ///
-/// Read-only also side-steps the round-trip losses `python_adjust` documents
-/// (a bitfield's `#bitfield` flag, an explicit alignment attribute): those only
-/// matter to a write-back, and C headers are exactly the place they occur.
+/// The gate has a cost worth knowing about when reading a symbol-table A/B: an
+/// unchanged body still prints its *converter* tree, which is not what this
+/// pass produced. See `writeback_all` below and §135.
 ///
 /// Known limitation: the walk aborts on a union constant whose type is still a
 /// by-name tag -- `migrate_expr` hands `migrate_type`'s `symbol_type2t` to
@@ -39,8 +40,21 @@ public:
   /// -- declaring an implicitly-declared callee (§70) -- must run only then:
   /// in shadow mode the legacy pass has already done it, and doing it twice
   /// adds conflicting symbols for library functions.
-  explicit clang_c_adjust_irep2(contextt &_context, bool sole_adjuster = false)
-    : context(_context), sole_adjuster(sole_adjuster)
+  /// @param writeback_all diagnostic only
+  /// (--clang-c-irep2-adjust-writeback-all): refresh every symbol's legacy
+  /// value, not just the ones this pass changed. adjust() gates the write-back
+  /// on `value != before` so an untouched body never pays migrate_expr_back's
+  /// losses -- but that also means `--symbol-table-only` prints the
+  /// *converter's* tree for those bodies, not this pass's, and the two differ
+  /// wherever migrate_expr normalises (§135). Set this to see what the pass
+  /// actually produced.
+  explicit clang_c_adjust_irep2(
+    contextt &_context,
+    bool sole_adjuster = false,
+    bool writeback_all = false)
+    : context(_context),
+      sole_adjuster(sole_adjuster),
+      writeback_all(writeback_all)
   {
   }
 
@@ -222,6 +236,7 @@ private:
 
   contextt &context;
   const bool sole_adjuster;
+  const bool writeback_all;
   /// Location of the innermost enclosing statement, for the nodes that carry
   /// none of their own.
   locationt enclosing_location;

--- a/src/clang-c-frontend/clang_c_language.cpp
+++ b/src/clang-c-frontend/clang_c_language.cpp
@@ -480,7 +480,10 @@ bool clang_c_languaget::typecheck(contextt &context, const std::string &module)
   // aborts on a construct migrate_expr cannot represent.
   if (irep2_only || config.options.get_bool_option("clang-c-irep2-adjust"))
   {
-    clang_c_adjust_irep2 irep2_adjuster(new_context, irep2_only);
+    clang_c_adjust_irep2 irep2_adjuster(
+      new_context,
+      irep2_only,
+      config.options.get_bool_option("clang-c-irep2-adjust-writeback-all"));
     if (irep2_adjuster.adjust())
       return true;
   }

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -194,7 +194,13 @@ const struct group_opt_templ all_cmd_options[] = {
     {"clang-c-irep2-adjust-only",
      NULL,
      "Use the IREP2-native C adjuster instead of the legacy adjust pass "
-     "(Phase 6 hop-off; experimental, default off)"}}},
+     "(Phase 6 hop-off; experimental, default off)"},
+    {"clang-c-irep2-adjust-writeback-all",
+     NULL,
+     "Diagnostic: make the IREP2-native C adjuster refresh every symbol's "
+     "legacy value, not only the ones it changed. Without it a body the pass "
+     "did not touch still prints its converter tree under "
+     "--symbol-table-only, which is not what the pass produced"}}},
 #ifdef ENABLE_PYTHON_FRONTEND
   {"Python frontend",
    {


### PR DESCRIPTION
`adjust()` refreshes a symbol's legacy value only when the walk changed it, so
`--symbol-table-only` prints the *converter's* tree for every body the pass
left alone. The two differ wherever `migrate_expr` normalises, which made the
ternary array decay read as an unported arm when the IREP2 value was already
correct — §134.3 had it down as the next arm to write.

`--clang-c-irep2-adjust-writeback-all` shows what the pass produced. It is for
per-cause diagnosis, not a mode to verify in: forcing the write-back makes every
body pay `migrate_expr_back`'s losses and takes the stride-16 sample from 85
DIFF to 114. §135 re-scores §134.3's six — two are artefacts of this gate.

Nothing downstream changes: `goto_convert_functions.cpp` reads a body through
`get_value2()`. The stale class comment claiming the walk "never writes one
back" is corrected.

The two new tests pin opposite sides of the condition and were mutation-checked
against both mutants: ignoring the flag fails `..._all` only, removing the gate
fails `..._gated` only.

**Stacked on #7590**, which is stacked on #7588 — merge in that order.