### PR TITLE
Allow immutable values in struct literals for constant propagation

### DIFF
--- a/regression/esbmc/nondet_struct_sibling_field_loop_bound/main.c
+++ b/regression/esbmc/nondet_struct_sibling_field_loop_bound/main.c
@@ -1,0 +1,26 @@
+/* A FOR loop with a fully static bound (1 TO 5) whose induction variable is
+ * a sibling field of a nondet-assigned struct member. Before the fix, any
+ * nondet write into one field made the whole struct's SSA value opaque, so
+ * the loop guard on the (otherwise perfectly concrete) counter field never
+ * folded to a literal: without an explicit --unwind, ESBMC's automatic
+ * loop-bound search never recognises the loop as bounded and unwinds it
+ * forever. This is a correctness sibling of #7524, which fixed a
+ * performance-only consequence of the same whole-struct-not-per-field SSA
+ * caching. */
+typedef struct
+{
+  float REAL_1;
+  int INT_1;
+} VAR_t;
+VAR_t VAR;
+float nondet_val;
+
+int main(void)
+{
+  VAR.INT_1 = 0;
+  VAR.REAL_1 = 0.0;
+  nondet_val = nondet_float();
+  for (VAR.INT_1 = 1; VAR.INT_1 <= 5; VAR.INT_1 = VAR.INT_1 + 1)
+    VAR.REAL_1 = nondet_val;
+  return 0;
+}

--- a/regression/esbmc/nondet_struct_sibling_field_loop_bound/test.desc
+++ b/regression/esbmc/nondet_struct_sibling_field_loop_bound/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-unwinding-assertions
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/nondet_struct_sibling_field_loop_bound_fail/main.c
+++ b/regression/esbmc/nondet_struct_sibling_field_loop_bound_fail/main.c
@@ -1,0 +1,25 @@
+/* Negative twin of nondet_struct_sibling_field_loop_bound: same sibling-field
+ * loop, but with an assertion on the counter's final value that must be
+ * refuted (the loop exits with INT_1 == 6, not 5). This proves the fix's
+ * folding is genuinely tracking the concrete field's value -- not merely
+ * suppressing the hang by giving up and reporting success -- and that ESBMC
+ * still terminates and finds the violation, rather than unwinding forever,
+ * once the sibling field can fold past the nondet one. */
+typedef struct
+{
+  float REAL_1;
+  int INT_1;
+} VAR_t;
+VAR_t VAR;
+float nondet_val;
+
+int main(void)
+{
+  VAR.INT_1 = 0;
+  VAR.REAL_1 = 0.0;
+  nondet_val = nondet_float();
+  for (VAR.INT_1 = 1; VAR.INT_1 <= 5; VAR.INT_1 = VAR.INT_1 + 1)
+    VAR.REAL_1 = nondet_val;
+  __ESBMC_assert(VAR.INT_1 == 5, "loop counter wrongly asserted 5 after natural exit");
+  return 0;
+}

--- a/regression/esbmc/nondet_struct_sibling_field_loop_bound_fail/main.c
+++ b/regression/esbmc/nondet_struct_sibling_field_loop_bound_fail/main.c
@@ -20,6 +20,7 @@ int main(void)
   nondet_val = nondet_float();
   for (VAR.INT_1 = 1; VAR.INT_1 <= 5; VAR.INT_1 = VAR.INT_1 + 1)
     VAR.REAL_1 = nondet_val;
-  __ESBMC_assert(VAR.INT_1 == 5, "loop counter wrongly asserted 5 after natural exit");
+  __ESBMC_assert(
+    VAR.INT_1 == 5, "loop counter wrongly asserted 5 after natural exit");
   return 0;
 }

--- a/regression/esbmc/nondet_struct_sibling_field_loop_bound_fail/test.desc
+++ b/regression/esbmc/nondet_struct_sibling_field_loop_bound_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-unwinding-assertions
+^\s*VAR\.INT_1 == 5$
+^VERIFICATION FAILED$

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -236,13 +236,15 @@ static bool aggregate_literal_may_propagate(
   const bool is_struct_literal = is_constant_struct2t(expr);
   bool noconst = true;
 
-  expr->foreach_operand([&](const expr2tc &e) {
-    if (
-      noconst &&
-      !((is_union_literal || is_struct_literal) && is_immutable_value(e)) &&
-      !state.constant_propagation(e))
-      noconst = false;
-  });
+  expr->foreach_operand(
+    [&](const expr2tc &e)
+    {
+      if (
+        noconst &&
+        !((is_union_literal || is_struct_literal) && is_immutable_value(e)) &&
+        !state.constant_propagation(e))
+        noconst = false;
+    });
   return noconst;
 }
 
