### PR TITLE
[python] Bind a builtin call's keyword arguments to their parameters

### DIFF
--- a/regression/python/github_7557/main.py
+++ b/regression/python/github_7557/main.py
@@ -1,0 +1,15 @@
+# A keyword names a builtin's parameter; the value must reach that parameter
+# rather than falling back to its default (#7557).
+def main() -> None:
+    assert int("10", base=2) == 2
+    assert str(object=500) == "500"
+    assert round(1.567, ndigits=2) == 1.57
+    assert round(number=1.5) == 2
+    assert pow(base=2, exp=4) == 16
+    assert pow(2, 4, mod=3) == 1
+
+    b: int = 2
+    assert int("11", base=b) == 3
+
+
+main()

--- a/regression/python/github_7557/test.desc
+++ b/regression/python/github_7557/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7557_evalorder/main.py
+++ b/regression/python/github_7557_evalorder/main.py
@@ -1,0 +1,25 @@
+# Keywords written out of the builtin's declaration order must not be moved
+# into positional slots: Python evaluates arguments in source order, and
+# reordering these two calls crashes the converter (#7557). The property that
+# actually fails is an unrelated pre-existing "uncaught exception: TypeError"
+# false alarm, not seen[0] == 1; what this pins is that a verdict is reached
+# at all, rather than a SIGSEGV.
+seen: list[int] = []
+
+
+def f() -> int:
+    seen.append(1)
+    return 4
+
+
+def g() -> int:
+    seen.append(2)
+    return 2
+
+
+def main() -> None:
+    pow(exp=f(), base=g())
+    assert seen[0] == 1
+
+
+main()

--- a/regression/python/github_7557_evalorder/test.desc
+++ b/regression/python/github_7557_evalorder/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7557_extrakw_fail/main.py
+++ b/regression/python/github_7557_extrakw_fail/main.py
@@ -1,0 +1,9 @@
+# A keyword the rewrite cannot place must leave the whole call alone. Binding
+# only `object` here would drop `encoding` silently -- the #7557 failure mode,
+# reintroduced by the rewrite itself. CPython raises TypeError for this call.
+def main() -> None:
+    x = str(object=500, encoding="utf-8")
+    assert x == "500"
+
+
+main()

--- a/regression/python/github_7557_extrakw_fail/test.desc
+++ b/regression/python/github_7557_extrakw_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7557_fail/main.py
+++ b/regression/python/github_7557_fail/main.py
@@ -1,0 +1,6 @@
+# int("10", base=2) is 2, not the 10 the dropped keyword used to prove (#7557).
+def main() -> None:
+    assert int("10", base=2) == 10
+
+
+main()

--- a/regression/python/github_7557_fail/test.desc
+++ b/regression/python/github_7557_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7557_kwargs/main.py
+++ b/regression/python/github_7557_kwargs/main.py
@@ -1,0 +1,9 @@
+# A **kwargs splat carries no statically known names, so the rewrite must leave
+# the call alone: binding the splat to a positional slot turns int(**d) into
+# int(d) and crashes the converter (#7557).
+def main() -> None:
+    d: dict = {}
+    assert int(**d) == 0
+
+
+main()

--- a/regression/python/github_7557_kwargs/test.desc
+++ b/regression/python/github_7557_kwargs/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7557_localshadow_fail/main.py
+++ b/regression/python/github_7557_localshadow_fail/main.py
@@ -1,0 +1,13 @@
+# A binding of `int` local to another function still suppresses the keyword
+# rewrite module-wide, so the keyword is dropped and base's default proves the
+# wrong value. The same false proof as #7557, from a pattern that predates it.
+def helper() -> int:
+    int = 5
+    return int
+
+
+def main() -> None:
+    assert int("10", base=2) == 10
+
+
+main()

--- a/regression/python/github_7557_localshadow_fail/test.desc
+++ b/regression/python/github_7557_localshadow_fail/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7557_shadow/main.py
+++ b/regression/python/github_7557_shadow/main.py
@@ -1,0 +1,11 @@
+# A user function shadowing a builtin keeps its own parameter order: binding
+# these keywords to the builtin's slots would swap them (#7557).
+def pow(exp: int, base: int) -> int:
+    return exp - base
+
+
+def main() -> None:
+    assert pow(base=2, exp=4) == 2
+
+
+main()

--- a/regression/python/github_7557_shadow/test.desc
+++ b/regression/python/github_7557_shadow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7557_shadow_fail/main.py
+++ b/regression/python/github_7557_shadow_fail/main.py
@@ -1,0 +1,12 @@
+# Python resolves pow when the call runs, so this def below main() shadows the
+# builtin too. Binding the keywords to the builtin's own parameter order would
+# compute 204 and prove it; the user function's order does not (#7557).
+def main() -> None:
+    assert pow(base=2, exp=4) == 204
+
+
+def pow(exp: int, base: int) -> int:
+    return exp * 100 + base
+
+
+main()

--- a/regression/python/github_7557_shadow_fail/test.desc
+++ b/regression/python/github_7557_shadow_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -18,6 +18,16 @@ class CoreVisitorsMixin:
         "sort",
     }
     _PURE_DICT_METHODS = {"__getitem__", "copy", "get", "items", "keys", "values"}
