### PR TITLE
[python] Decode a folded code point in ord() instead of its first byte

### DIFF
--- a/regression/python/github_7552/main.py
+++ b/regression/python/github_7552/main.py
@@ -1,0 +1,12 @@
+# chr() folds a code point into its UTF-8 bytes, so ord() must decode the whole
+# sequence rather than read the first byte as a signed char (#7552).
+def main() -> None:
+    assert ord(chr(0)) == 0
+    assert ord(chr(65)) == 65
+    assert ord(chr(127)) == 127
+    assert ord(chr(128)) == 128
+    assert ord(chr(200)) == 200
+    assert ord(chr(1114111)) == 1114111
+
+
+main()

--- a/regression/python/github_7552/test.desc
+++ b/regression/python/github_7552/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7552_fail/main.py
+++ b/regression/python/github_7552_fail/main.py
@@ -1,0 +1,7 @@
+# -61 is 0xC3 read as a signed byte: the first byte of chr(200)'s UTF-8 form.
+# ord() is documented to return a value in [0, 0x10FFFF] (#7552).
+def main() -> None:
+    assert ord(chr(200)) == -61
+
+
+main()

--- a/regression/python/github_7552_fail/test.desc
+++ b/regression/python/github_7552_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7552_len/main.py
+++ b/regression/python/github_7552_len/main.py
@@ -1,0 +1,8 @@
+# chr(n) above 127 is still stored as its multi-byte UTF-8 form, so len() counts
+# encoding units instead of characters. Fixing that needs a code-point string
+# representation, not a change to ord() (#7552).
+def main() -> None:
+    assert len(chr(200)) == 1
+
+
+main()

--- a/regression/python/github_7552_len/test.desc
+++ b/regression/python/github_7552_len/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -357,6 +357,11 @@ private:
    * Rewrites the argument AST node into an integer Constant holding the given
    * code point and returns the resulting int expression. Helper for handle_ord.
    */
+  /// Code point of a constant char array -- what chr() folds to -- or nullopt
+  /// when @p e is not one. bytes are long_long_int arrays and are excluded, so
+  /// ord(b"\xc3") keeps its existing behaviour rather than becoming an error.
+  std::optional<int> folded_char_array_codepoint(const exprt &e) const;
+
   exprt build_ord_constant(nlohmann::json &arg, int code_point) const;
 
   /*

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -377,6 +377,21 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
     return migrate_expr_back(typecast2tc(migrate_type(int_type()), expr2));
   }
 
+  // chr() folds a code point into a constant char array of its UTF-8 bytes.
+  // The runtime path below reads only the first, sign-extended, so
+  // ord(chr(200)) came back as -61 (#7552). Reuse the same walk the Name path
+  // uses. The char-subtype test keeps bytes out: those are long_long_int
+  // arrays, and admitting them would turn ord(b"\xc3") into an error.
+  if (
+    expr.is_constant() && expr.type().is_array() &&
+    expr.type().subtype() == char_type() && expr.has_operands())
+  {
+    symbolt folded;
+    folded.set_value(expr);
+    if (auto text = extract_string_from_symbol(&folded); text && !text->empty())
+      return build_ord_constant(arg, decode_utf8_codepoint(*text));
+  }
+
   // A runtime string: return the code point of its first character.
   if (type_utils::is_string_type(expr.type()))
     return converter_.get_string_handler().handle_ord_conversion(

--- a/src/python-frontend/function_call/str_conv.cpp
+++ b/src/python-frontend/function_call/str_conv.cpp
@@ -334,6 +334,26 @@ exprt function_call_expr::build_ord_constant(
   return expr;
 }
 
+std::optional<int>
+function_call_expr::folded_char_array_codepoint(const exprt &e) const
+{
+  // Reuse the walk the Name path uses. The char-subtype test keeps bytes out:
+  // those are long_long_int arrays, and admitting them would turn
+  // ord(b"\xc3") into an error rather than 195.
+  if (
+    !e.is_constant() || !e.type().is_array() ||
+    e.type().subtype() != char_type() || !e.has_operands())
+    return std::nullopt;
+
+  symbolt folded;
+  folded.set_value(e);
+  auto text = extract_string_from_symbol(&folded);
+  if (!text || text->empty())
+    return std::nullopt;
+
+  return decode_utf8_codepoint(*text);
+}
+
 exprt function_call_expr::handle_ord(nlohmann::json &arg) const
 {
   // Fast path: constant string literal. Folding also handles multi-byte UTF-8
@@ -379,18 +399,9 @@ exprt function_call_expr::handle_ord(nlohmann::json &arg) const
 
   // chr() folds a code point into a constant char array of its UTF-8 bytes.
   // The runtime path below reads only the first, sign-extended, so
-  // ord(chr(200)) came back as -61 (#7552). Reuse the same walk the Name path
-  // uses. The char-subtype test keeps bytes out: those are long_long_int
-  // arrays, and admitting them would turn ord(b"\xc3") into an error.
-  if (
-    expr.is_constant() && expr.type().is_array() &&
-    expr.type().subtype() == char_type() && expr.has_operands())
-  {
-    symbolt folded;
-    folded.set_value(expr);
-    if (auto text = extract_string_from_symbol(&folded); text && !text->empty())
-      return build_ord_constant(arg, decode_utf8_codepoint(*text));
-  }
+  // ord(chr(200)) came back as -61 (#7552).
+  if (auto code_point = folded_char_array_codepoint(expr))
+    return build_ord_constant(arg, *code_point);
 
   // A runtime string: return the code point of its first character.
   if (type_utils::is_string_type(expr.type()))


### PR DESCRIPTION
`chr(n)` folds n into its UTF-8 bytes, and `ord()` read only the first of them
as a signed char, so `ord(chr(200))` was -61 and ESBMC proved it. Decode the
whole sequence, reusing the walk the `Name` path already uses.

Refs #7552 — `len(chr(200))` still counts encoding units; that needs a
code-point string representation, and is pinned as KNOWNBUG. `ord(chr(200)[0])`
remains a provable -61 on the untouched char-indexing path.