### PR TITLE
[python] Refuse same-named classes in two function bodies

### DIFF
--- a/regression/python/github_7541/main.py
+++ b/regression/python/github_7541/main.py
@@ -1,0 +1,18 @@
+# A class symbol carries no enclosing-scope component, so two functions each
+# defining a class named A would share one symbol and g() would silently run
+# f()'s constructor and return 1. Refuse rather than answer wrongly (#7541).
+def f() -> int:
+    class A:
+        def __init__(self) -> None:
+            self.x = 1
+    return A().x
+
+
+def g() -> int:
+    class A:
+        def __init__(self) -> None:
+            self.x = 2
+    return A().x
+
+
+assert g() == 2

--- a/regression/python/github_7541/test.desc
+++ b/regression/python/github_7541/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^ERROR: class 'A' is defined in more than one function body

--- a/regression/python/github_7541_control/main.py
+++ b/regression/python/github_7541_control/main.py
@@ -1,0 +1,22 @@
+# Distinctly named function-scope classes do not collide and must still verify
+# (#7541).
+def f() -> int:
+    class A:
+        def __init__(self) -> None:
+            self.x = 1
+    return A().x
+
+
+def g() -> int:
+    class B:
+        def __init__(self) -> None:
+            self.x = 2
+    return B().x
+
+
+def main() -> None:
+    assert f() == 1
+    assert g() == 2
+
+
+main()

--- a/regression/python/github_7541_control/test.desc
+++ b/regression/python/github_7541_control/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_class.cpp
+++ b/src/python-frontend/converter/converter_class.cpp
@@ -904,5 +904,21 @@ void python_converter::get_class_definition(
   const nlohmann::json &class_node,
   codet &target_block)
 {
+  // A class symbol is keyed by name alone, with no enclosing-scope component,
+  // so two functions each defining a class of the same name share one symbol:
+  // the second registration is dropped and the second function silently runs
+  // the first one's constructor, proving the wrong value (#7541). #6765 already
+  // makes is_class decline such a name; declining does not prevent the
+  // collision, so refuse the program rather than answer it wrongly.
+  const std::string &class_name = class_node["name"].get<std::string>();
+  if (
+    ast_json && json_utils::count_function_scope_classes(
+                  (*ast_json)["body"], class_name) > 1)
+    throw std::runtime_error(
+      "class '" + class_name +
+      "' is defined in more than one function body; ESBMC keys a class symbol "
+      "by name alone, so the definitions would share one symbol. Rename one of "
+      "them.");
+
   python_class_builder(*this, class_node).build(target_block);
 }


### PR DESCRIPTION
A class symbol carries no enclosing-scope component, so two functions each
defining a class of that name share one symbol: the second registration is
dropped and the second function silently runs the first one's constructor,
proving the wrong value. Refuse rather than answer wrongly.

Refs #7541 — the fix that would accept these programs is to key a class symbol
by its enclosing scope; this only stops the wrong answer.