### PR TITLE
[python] Compare a dict keys view with a set by content

### DIFF
--- a/regression/python/github_7553/main.py
+++ b/regression/python/github_7553/main.py
@@ -1,0 +1,14 @@
+# A dict keys view is set-like: it compares equal to a set with the same
+# elements, in either order and regardless of ordering. A values view is not
+# set-like, and a plain list still never equals a set (#7553).
+def main() -> None:
+    assert {1: 1}.keys() == {1}
+    assert {1} == {1: 1}.keys()
+    assert {1: 1, 2: 2}.keys() == {2, 1}
+    assert {1: 1}.keys() != {2}
+    assert {1: 1}.values() != {1}
+    assert [1] != {1}
+    assert len({1: 1}.keys()) == 1
+
+
+main()

--- a/regression/python/github_7553/main.py
+++ b/regression/python/github_7553/main.py
@@ -8,6 +8,7 @@ def main() -> None:
     assert {1: 1}.keys() != {2}
     assert {1: 1}.values() != {1}
     assert [1] != {1}
+    assert {1: 1}.keys() != [1]
     assert len({1: 1}.keys()) == 1
 
 

--- a/regression/python/github_7553/test.desc
+++ b/regression/python/github_7553/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7553_attr_fail/main.py
+++ b/regression/python/github_7553_attr_fail/main.py
@@ -1,0 +1,14 @@
+# A user attribute called `keys` is not a dict view. It reaches the list
+# comparison as a `keys` member too, so matching on the member name alone
+# would wrongly prove this one (#7553).
+class Node:
+    def __init__(self) -> None:
+        self.keys = [1]
+
+
+def main() -> None:
+    n = Node()
+    assert n.keys != [1]
+
+
+main()

--- a/regression/python/github_7553_attr_fail/test.desc
+++ b/regression/python/github_7553_attr_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7553_fail/main.py
+++ b/regression/python/github_7553_fail/main.py
@@ -1,0 +1,7 @@
+# The keys view equals {1}, so != is false. This was proved before the view
+# was made set-like, whatever the contents (#7553).
+def main() -> None:
+    assert {1: 1}.keys() != {1}
+
+
+main()

--- a/regression/python/github_7553_fail/test.desc
+++ b/regression/python/github_7553_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7553_items_fail/main.py
+++ b/regression/python/github_7553_items_fail/main.py
@@ -1,0 +1,8 @@
+# An items view holds (key, value) pairs, so it never equals a set of bare
+# keys. It lowers to the same `keys` member as a keys view, so a comparison
+# keyed on the member name alone would wrongly prove this one (#7553).
+def main() -> None:
+    assert {1: 1}.items() == {1}
+
+
+main()

--- a/regression/python/github_7553_items_fail/test.desc
+++ b/regression/python/github_7553_items_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/regression/python/github_7553_ordering/main.py
+++ b/regression/python/github_7553_ordering/main.py
@@ -1,0 +1,6 @@
+# A keys view is set-like, so ordering it against a set is subset comparison,
+# which is not modelled. ESBMC must reject it explicitly rather than fall
+# through to the list comparator and return a wrong verdict (#7553).
+d = {1: 1}
+r = d.keys() <= {1, 2}
+assert r

--- a/regression/python/github_7553_ordering/test.desc
+++ b/regression/python/github_7553_ordering/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: set ordering \(<, <=, >, >=\) is not yet supported$

--- a/regression/python/github_7553_values_fail/main.py
+++ b/regression/python/github_7553_values_fail/main.py
@@ -1,0 +1,8 @@
+# A values view is deliberately not set-like: it compares unequal to a set
+# whatever it holds. Marking it set-like alongside keys() would prove this
+# one, which CPython says is false (#7553).
+def main() -> None:
+    assert {1: 1}.values() == {1}
+
+
+main()

--- a/regression/python/github_7553_values_fail/test.desc
+++ b/regression/python/github_7553_values_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -769,11 +769,8 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
         }
         exprt view = migrate_expr_back(
           member2tc(migrate_type(list_type), dict2, method_name));
-        // Only a keys view is set-like. The comparison layer sees a bare
-        // member and cannot tell one from the items placeholder above or from
-        // a user attribute called `keys` (#7553).
         if (method_name == "keys")
-          view.set("#python_keys_view", true);
+          view.set(PYTHON_KEYS_VIEW_ATTR, true);
         return view;
       }
     }

--- a/src/python-frontend/converter/converter_funcall.cpp
+++ b/src/python-frontend/converter/converter_funcall.cpp
@@ -767,9 +767,14 @@ exprt python_converter::get_function_call(const nlohmann::json &element)
           return migrate_expr_back(
             member2tc(migrate_type(list_type), dict2, "keys"));
         }
-        // Return the keys or values member directly
-        return migrate_expr_back(
+        exprt view = migrate_expr_back(
           member2tc(migrate_type(list_type), dict2, method_name));
+        // Only a keys view is set-like. The comparison layer sees a bare
+        // member and cannot tell one from the items placeholder above or from
+        // a user attribute called `keys` (#7553).
+        if (method_name == "keys")
+          view.set("#python_keys_view", true);
+        return view;
       }
     }
   }