@@ -294,10 +296,12 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
     // it can't itself be folded to a literal, but caching the arithmetic
     // expression built from it is still sound and lets a sibling field's
     // read walk past it structurally instead of hitting an opaque symbol.
-    expr->foreach_operand([this, &noconst](const expr2tc &e) {
-      if (noconst && !constant_propagation(e) && !is_immutable_value(e))
-        noconst = false;
-    });
+    expr->foreach_operand(
+      [this, &noconst](const expr2tc &e)
+      {
+        if (noconst && !constant_propagation(e) && !is_immutable_value(e))
+          noconst = false;
+      });
 
     return noconst;
   }

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -170,24 +170,43 @@ static bool is_const_foldable_arith(const expr2tc &e)
          is_modulus2t(e);
 }
 
-/// A (possibly typecast) symbol whose value can never change under
-/// it: a level2 SSA generation (assigned once) or a nondet$ free
-/// variable (never assigned; no level2 generation is minted for it).
-/// Unlike constant_propagation's bare-symbol nondet$ exclusion, the
-/// symbol here is a member value inside a recorded aggregate, so a
-/// member read folds to the free variable the trace shows anyway.
+/// A (possibly typecast, possibly member/constant-index-selected) value
+/// that can never change under it: ultimately a level2 SSA generation
+/// (assigned once) or a nondet$ free variable (never assigned; no level2
+/// generation is minted for it). Unlike constant_propagation's bare-symbol
+/// nondet$ exclusion, the symbol here is a member value inside a recorded
+/// aggregate, so a member read folds to the free variable the trace shows
+/// anyway.
+///
+/// The base a member/index chain bottoms out at may be an aggregate of any
+/// size -- a level2 (or nondet$) symbol is immutable regardless of its
+/// type, since SSA never reassigns it -- but only the caller's *scalar*
+/// projection of it (checked up front, on the original expression) is ever
+/// treated as immutable here, never the aggregate as a whole. That keeps
+/// this from reopening the infinite/oversized-aggregate concerns that keep
+/// constant_propagation from inlining a full aggregate value (see
+/// array_may_propagate): nothing this function green-lights ever gets
+/// embedded as one, only referenced through the same field/index selector
+/// the trace already carries.
 static bool is_immutable_value(const expr2tc &expr)
 {
-  const expr2tc *b = &expr;
-  while (is_typecast2t(*b))
-    b = &to_typecast2t(*b).from;
-  if (!is_symbol2t(*b))
+  if (!(is_number_type(expr->type) || is_bool_type(expr->type) ||
+        is_pointer_type(expr->type)))
     return false;
-  // Scalars only: an aggregate-typed symbol must keep going through
-  // constant_propagation, whose array_may_propagate refuses the
-  // infinite-size modelling arrays and oversized nests.
-  if (!(is_number_type((*b)->type) || is_bool_type((*b)->type) ||
-        is_pointer_type((*b)->type)))
+
+  const expr2tc *b = &expr;
+  for (;;)
+  {
+    if (is_typecast2t(*b))
+      b = &to_typecast2t(*b).from;
+    else if (is_member2t(*b))
+      b = &to_member2t(*b).source_value;
+    else if (is_index2t(*b) && is_constant_int2t(to_index2t(*b).index))
+      b = &to_index2t(*b).source_value;
+    else
+      break;
+  }
+  if (!is_symbol2t(*b))
     return false;
   const symbol2t &sym = to_symbol2t(*b);
   if (
@@ -200,17 +219,27 @@ static bool is_immutable_value(const expr2tc &expr)
 /// Whether a constant aggregate literal may propagate: every element
 /// must itself propagate. A union literal may also carry a (typecast)
 /// symbol as its initializing member — constant_union's init_field
-/// keeps a later cross-member read visible as one.
+/// keeps a later cross-member read visible as one. A struct literal gets
+/// the same allowance for an immutable (e.g. nondet-derived) member: unlike
+/// a union, distinct struct members don't alias, so one field carrying a
+/// free variable can't affect what a read of any *other*, still-constant
+/// field observes -- but caching nothing at all for the whole literal (the
+/// pre-fix behaviour) makes every field, including those still-constant
+/// ones, opaque to future member-of-with folding (e.g. a bounded loop whose
+/// counter is a sibling field of a nondet-assigned one would never be seen
+/// to terminate, unwinding forever).
 static bool aggregate_literal_may_propagate(
   const goto_symex_statet &state,
   const expr2tc &expr)
 {
   const bool is_union_literal = is_constant_union2t(expr);
+  const bool is_struct_literal = is_constant_struct2t(expr);
   bool noconst = true;
 
   expr->foreach_operand([&](const expr2tc &e) {
     if (
-      noconst && !(is_union_literal && is_immutable_value(e)) &&
+      noconst &&
+      !((is_union_literal || is_struct_literal) && is_immutable_value(e)) &&
       !state.constant_propagation(e))
       noconst = false;
   });
@@ -260,9 +289,13 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
     bool noconst = true;
 
     // Use noconst as a flag to indicate (and short-circuit) when a non
-    // constant propagatable expr is found.
+    // constant propagatable expr is found. An immutable (e.g. nondet-
+    // derived, possibly member/index-projected) operand is also fine here:
+    // it can't itself be folded to a literal, but caching the arithmetic
+    // expression built from it is still sound and lets a sibling field's
+    // read walk past it structurally instead of hitting an opaque symbol.
     expr->foreach_operand([this, &noconst](const expr2tc &e) {
-      if (noconst && !constant_propagation(e))
+      if (noconst && !constant_propagation(e) && !is_immutable_value(e))
         noconst = false;
     });
 
@@ -328,7 +361,18 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
           (is_struct_type(uv->type) || is_array_type(uv->type) ||
            is_union_type(uv->type)) &&
           type_has_constant_size(uv->type) && struct_is_fixed_size;
-        if (!(scalar_update || aggregate_update) || !constant_propagation(uv))
+        // A nondet (or otherwise never-reassigned) scalar sitting in one
+        // field must not poison propagation of the *other* fields: a
+        // member read of this same field folds to the free variable the
+        // trace shows anyway (see is_immutable_value), and a member read
+        // of any other field must still be able to walk past this WITH
+        // layer via member2t::do_simplify. Mirrors the union branch below
+        // (#7446), which already allows this for its aliasing-sensitive
+        // case; plain structs have independent fields, so it applies even
+        // more directly here.
+        if (
+          !(scalar_update || aggregate_update) ||
+          !(constant_propagation(uv) || is_immutable_value(uv)))
         {
           all_constant_updates = false;
           break;


### PR DESCRIPTION
## Summary

Extend constant propagation to allow struct literals containing immutable (nondet-derived or never-reassigned) member values, mirroring existing union literal handling. This enables folding of arithmetic expressions built from such members and improves field-level constant tracking in structs.

## Key Changes

- **Enhanced `is_immutable_value()`**: Now traverses member accesses and constant-index array selections in addition to typecasts, allowing detection of immutable values nested within aggregates. Added early scalar-type check to maintain the invariant that only scalar projections are treated as immutable.

- **Updated `aggregate_literal_may_propagate()`**: Extended to accept struct literals with immutable members alongside union literals. Added detailed comments explaining why structs can safely allow this: distinct struct members don't alias, so one field carrying a free variable cannot affect reads of other constant fields.

- **Refined arithmetic operand handling**: Modified the arithmetic expression case in `constant_propagation()` to accept immutable operands alongside constant-propagatable ones. This allows caching arithmetic expressions built from free variables, enabling structural folding of member reads past WITH layers.

- **Fixed struct WITH updates**: Corrected the condition for struct field updates to allow immutable (nondet-derived) values in one field without poisoning propagation of other fields. A member read of the immutable field folds to the free variable directly, while reads of other fields can still walk past the WITH layer.

## Implementation Details

The changes maintain the existing safety invariant that only scalar projections of immutable values are cached—never full aggregates. This prevents reopening infinite/oversized-aggregate concerns that constant_propagation avoids. All immutable values are ultimately referenced through the same field/index selectors the trace already carries, ensuring soundness.

https://claude.ai/code/session_01CsS4NWksrkYQCLEdrwVb3U