### PR TITLE
[python] Give a class used as a value a class-object representation

### DIFF
--- a/regression/python/github_7549/main.py
+++ b/regression/python/github_7549/main.py
@@ -1,0 +1,33 @@
+# A class or a builtin type name bound to a value is a class object: usable in
+# a class body, as a default argument, and distinguishable from another class
+# (#7549).
+class C:
+    pass
+
+
+class D:
+    pass
+
+
+class MyErr(Exception):
+    pass
+
+
+class Holder:
+    t = int
+    u = C
+
+
+def f(x: int, exc=MyErr) -> int:
+    return x
+
+
+def main() -> None:
+    x = C
+    y = C
+    assert x == y
+    assert x != D
+    assert f(1) == 1
+
+
+main()

--- a/regression/python/github_7549/test.desc
+++ b/regression/python/github_7549/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7549_fail/main.py
+++ b/regression/python/github_7549_fail/main.py
@@ -1,0 +1,19 @@
+# Two different classes bound as values are not equal (#7549).
+class C:
+    pass
+
+
+class D:
+    pass
+
+
+class Holder:
+    t = int
+
+
+def main() -> None:
+    x = C
+    assert x == D
+
+
+main()

--- a/regression/python/github_7549_fail/test.desc
+++ b/regression/python/github_7549_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7549_shadow/main.py
+++ b/regression/python/github_7549_shadow/main.py
@@ -1,0 +1,19 @@
+# A name rebound to a value resolves to that value, even where a class of the
+# same name exists: the class-object fallback must sit behind symbol lookup,
+# not ahead of it (#7549).
+class C:
+    pass
+
+
+class Item:
+    pass
+
+
+C = 5
+assert C == 5
+
+total = 0
+for Item in range(3):
+    total = total + Item
+
+assert total == 3

--- a/regression/python/github_7549_shadow/test.desc
+++ b/regression/python/github_7549_shadow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1635,13 +1635,18 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           // A bare class name used as a value, e.g. `register(SomeClass)` or
           // `create_publisher(topic, Twist)` -- passing the class object itself
           // as an argument. Python classes are first-class objects, but ESBMC
-          // has no first-class type value, so model it as an opaque nondet
-          // placeholder. Inert uses (storing or forwarding the class) then
-          // convert instead of aborting; constructing through such a forwarded
-          // value is not modelled.
+          // has no first-class type value, so model one the way a builtin type
+          // identifier is modelled: the class name as a string constant. A
+          // nondet placeholder made two reads of the same class unequal
+          // (#7549). Constructing through such a forwarded value is not
+          // modelled, and two same-named classes in different modules compare
+          // equal. This is reached only after symbol lookup fails, so a name
+          // rebound to a value still resolves to that value.
           if (is_class(var_name, *ast_json))
           {
-            expr = side_effect_expr_nondett(any_type());
+            typet str_type =
+              type_handler_.build_array(char_type(), var_name.size() + 1);
+            expr = constant_exprt(var_name, var_name, str_type);
             expr.location() = get_location_from_decl(element);
             break;
           }

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -1732,6 +1732,15 @@ std::string python_annotation<Json>::get_type_from_rhs_variable(
     if (iterable_builtins.count(rhs_var_name))
       return builtin_functions().at(rhs_var_name);
 
+    // A class or a builtin type name bound to a name is a class object; the
+    // converter gives both the same representation (#7549). The module-level
+    // pass recognises the builtin names on its own, but a class body and a
+    // default argument reach inference only through here.
+    if (
+      json_utils::is_class(rhs_var_name, ast_) ||
+      type_utils::is_type_identifier(rhs_var_name))
+      return "type";
+
     const auto &lineno = element["lineno"].template get<int>();
 
     std::ostringstream oss;


### PR DESCRIPTION
Binding a class to a name aborted type inference with `Variable C not found`,
and a class read as a value became a fresh nondet, so two reads of the same
class compared unequal. Resolve the name and model it as the class name, behind
symbol lookup so a name rebound to a value still resolves to that value.

Refs #7549 — `exc = ValueError` still aborts, because the exception model is not
in the AST unless the program uses exceptions. A class value is modelled as its
name, so two same-named classes in different modules are indistinguishable.