### PR TITLE
[om] Define std::reverse_iterator instead of only declaring it

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7535/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7535/main.cpp
@@ -1,0 +1,23 @@
+// std::reverse_iterator declared members but defined none, so explicit
+// construction was a PARSING ERROR and every member returned nondet (#7535).
+#include <cassert>
+#include <iterator>
+
+int main()
+{
+  double a[4] = {1, 2, 3, 4};
+  std::reverse_iterator<double *> r(a + 4);
+  assert(*r == 4.0);
+  ++r;
+  assert(*r == 3.0);
+  assert(r.base() == a + 3);
+
+  std::reverse_iterator<double *> d;
+  d = r;
+  assert(*d == 3.0);
+
+  std::reverse_iterator<double *> s = r + 1;
+  assert(*s == 2.0);
+  assert(r[0] == 3.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7535/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7535/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7535_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7535_fail/main.cpp
@@ -1,0 +1,12 @@
+// A reverse iterator refers to the element before its base ([reverse.iter.elem]),
+// so *reverse_iterator(a + 4) is a[3], not a[0] (#7535).
+#include <cassert>
+#include <iterator>
+
+int main()
+{
+  double a[4] = {1, 2, 3, 4};
+  std::reverse_iterator<double *> r(a + 4);
+  assert(*r == 1.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7535_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7535_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+
+^VERIFICATION FAILED$

--- a/src/cpp/library/iterator
+++ b/src/cpp/library/iterator
@@ -366,19 +366,103 @@ public:
   typedef typename std::iterator_traits<Iterator>::pointer pointer;
   typedef typename std::iterator_traits<Iterator>::reference reference;
 
-  Iterator base() const;
-  reference operator*() const;
-  reverse_iterator operator+(difference_type n) const;
-  reverse_iterator &operator++();
-  reverse_iterator operator++(int);
-  reverse_iterator &operator+=(difference_type n);
-  reverse_iterator operator-(difference_type n) const;
-  reverse_iterator &operator--();
-  reverse_iterator operator--(int);
-  reverse_iterator &operator-=(difference_type n);
-  pointer operator->() const;
-  reference operator[](difference_type n) const;
+  typedef Iterator iterator_type;
+
+  // [reverse.iter.cons]. Declaring these without definitions left the class
+  // unmodelled: explicit construction was a PARSING ERROR, and every member
+  // returned nondet, so dereferencing one was a false alarm (#7535).
+  reverse_iterator() : current()
+  {
+  }
+  explicit reverse_iterator(Iterator x) : current(x)
+  {
+  }
+  template <class U>
+  reverse_iterator(const reverse_iterator<U> &u) : current(u.base())
+  {
+  }
+
+  Iterator base() const
+  {
+    return current;
+  }
+
+  // [reverse.iter.elem]: a reverse iterator refers to the element before the
+  // one its base iterator addresses.
+  reference operator*() const
+  {
+    Iterator tmp = current;
+    return *--tmp;
+  }
+  pointer operator->() const
+  {
+    return &(operator*());
+  }
+  reference operator[](difference_type n) const
+  {
+    return current[-n - 1];
+  }
+
+  reverse_iterator operator+(difference_type n) const
+  {
+    return reverse_iterator(current - n);
+  }
+  reverse_iterator operator-(difference_type n) const
+  {
+    return reverse_iterator(current + n);
+  }
+  reverse_iterator &operator+=(difference_type n)
+  {
+    current -= n;
+    return *this;
+  }
+  reverse_iterator &operator-=(difference_type n)
+  {
+    current += n;
+    return *this;
+  }
+  reverse_iterator &operator++()
+  {
+    --current;
+    return *this;
+  }
+  reverse_iterator operator++(int)
+  {
+    reverse_iterator tmp = *this;
+    --current;
+    return tmp;
+  }
+  reverse_iterator &operator--()
+  {
+    ++current;
+    return *this;
+  }
+  reverse_iterator operator--(int)
+  {
+    reverse_iterator tmp = *this;
+    ++current;
+    return tmp;
+  }
+
+protected:
+  Iterator current;
 };
+
+template <class Iterator1, class Iterator2>
+bool operator==(
+  const reverse_iterator<Iterator1> &x,
+  const reverse_iterator<Iterator2> &y)
+{
+  return x.base() == y.base();
+}
+
+template <class Iterator1, class Iterator2>
+bool operator!=(
+  const reverse_iterator<Iterator1> &x,
+  const reverse_iterator<Iterator2> &y)
+{
+  return !(x == y);
+}
 
 template <
   class T,


### PR DESCRIPTION
The class declared its members but defined none and had no constructors, so
explicit construction was a PARSING ERROR and, once parsed, every member
returned nondet. Give it the [reverse.iter] semantics over a stored base
iterator, matching what vector's own nested class already models.

Fixes #7535