+    # Positional-or-keyword parameters of the builtins whose call paths read
+    # positional arguments only, in declaration order (CPython 3.12). A leading
+    # positional-only parameter is spelled None so no keyword can bind it:
+    # int(x="10") is a TypeError, only int(x, base=...) names its second one.
+    _BUILTIN_POSITIONAL_PARAMS = {
+        "int": (None, "base"),
+        "pow": ("base", "exp", "mod"),
+        "round": ("number", "ndigits"),
+        "str": ("object", ),
+    }
     _PURE_LIST_CONSUMERS = {
         "abs",
         "all",
@@ -695,6 +705,64 @@ class CoreVisitorsMixin:
                 expected_args = self.functionParams[func_name]
                 kwonly_args = self.functionKwonlyParams.get(func_name, [])
         return function_name, expected_args, kwonly_args
+
+    def _scan_builtin_shadow_names(self, module_node):
+        """Builtin names from the table that this module binds anywhere.
+
+        Python resolves a name at call time, so a ``def pow(...)`` below the
+        call shadows the builtin exactly as one above it does. A syntactic pass
+        cannot answer that per scope, so over-approximate: any binding of the
+        name anywhere disables the rewrite for the whole module.
+        """
+        bound = set()
+        for n in ast.walk(module_node):
+            if isinstance(n, ast.Name) and isinstance(n.ctx, (ast.Store, ast.Del)):
+                bound.add(n.id)
+            elif isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                bound.add(n.name)
+            elif isinstance(n, ast.arg):
+                bound.add(n.arg)
+            elif isinstance(n, ast.ExceptHandler) and n.name:
+                bound.add(n.name)
+            elif isinstance(n, (ast.Import, ast.ImportFrom)):
+                bound.update(a.asname or a.name.split(".")[0] for a in n.names)
+        return bound & set(self._BUILTIN_POSITIONAL_PARAMS)
+
+    def _builtin_is_shadowed(self, name):
+        # None means the module was never scanned: assume shadowed, so an
+        # unscanned path keeps the pre-existing behaviour instead of rewriting.
+        return self._builtin_shadow_names is None or name in self._builtin_shadow_names
+
+    def _normalize_builtin_keyword_args(self, node):
+        """Move a builtin call's keywords into their positional slots (#7557).
+
+        The builtin call paths read node.args and never node.keywords, so a
+        keyword spelling silently falls back to the parameter default and
+        proves the wrong value. Rewrite only a run of keywords that fills the
+        slots directly after the positional arguments; anything else (a gap, an
+        unknown name, **kwargs) is left alone rather than guessed at.
+        """
+        if not isinstance(node.func, ast.Name) or not node.keywords:
+            return
+        params = self._BUILTIN_POSITIONAL_PARAMS.get(node.func.id)
+        if params is None or self._builtin_is_shadowed(node.func.id):
+            return
+        if any(kw.arg is None for kw in node.keywords):
+            return  # **kwargs splat: the names are not statically known
+        keywords = self._build_keyword_map(node)
+        bound = []
+        for param in params[len(node.args):]:
+            if param not in keywords:
+                break
+            bound.append(keywords.pop(param))
+        if keywords:
+            return
+        slots = params[len(node.args):len(node.args) + len(bound)]
+        if [kw.arg for kw in node.keywords] != list(slots) and not all(
+                isinstance(value, (ast.Constant, ast.Name)) for value in bound):
+            return  # Python evaluates arguments in source order (ref/expressions)
+        node.args = node.args + bound
+        node.keywords = []
 
     def _build_keyword_map(self, node):
         keywords = {}
@@ -1507,6 +1575,7 @@ class CoreVisitorsMixin:
         if rewritten_ratio is not None:
             return rewritten_ratio
 
+        self._normalize_builtin_keyword_args(node)
         self._normalize_int_from_bytes_endianness(node)
         self._normalize_math_gcd_lcm_variadic(node)
 

--- a/src/python-frontend/preprocessor/module_lifecycle_mixin.py
+++ b/src/python-frontend/preprocessor/module_lifecycle_mixin.py
@@ -32,6 +32,7 @@ class ModuleLifecycleMixin:
 
     def finalize_module(self, node):
         """Run generic_visit and inject helper nodes requested during traversal."""
+        self._builtin_shadow_names = self._scan_builtin_shadow_names(node)
         # Per-module scope for the eq-only set and call-origin map.
         saved_eq_only = set(self._eq_only_items_view_targets)
         self._eq_only_items_view_targets = (self._scan_eq_only_items_view_targets(node.body))

--- a/src/python-frontend/preprocessor/preprocessor_state_mixin.py
+++ b/src/python-frontend/preprocessor/preprocessor_state_mixin.py
@@ -17,6 +17,7 @@ class PreprocessorStateMixin:
         self.nondet_expand_counter = 0
         self.helper_functions_added = False
         self.functionKwonlyParams = {}
+        self._builtin_shadow_names = None
         self.functionVarargs = set()
         self._vararg_func_defs = {}
         self._vararg_module_defs = set()


### PR DESCRIPTION
The builtin call paths read `node.args` and never `node.keywords`, so
`int("10", base=2)` fell back to base's default and was *proved* equal to 10.
Bind a run of keywords to their positional slots for the builtins measured to
need it (`int`/`pow`/`round`/`str`), skipping any module that binds the name.

Refs #7557. One residual remains: a binding of the name anywhere in the module
suppresses the rewrite, so the same false proof survives that pattern — pinned
as KNOWNBUG in `github_7557_localshadow_fail`. Codecov will show an empty patch
because the preprocessor is FLAIL-mangled into the binary, not instrumented.