--- a/src/python-frontend/python-list/list_query.cpp
+++ b/src/python-frontend/python-list/list_query.cpp
@@ -45,18 +45,12 @@ exprt python_list::compare(
   assert(lhs_symbol);
   assert(rhs_symbol);
 
-  // A dict keys view is set-like: it compares equal to a set holding the same
-  // elements. It reaches here as the dict's `keys` member, whose symbol is not
-  // marked, so exactly one operand was a set and the comparison folded to a
-  // constant whatever the contents (#7553). Treat it as a set for this
-  // comparison only -- marking it at the point d.keys() is lowered would drop
-  // the element type that slicing and tuple unpacking rely on.
-  auto is_dict_keys_view = [](const exprt &e) {
-    return e.id() == "member" &&
-           to_member_expr(e).get_component_name() == "keys";
+  // A dict keys view is set-like and must compare by content, not fold (#7553).
+  auto is_keys_view = [](const exprt &e) {
+    return e.get_bool("#python_keys_view");
   };
-  const bool lhs_is_set = lhs_symbol->is_set || is_dict_keys_view(l1);
-  const bool rhs_is_set = rhs_symbol->is_set || is_dict_keys_view(l2);
+  const bool lhs_is_set = lhs_symbol->is_set || is_keys_view(l1);
+  const bool rhs_is_set = rhs_symbol->is_set || is_keys_view(l2);
   if (lhs_is_set || rhs_is_set)
   {
     if (!(lhs_is_set && rhs_is_set))

--- a/src/python-frontend/python-list/list_query.cpp
+++ b/src/python-frontend/python-list/list_query.cpp
@@ -45,9 +45,8 @@ exprt python_list::compare(
   assert(lhs_symbol);
   assert(rhs_symbol);
 
-  // A dict keys view is set-like and must compare by content, not fold (#7553).
   auto is_keys_view = [](const exprt &e) {
-    return e.get_bool("#python_keys_view");
+    return e.get_bool(PYTHON_KEYS_VIEW_ATTR);
   };
   const bool lhs_is_set = lhs_symbol->is_set || is_keys_view(l1);
   const bool rhs_is_set = rhs_symbol->is_set || is_keys_view(l2);

--- a/src/python-frontend/python-list/list_query.cpp
+++ b/src/python-frontend/python-list/list_query.cpp
@@ -45,8 +45,18 @@ exprt python_list::compare(
   assert(lhs_symbol);
   assert(rhs_symbol);
 
-  const bool lhs_is_set = lhs_symbol->is_set;
-  const bool rhs_is_set = rhs_symbol->is_set;
+  // A dict keys view is set-like: it compares equal to a set holding the same
+  // elements. It reaches here as the dict's `keys` member, whose symbol is not
+  // marked, so exactly one operand was a set and the comparison folded to a
+  // constant whatever the contents (#7553). Treat it as a set for this
+  // comparison only -- marking it at the point d.keys() is lowered would drop
+  // the element type that slicing and tuple unpacking rely on.
+  auto is_dict_keys_view = [](const exprt &e) {
+    return e.id() == "member" &&
+           to_member_expr(e).get_component_name() == "keys";
+  };
+  const bool lhs_is_set = lhs_symbol->is_set || is_dict_keys_view(l1);
+  const bool rhs_is_set = rhs_symbol->is_set || is_dict_keys_view(l2);
   if (lhs_is_set || rhs_is_set)
   {
     if (!(lhs_is_set && rhs_is_set))

--- a/src/util/lang/python_types.h
+++ b/src/util/lang/python_types.h
@@ -49,6 +49,12 @@ bool returns_no_value(const typet &t);
 // constant, whose folding is what stops method-heavy programs from blowing up.
 #define PYTHON_UNRESOLVED_CALL_ATTR "#python_unresolved_call"
 
+// Marks a dict keys view, which is set-like and so compares with a set by
+// content. It must be stamped where `d.keys()` is lowered: by the time the
+// comparison sees it, it is a bare `keys` member indistinguishable from the
+// items placeholder or from a user attribute of that name.
+#define PYTHON_KEYS_VIEW_ATTR "#python_keys_view"
+
 // Stamp a Python internal-aggregate kind ("tuple", "dict", "optional") onto a
 // freshly created struct type.
 void set_python_aggregate_kind(typet &type, const irep_idt &kind);


### PR DESCRIPTION
A keys view compared with a set folded to a constant whatever the contents:
`==` failed and `!=` was proved. Route it through the existing set-equality
model, flagging the view at its lowering in `converter_funcall.cpp`, where
`keys()` is still distinguishable from the `items()` placeholder and from a
user attribute of that name — matching on the member name alone proves both.

Refs #7553. `regression/python/github_7553{,_fail,_items_fail,_attr_fail,_values_fail,_ordering}/`
cover the view, the two non-views, and the ordering refusal. Still on the old
path: an items view compared with a set of tuples, and a view bound to a name
before it is compared.