### PR TITLE
[symex] Keep a sibling member's value when a member write is symbolic

### DIFF
--- a/regression/esbmc/github_7597-array/main.c
+++ b/regression/esbmc/github_7597-array/main.c
@@ -1,0 +1,19 @@
+/* Array counterpart of github_7597: the counter is an element of the same
+ * array whose other element is written a symbolic value. */
+#include <assert.h>
+
+int A[3];
+
+int nondet_int(void);
+
+int main(void)
+{
+  int in = nondet_int();
+
+  for (A[0] = 1; A[0] <= 5; A[0] = A[0] + 1)
+    A[1] = in;
+
+  assert(A[0] == 6);
+  assert(A[1] == in);
+  return 0;
+}

--- a/regression/esbmc/github_7597-array/test.desc
+++ b/regression/esbmc/github_7597-array/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_7597-array_fail/main.c
+++ b/regression/esbmc/github_7597-array_fail/main.c
@@ -1,0 +1,18 @@
+/* Negative counterpart of github_7597-array: the element written the symbolic
+ * value must keep it, not the counter's. */
+#include <assert.h>
+
+int A[3];
+
+int nondet_int(void);
+
+int main(void)
+{
+  int in = nondet_int();
+
+  for (A[0] = 1; A[0] <= 5; A[0] = A[0] + 1)
+    A[1] = in;
+
+  assert(A[1] == 6);
+  return 0;
+}

--- a/regression/esbmc/github_7597-array_fail/test.desc
+++ b/regression/esbmc/github_7597-array_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-standard-checks
+^\s*FAILED\s+\[main\.assertion\.\d+\]\s+line \d+\s+assertion A\[1\] == 6$
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_7597-chain-bound/main.c
+++ b/regression/esbmc/github_7597-chain-bound/main.c
@@ -1,0 +1,25 @@
+/* #7597's shape at the propagation cap: the counter is a member of the struct
+ * whose array member takes one symbolic write per iteration, so the guard
+ * folds only while those writes stay within symbolic_chain_bound. Anything
+ * above 128 hung before the cap was raised; 1000 leaves margin under it, so a
+ * future counted update turns this into a failure rather than a hang. */
+#include <assert.h>
+
+struct plc
+{
+  int step;
+  float out[1000];
+};
+
+struct plc VAR;
+
+float nondet_float(void);
+
+int main(void)
+{
+  for (VAR.step = 0; VAR.step < 1000; VAR.step = VAR.step + 1)
+    VAR.out[VAR.step] = nondet_float();
+
+  assert(VAR.step == 1000);
+  return 0;
+}

--- a/regression/esbmc/github_7597-chain-bound/test.desc
+++ b/regression/esbmc/github_7597-chain-bound/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_7597-chain-bound_fail/main.c
+++ b/regression/esbmc/github_7597-chain-bound_fail/main.c
@@ -1,0 +1,23 @@
+/* Negative counterpart of github_7597-chain-bound: the counter folds to 1000,
+ * so the claim below is refuted. It is reached only once the loop terminates,
+ * which needs the whole 1000-update chain to be carried. */
+#include <assert.h>
+
+struct plc
+{
+  int step;
+  float out[1000];
+};
+
+struct plc VAR;
+
+float nondet_float(void);
+
+int main(void)
+{
+  for (VAR.step = 0; VAR.step < 1000; VAR.step = VAR.step + 1)
+    VAR.out[VAR.step] = nondet_float();
+
+  assert(VAR.step == 999);
+  return 0;
+}

--- a/regression/esbmc/github_7597-chain-bound_fail/test.desc
+++ b/regression/esbmc/github_7597-chain-bound_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-standard-checks
+^\s*FAILED\s+\[main\.assertion\.\d+\]\s+line \d+\s+assertion VAR\.step == 999$
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_7597-chain-dropped/main.c
+++ b/regression/esbmc/github_7597-chain-dropped/main.c
@@ -1,0 +1,20 @@
+/* Past symbolic_chain_bound the `with` chain is dropped, which is silent and
+ * indistinguishable from an unexplained hang when the dropped chain also
+ * holds the loop counter (#7597). Here the counter is a local, so the loop
+ * still folds and the run only has to say once that it gave up. */
+#include <assert.h>
+
+int a[1025];
+
+int nondet_int(void);
+
+int main(void)
+{
+  int i;
+
+  for (i = 0; i < 1025; i = i + 1)
+    a[i] = nondet_int();
+
+  assert(i == 1025);
+  return 0;
+}

--- a/regression/esbmc/github_7597-chain-dropped/test.desc
+++ b/regression/esbmc/github_7597-chain-dropped/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-standard-checks
+^WARNING: constant propagation gave up on a `with` chain past 1024 symbolic updates
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_7597-chain-dropped_fail/main.c
+++ b/regression/esbmc/github_7597-chain-dropped_fail/main.c
@@ -1,0 +1,19 @@
+/* Negative counterpart of github_7597-chain-dropped: the local counter still
+ * folds to 1025 after the chain over `a` is dropped, so the claim below is
+ * refuted rather than the loop unwinding forever. */
+#include <assert.h>
+
+int a[1025];
+
+int nondet_int(void);
+
+int main(void)
+{
+  int i;
+
+  for (i = 0; i < 1025; i = i + 1)
+    a[i] = nondet_int();
+
+  assert(i == 1024);
+  return 0;
+}

--- a/regression/esbmc/github_7597-chain-dropped_fail/test.desc
+++ b/regression/esbmc/github_7597-chain-dropped_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.c
+--no-standard-checks
+^WARNING: constant propagation gave up on a `with` chain past 1024 symbolic updates
+^\s*FAILED\s+\[main\.assertion\.\d+\]\s+line \d+\s+assertion i == 1024$
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_7597-literal/main.c
+++ b/regression/esbmc/github_7597-literal/main.c
@@ -1,0 +1,29 @@
+/* The aggregate-literal arm of #7597, and the only one of the three not gated
+ * off under --k-induction / --incremental-bmc. One symbolic element used to
+ * drop the whole literal, so the sibling bounding this loop stayed symbolic
+ * and the loop never folded. (Under k-induction the verdict is the same
+ * either way -- it terminates by the forward condition, not by folding -- so
+ * plain BMC is where this arm is observable.) */
+#include <assert.h>
+
+struct pair
+{
+  int n;
+  int r;
+};
+
+int nondet_int(void);
+
+int main(void)
+{
+  int v = nondet_int();
+  struct pair s = {5, v};
+  int c = 0;
+
+  for (int i = 0; i < s.n; i++)
+    c++;
+
+  assert(c == 5);
+  assert(s.r == v);
+  return 0;
+}

--- a/regression/esbmc/github_7597-literal/test.desc
+++ b/regression/esbmc/github_7597-literal/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_7597-literal_fail/main.c
+++ b/regression/esbmc/github_7597-literal_fail/main.c
@@ -1,0 +1,25 @@
+/* Negative counterpart of github_7597-literal: the loop still has to fold for
+ * this claim to be reached, and the symbolic element must not read back as
+ * the literal beside it. */
+#include <assert.h>
+
+struct pair
+{
+  int n;
+  int r;
+};
+
+int nondet_int(void);
+
+int main(void)
+{
+  int v = nondet_int();
+  struct pair s = {5, v};
+  int c = 0;
+
+  for (int i = 0; i < s.n; i++)
+    c++;
+
+  assert(s.r == 5);
+  return 0;
+}

--- a/regression/esbmc/github_7597-literal_fail/test.desc
+++ b/regression/esbmc/github_7597-literal_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-standard-checks
+^\s*FAILED\s+\[main\.assertion\.\d+\]\s+line \d+\s+assertion s\.r == 5$
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_7597-merged-base/main.c
+++ b/regression/esbmc/github_7597-merged-base/main.c
@@ -1,0 +1,31 @@
+/* #7597, the shape where the struct carries no literal at all: the branch
+ * above the loop leaves VAR as a phi symbol, so the counter folds only if a
+ * `with` chain over that symbol may carry the symbolic sibling write. */
+#include <assert.h>
+
+struct plc
+{
+  int step;
+  int out;
+};
+
+struct plc VAR;
+
+int nondet_int(void);
+
+int main(void)
+{
+  int in = nondet_int();
+
+  if (nondet_int())
+    VAR.out = 1;
+  else
+    VAR.out = 2;
+
+  for (VAR.step = 1; VAR.step <= 5; VAR.step = VAR.step + 1)
+    VAR.out = in;
+
+  assert(VAR.step == 6);
+  assert(VAR.out == in);
+  return 0;
+}

--- a/regression/esbmc/github_7597-merged-base/test.desc
+++ b/regression/esbmc/github_7597-merged-base/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_7597-merged-base_fail/main.c
+++ b/regression/esbmc/github_7597-merged-base_fail/main.c
@@ -1,0 +1,30 @@
+/* Negative counterpart of github_7597-merged-base: the symbolic sibling write
+ * inside the loop must survive on the merged base, so VAR.out holds `in` and
+ * not the literal either branch left there. */
+#include <assert.h>
+
+struct plc
+{
+  int step;
+  int out;
+};
+
+struct plc VAR;
+
+int nondet_int(void);
+
+int main(void)
+{
+  int in = nondet_int();
+
+  if (nondet_int())
+    VAR.out = 1;
+  else
+    VAR.out = 2;
+
+  for (VAR.step = 1; VAR.step <= 5; VAR.step = VAR.step + 1)
+    VAR.out = in;
+
+  assert(VAR.out == 1);
+  return 0;
+}

--- a/regression/esbmc/github_7597-merged-base_fail/test.desc
+++ b/regression/esbmc/github_7597-merged-base_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-standard-checks
+^\s*FAILED\s+\[main\.assertion\.\d+\]\s+line \d+\s+assertion VAR\.out == 1$
+^VERIFICATION FAILED$

--- a/regression/esbmc/github_7597/main.c
+++ b/regression/esbmc/github_7597/main.c
@@ -1,0 +1,38 @@
+/* #7597: the loop counter is a member of the same struct whose other member
+ * is written a symbolic value. Propagation worked at whole-object
+ * granularity, so that one write dropped the counter with it, the guard never
+ * folded and symex unwound forever. No --unwind here: the bound has to come
+ * from propagation. */
+#include <assert.h>
+
+struct plc
+{
+  int step;
+  float out;
+};
+
+struct io
+{
+  float in;
+};
+
+struct plc VAR;
+struct io IO;
+
+float nondet_float(void);
+
+int main(void)
+{
+  IO.in = nondet_float();
+  /* A merge point, so IO carries no propagated constant afterwards. */
+  if (IO.in < -1.0e38f)
+    IO.in = -1.0e38f;
+  else if (IO.in > 1.0e38f)
+    IO.in = 1.0e38f;
+
+  for (VAR.step = 1; VAR.step <= 5; VAR.step = VAR.step + 1)
+    VAR.out = IO.in;
+
+  assert(VAR.step == 6);
+  return 0;
+}

--- a/regression/esbmc/github_7597/test.desc
+++ b/regression/esbmc/github_7597/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--no-standard-checks
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_7597_fail/main.c
+++ b/regression/esbmc/github_7597_fail/main.c
@@ -1,0 +1,35 @@
+/* Negative counterpart of github_7597: the counter folds to 6, so the claim
+ * below is refuted. It is reached only once the loop terminates, which is
+ * what whole-object propagation prevented (#7597). */
+#include <assert.h>
+
+struct plc
+{
+  int step;
+  float out;
+};
+
+struct io
+{
+  float in;
+};
+
+struct plc VAR;
+struct io IO;
+
+float nondet_float(void);
+
+int main(void)
+{
+  IO.in = nondet_float();
+  if (IO.in < -1.0e38f)
+    IO.in = -1.0e38f;
+  else if (IO.in > 1.0e38f)
+    IO.in = 1.0e38f;
+
+  for (VAR.step = 1; VAR.step <= 5; VAR.step = VAR.step + 1)
+    VAR.out = IO.in;
+
+  assert(VAR.step == 5);
+  return 0;
+}

--- a/regression/esbmc/github_7597_fail/test.desc
+++ b/regression/esbmc/github_7597_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--no-standard-checks
+^\s*FAILED\s+\[main\.assertion\.\d+\]\s+line \d+\s+assertion VAR\.step == 5$
+^VERIFICATION FAILED$

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -201,25 +201,38 @@ static bool is_const_foldable_arith(const expr2tc &e)
          is_modulus2t(e);
 }
 
-/// A (possibly typecast) symbol whose value can never change under
-/// it: a level2 SSA generation (assigned once) or a nondet$ free
-/// variable (never assigned; no level2 generation is minted for it).
-/// Unlike constant_propagation's bare-symbol nondet$ exclusion, the
-/// symbol here is a member value inside a recorded aggregate, so a
-/// member read folds to the free variable the trace shows anyway.
+/// A value that can never change once recorded: a level2 SSA generation
+/// (assigned once), a nondet$ free variable (never assigned; no level2
+/// generation is minted for it), or a member / fixed-index read out of one.
+/// Unlike constant_propagation's bare-symbol nondet$ exclusion, the value
+/// here sits inside a recorded aggregate, so the read folds to the free
+/// variable the trace shows anyway.
 static bool is_immutable_value(const expr2tc &expr)
 {
   const expr2tc *b = &expr;
   while (is_typecast2t(*b))
     b = &to_typecast2t(*b).from;
-  if (!is_symbol2t(*b))
-    return false;
-  // Scalars only: an aggregate-typed symbol must keep going through
+
+  // Scalars only: an aggregate-typed value must keep going through
   // constant_propagation, whose array_may_propagate refuses the
   // infinite-size modelling arrays and oversized nests.
   if (!(is_number_type((*b)->type) || is_bool_type((*b)->type) ||
         is_pointer_type((*b)->type)))
     return false;
+
+  // A member or fixed-index read is immutable exactly when the object read
+  // from is. Only the scalar leaf is carried, so array_may_propagate's refusal
+  // to propagate an array does not apply here.
+  while (!is_symbol2t(*b))
+  {
+    if (is_member2t(*b))
+      b = &to_member2t(*b).source_value;
+    else if (is_index2t(*b) && is_constant_int2t(to_index2t(*b).index))
+      b = &to_index2t(*b).source_value;
+    else
+      return false;
+  }
+
   const symbol2t &sym = to_symbol2t(*b);
   if (
     sym.rlevel == symbol_renaming_level::level2 ||
@@ -228,21 +241,37 @@ static bool is_immutable_value(const expr2tc &expr)
   return has_prefix(sym.thename.as_string(), "nondet$");
 }
 
-/// Whether a constant aggregate literal may propagate: every element
-/// must itself propagate. A union literal may also carry a (typecast)
-/// symbol as its initializing member — constant_union's init_field
-/// keeps a later cross-member read visible as one.
+/* Above this many symbolic updates a `with` chain is left symbolic. A carried
+ * chain is inlined at every read, so its cost is quadratic in its length;
+ * before #7597 a symbolic update ended the chain, capping it implicitly, and
+ * `for (i = 0; i < n; i++) a[i] = nondet();` is common enough that removing
+ * that cap outright costs 47s at n=3200 against 2.3s with it. Chains whose
+ * updates all propagate are unaffected, so pre-#7597 folding is unchanged. */
+static constexpr unsigned symbolic_chain_bound = 128;
+
+/// Whether a `with` update value may be carried, counting in @p symbolic the
+/// ones only is_immutable_value accepts -- the class #7597 admits, and the one
+/// symbolic_chain_bound caps.
+static bool update_may_propagate(
+  const goto_symex_statet &state,
+  const expr2tc &value,
+  unsigned &symbolic)
+{
+  if (state.constant_propagation(value))
+    return true;
+  return is_immutable_value(value) && ++symbolic <= symbolic_chain_bound;
+}
+
+/// Whether a constant aggregate literal may propagate: every element must
+/// itself propagate, or be immutable (#7597).
 static bool aggregate_literal_may_propagate(
   const goto_symex_statet &state,
   const expr2tc &expr)
 {
-  const bool is_union_literal = is_constant_union2t(expr);
   bool noconst = true;
 
   expr->foreach_operand([&](const expr2tc &e) {
-    if (
-      noconst && !(is_union_literal && is_immutable_value(e)) &&
-      !state.constant_propagation(e))
+    if (noconst && !is_immutable_value(e) && !state.constant_propagation(e))
       noconst = false;
   });
   return noconst;
@@ -338,6 +367,7 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
       // node.next_idx) concrete so pool loops fold instead of unrolling to
       // capacity.
       bool all_constant_updates = true;
+      unsigned symbolic_updates = 0;
       expr2tc current = expr;
 
       // Inlining an aggregate value is only sound when the whole enclosing
@@ -359,7 +389,9 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
           (is_struct_type(uv->type) || is_array_type(uv->type) ||
            is_union_type(uv->type)) &&
           type_has_constant_size(uv->type) && struct_is_fixed_size;
-        if (!(scalar_update || aggregate_update) || !constant_propagation(uv))
+        if (
+          !(scalar_update || aggregate_update) ||
+          !update_may_propagate(*this, uv, symbolic_updates))
         {
           all_constant_updates = false;
           break;
@@ -379,12 +411,13 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
     {
       // Check if this is a chain of WITHs with all constant updates
       bool all_constant_updates = true;
+      unsigned symbolic_updates = 0;
       expr2tc current = expr;
 
       while (is_with2t(current))
       {
         const with2t &w = to_with2t(current);
-        if (!constant_propagation(w.update_value))
+        if (!update_may_propagate(*this, w.update_value, symbolic_updates))
         {
           all_constant_updates = false;
           break;
@@ -403,7 +436,9 @@ bool goto_symex_statet::constant_propagation(const expr2tc &expr) const
       // A chain touching several fields is safe to carry: member2t::do_simplify
       // refuses to step past a `with` whose source is a union, so only a read
       // of the last-written field folds and every aliased read stays symbolic.
-      // #7446: an update may also be an immutable symbol, not just a literal.
+      // #7446: an update may also be an immutable symbol, not just a literal --
+      // a cross-member read folds through fold_union_member_read only at equal
+      // width, and correctly, because the carried value cannot change.
       for (const expr2tc *current = &expr; is_with2t(*current);
            current = &to_with2t(*current).source_value)
       {

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -216,9 +216,11 @@ static bool is_immutable_value(const expr2tc &expr)
 
   // Scalars only: an aggregate-typed value must keep going through
   // constant_propagation, whose array_may_propagate refuses the
-  // infinite-size modelling arrays and oversized nests.
-  if (!(is_number_type((*b)->type) || is_bool_type((*b)->type) ||
-        is_pointer_type((*b)->type)))
+  // infinite-size modelling arrays and oversized nests. Pointers are out too
+  // -- carrying one resolves a later dereference against the wrong object, a
+  // false "Incorrect alignment when accessing data object" on the iterator
+  // read in regression/esbmc-cpp/cpp/github_5868_list_iterator_adl.
+  if (!(is_number_type((*b)->type) || is_bool_type((*b)->type)))
     return false;
 
   // A member or fixed-index read is immutable exactly when the object read

--- a/src/goto-symex/goto_symex_state.cpp
+++ b/src/goto-symex/goto_symex_state.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <optional>
 #include <sstream>
+#include <utility>
 #include <util/expr/expr_util.h>
 #include <util/base/i2string.h>
 #include <util/base/prefix.h>
@@ -241,13 +242,15 @@ static bool is_immutable_value(const expr2tc &expr)
   return has_prefix(sym.thename.as_string(), "nondet$");
 }
 
-/* Above this many symbolic updates a `with` chain is left symbolic. A carried
- * chain is inlined at every read, so its cost is quadratic in its length;
- * before #7597 a symbolic update ended the chain, capping it implicitly, and
- * `for (i = 0; i < n; i++) a[i] = nondet();` is common enough that removing
- * that cap outright costs 47s at n=3200 against 2.3s with it. Chains whose
- * updates all propagate are unaffected, so pre-#7597 folding is unchanged. */
-static constexpr unsigned symbolic_chain_bound = 128;
+/* Raising this buys termination: a loop counter held in the aggregate being
+ * written (#7597) folds only while the writes stay under the bound. Above it
+ * the chain is left symbolic and the next update starts a fresh one, so a loop
+ * writing M elements of one aggregate walks O(M * symbolic_chain_bound) nodes,
+ * besides inlining the carried chain at every read. On
+ * `int a[M]; for (i = 0; i < M; i++) a[i] = nondet();` at M=8192: 0.7s at 128
+ * against 4.6s here. Chains whose updates all propagate are not counted, so
+ * pre-#7597 folding is unchanged. */
+static constexpr unsigned symbolic_chain_bound = 1024;
 
 /// Whether a `with` update value may be carried, counting in @p symbolic the
 /// ones only is_immutable_value accepts -- the class #7597 admits, and the one
@@ -259,7 +262,22 @@ static bool update_may_propagate(
 {
   if (state.constant_propagation(value))
     return true;
-  return is_immutable_value(value) && ++symbolic <= symbolic_chain_bound;
+  if (!is_immutable_value(value))
+    return false;
+  if (++symbolic <= symbolic_chain_bound)
+    return true;
+
+  // Warn once per process: dropping the chain is otherwise silent, and a loop
+  // bounded by a value held in the same object then unwinds forever with
+  // nothing in the output to say why.
+  static bool warned = false;
+  if (!std::exchange(warned, true))
+    log_warning(
+      "constant propagation gave up on a `with` chain past {} symbolic "
+      "updates; a loop bounded by a value held in the same object may not be "
+      "unwound to completion",
+      symbolic_chain_bound);
+  return false;
 }
 
 /// Whether a constant aggregate literal may propagate: every element must

--- a/unit/goto-symex/CMakeLists.txt
+++ b/unit/goto-symex/CMakeLists.txt
@@ -12,3 +12,4 @@ new_unit_test(value-set-merge-test "value_set_merge.test.cpp" "test_goto_factory
 new_unit_test(assumption-discharge-test "assumption_discharge.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(context-stack-test "context_stack.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
 new_unit_test(overapproximation-test "overapproximation.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")
+new_unit_test(constant-propagation-test "constant_propagation.test.cpp" "test_goto_factory;symex;solvers;gotoalgorithms;pointeranalysis;clangcppfrontend;clibs;filesystem;langapi")

--- a/unit/goto-symex/assumption_discharge.test.cpp
+++ b/unit/goto-symex/assumption_discharge.test.cpp
@@ -93,15 +93,18 @@ bool store_elided(const symex_target_equationt::SSA_stept &step)
 // the elision branch has to fire. Reading through an assertion, not the return
 // value, keeps the array live: a returned expression is itself sliced away, and
 // then the stores go with `ignore` rather than reaching the branch at all.
+// The values are expressions, not bare nondet symbols, for the reason
+// slice.test.cpp's "closure survives constant array indices" gives (#7597).
 const char *dead_array_store = R"(
 int nondet_int(void);
 int main(void)
 {
   int a[4];
-  a[0] = nondet_int();
-  a[1] = nondet_int();
-  a[2] = nondet_int();
-  a[3] = nondet_int();
+  int x = nondet_int();
+  a[0] = x + 1;
+  a[1] = x + 2;
+  a[2] = x + 3;
+  a[3] = x + 4;
   __ESBMC_assert(a[1] != 424242, "read one index");
   return 0;
 }

--- a/unit/goto-symex/constant_propagation.test.cpp
+++ b/unit/goto-symex/constant_propagation.test.cpp
@@ -1,0 +1,321 @@
+/*******************************************************************
+ Module: goto_symex_statet::constant_propagation on immutable leaves
+
+ Propagation is decided per symbol, but a member write is lowered to
+ `obj = with(obj, "f", v)`, so whether an object keeps a propagated value is
+ decided by the whole `with` chain. Before #7597 one symbolically-valued
+ member write dropped the object, taking a sibling loop counter's value with
+ it, and the loop guard never folded.
+
+ The regression tests in regression/esbmc/github_7597* pin the end-to-end
+ verdict. These pin the individual arms of the decision, which an end-to-end
+ test cannot separate: which leaf shapes count as immutable, and which of the
+ struct / array / literal paths carry one.
+
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <goto-symex/reachability_tree.h>
+#include <irep2/irep2_expr.h>
+#include <irep2/irep2_type.h>
+#include <irep2/irep2_utils.h>
+#include <util/lang/c_types.h>
+#include <util/symtab/namespace.h>
+
+#include "../testing-utils/goto_factory.h"
+
+namespace
+{
+/** Owns everything a real execution state needs to stay alive. */
+class engine
+{
+public:
+  engine()
+    : source("int main(void) { int x = 0; return x; }"),
+      prog(goto_factory::get_goto_functions(
+        source,
+        goto_factory::Architecture::BIT_64)),
+      ns(prog.context),
+      opts(goto_factory::get_default_options(
+        goto_factory::get_default_cmdline("test.c"))),
+      rt(
+        prog.functions,
+        ns,
+        opts,
+        std::make_shared<symex_target_equationt>(ns),
+        prog.context)
+  {
+    rt.setup_for_new_explore();
+  }
+
+  const goto_symex_statet &state()
+  {
+    return rt.get_cur_state().get_active_state();
+  }
+
+private:
+  std::string source;
+  program prog;
+  namespacet ns;
+  optionst opts;
+  reachability_treet rt;
+};
+
+expr2tc
+symbol_at(const type2tc &type, const char *name, symbol_renaming_level lev)
+{
+  return symbol2tc(type, irep_idt(name), lev, 0, 1, 0, 0);
+}
+
+expr2tc l2_int(const char *name = "c:test.c@F@main@v")
+{
+  return symbol_at(int_type2(), name, symbol_renaming_level::level2);
+}
+
+/** A nondet$ free variable: never assigned, so no L2 generation is minted. */
+expr2tc nondet_int_symbol()
+{
+  return symbol_at(
+    int_type2(), "nondet$symex::free_input", symbol_renaming_level::level0);
+}
+
+/** `struct { int i; int r; }`, the shape of #7597's counter and its sibling. */
+type2tc pair_struct()
+{
+  std::vector<type2tc> members{int_type2(), int_type2()};
+  std::vector<irep_idt> names{"i", "r"};
+  return struct_type2tc(members, names, names, "pair");
+}
+
+/** `struct { pair inner; }`, to build a nested member read. */
+type2tc nest_struct()
+{
+  std::vector<type2tc> members{pair_struct()};
+  std::vector<irep_idt> names{"inner"};
+  return struct_type2tc(members, names, names, "nest");
+}
+
+type2tc int_array(unsigned n)
+{
+  return array_type2tc(
+    int_type2(), constant_int2tc(size_type2(), BigInt(n)), false);
+}
+
+expr2tc int_const(int v)
+{
+  return constant_int2tc(int_type2(), BigInt(v));
+}
+
+/** `member(source, name)` at @p type. */
+expr2tc member_of(
+  const expr2tc &source,
+  const char *name,
+  const type2tc &type = int_type2())
+{
+  return member2tc(type, source, irep_idt(name));
+}
+
+/** `source[idx]` at @p type. */
+expr2tc index_of(
+  const expr2tc &source,
+  const expr2tc &idx,
+  const type2tc &type = int_type2())
+{
+  return index2tc(type, source, idx);
+}
+
+/** `with(source, field, value)`, the lowering of a member/element write. */
+expr2tc
+with_field(const expr2tc &source, const char *field, const expr2tc &value)
+{
+  const type2tc str_type =
+    array_type2tc(get_uint8_type(), gen_ulong(strlen(field) + 1), false);
+  return with2tc(
+    source->type,
+    source,
+    constant_string2tc(str_type, field, constant_string_kindt::DEFAULT),
+    value);
+}
+
+expr2tc
+with_index(const expr2tc &source, const expr2tc &idx, const expr2tc &value)
+{
+  return with2tc(source->type, source, idx, value);
+}
+} // namespace
+
+TEST_CASE(
+  "a member read out of an assigned-once object is propagatable",
+  "[symex][constant-propagation]")
+{
+  engine e;
+  const expr2tc obj = symbol_at(
+    pair_struct(), "c:test.c@F@main@IO", symbol_renaming_level::level2);
+
+  // The value #7597's loop body writes: IO.in, read out of an L2 generation.
+  REQUIRE(e.state().constant_propagation(with_field(
+    symbol_at(
+      pair_struct(), "c:test.c@F@main@VAR", symbol_renaming_level::level2),
+    "r",
+    member_of(obj, "i"))));
+}
+
+TEST_CASE(
+  "an immutable leaf reaches through nested member and index reads",
+  "[symex][constant-propagation]")
+{
+  engine e;
+  const expr2tc base = symbol_at(
+    pair_struct(), "c:test.c@F@main@VAR", symbol_renaming_level::level2);
+  const expr2tc arr =
+    symbol_at(int_array(4), "c:test.c@F@main@A", symbol_renaming_level::level2);
+  const expr2tc nest = symbol_at(
+    nest_struct(), "c:test.c@F@main@N", symbol_renaming_level::level2);
+  const expr2tc grid = symbol_at(
+    array_type2tc(int_array(4), gen_ulong(2), false),
+    "c:test.c@F@main@G",
+    symbol_renaming_level::level2);
+
+  // Each shape the peel loop accepts, as the update value of a struct chain.
+  const expr2tc leaves[] = {
+    l2_int(),
+    nondet_int_symbol(),
+    member_of(base, "i"),
+    member_of(member_of(nest, "inner", pair_struct()), "i"),
+    index_of(arr, int_const(2)),
+    index_of(index_of(grid, int_const(1), int_array(4)), int_const(0)),
+    typecast2tc(int_type2(), member_of(base, "i")),
+  };
+
+  for (const expr2tc &leaf : leaves)
+  {
+    CAPTURE(get_expr_id(leaf));
+    REQUIRE(e.state().constant_propagation(with_field(base, "r", leaf)));
+  }
+}
+
+TEST_CASE(
+  "a leaf that is not assigned-once is not propagatable",
+  "[symex][constant-propagation]")
+{
+  engine e;
+  const expr2tc base = symbol_at(
+    pair_struct(), "c:test.c@F@main@VAR", symbol_renaming_level::level2);
+  const expr2tc arr =
+    symbol_at(int_array(4), "c:test.c@F@main@A", symbol_renaming_level::level2);
+
+  // An L1 symbol still has generations to come, so a read of it is not fixed.
+  const expr2tc l1 =
+    symbol_at(int_type2(), "c:test.c@F@main@w", symbol_renaming_level::level1);
+  const expr2tc l1_struct = symbol_at(
+    pair_struct(), "c:test.c@F@main@P", symbol_renaming_level::level1);
+  // A symbolic index names a different element on each evaluation.
+  const expr2tc symbolic_index = index_of(arr, l2_int());
+  // add2t is neither a read nor a propagatable constant here.
+  const expr2tc arith = add2tc(int_type2(), l2_int(), l1);
+
+  for (const expr2tc &leaf :
+       {l1, member_of(l1_struct, "i"), symbolic_index, arith})
+  {
+    CAPTURE(get_expr_id(leaf));
+    REQUIRE_FALSE(e.state().constant_propagation(with_field(base, "r", leaf)));
+  }
+}
+
+TEST_CASE(
+  "an array chain carries an immutable element",
+  "[symex][constant-propagation]")
+{
+  engine e;
+  const expr2tc arr =
+    symbol_at(int_array(4), "c:test.c@F@main@A", symbol_renaming_level::level2);
+
+  // #7597's array half: A[1] written a symbolic value must not drop A[0].
+  REQUIRE(e.state().constant_propagation(
+    with_index(arr, int_const(1), nondet_int_symbol())));
+
+  REQUIRE_FALSE(e.state().constant_propagation(with_index(
+    arr,
+    int_const(1),
+    symbol_at(
+      int_type2(), "c:test.c@F@main@w", symbol_renaming_level::level1))));
+}
+
+TEST_CASE(
+  "an aggregate literal carries an immutable element",
+  "[symex][constant-propagation]")
+{
+  engine e;
+
+  // The union path already allowed this (#7446); struct and array literals
+  // are the arms #7597 opened.
+  std::vector<expr2tc> pair{int_const(1), nondet_int_symbol()};
+  REQUIRE(
+    e.state().constant_propagation(constant_struct2tc(pair_struct(), pair)));
+
+  std::vector<expr2tc> elems{int_const(0), l2_int()};
+  REQUIRE(
+    e.state().constant_propagation(constant_array2tc(int_array(2), elems)));
+
+  std::vector<expr2tc> mutable_elems{
+    int_const(0),
+    symbol_at(int_type2(), "c:test.c@F@main@w", symbol_renaming_level::level1)};
+  REQUIRE_FALSE(e.state().constant_propagation(
+    constant_array2tc(int_array(2), mutable_elems)));
+}
+
+TEST_CASE(
+  "an aggregate-typed leaf is decided by constant_propagation, not by "
+  "immutability",
+  "[symex][constant-propagation]")
+{
+  engine e;
+  const expr2tc base = symbol_at(
+    pair_struct(), "c:test.c@F@main@VAR", symbol_renaming_level::level2);
+
+  // The scalar guard: an L2 symbol of array type is still refused, so
+  // array_may_propagate keeps deciding the infinite-size modelling arrays.
+  const expr2tc inf_array = symbol_at(
+    array_type2tc(int_type2(), expr2tc(), true),
+    "c:test.c@F@main@__ESBMC_alloc",
+    symbol_renaming_level::level2);
+  REQUIRE_FALSE(e.state().constant_propagation(inf_array));
+
+  // But a fixed-index read out of one carries only the scalar leaf. This is
+  // the shape the peel permits rather than one observed in a C program: such
+  // reads normally carry a symbolic index, which the peel rejects.
+  REQUIRE(e.state().constant_propagation(
+    with_field(base, "r", index_of(inf_array, int_const(3)))));
+}
+
+TEST_CASE(
+  "a chain of symbolic updates is carried only up to the bound",
+  "[symex][constant-propagation]")
+{
+  engine e;
+  const expr2tc arr = symbol_at(
+    int_array(4096), "c:test.c@F@main@A", symbol_renaming_level::level2);
+
+  // Carrying a chain is quadratic in its length, so the updates only
+  // is_immutable_value accepts are counted and capped (#7597).
+  expr2tc chain = arr;
+  for (unsigned i = 0; i < 128; i++)
+    chain = with_index(chain, int_const(i), nondet_int_symbol());
+  REQUIRE(e.state().constant_propagation(chain));
+
+  REQUIRE_FALSE(e.state().constant_propagation(
+    with_index(chain, int_const(128), nondet_int_symbol())));
+
+  // Updates that propagate on their own are not counted, so a chain of them
+  // is carried at any length -- pre-#7597 behaviour is unchanged.
+  expr2tc literals = arr;
+  for (unsigned i = 0; i < 400; i++)
+    literals = with_index(literals, int_const(i), int_const(i));
+  REQUIRE(e.state().constant_propagation(literals));
+}

--- a/unit/goto-symex/constant_propagation.test.cpp
+++ b/unit/goto-symex/constant_propagation.test.cpp
@@ -17,7 +17,6 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#include <cstring>
 #include <string>
 #include <vector>
 
@@ -131,11 +130,13 @@ expr2tc index_of(
 }
 
 /** `with(source, field, value)`, the lowering of a member/element write. */
-expr2tc
-with_field(const expr2tc &source, const char *field, const expr2tc &value)
+expr2tc with_field(
+  const expr2tc &source,
+  const std::string &field,
+  const expr2tc &value)
 {
   const type2tc str_type =
-    array_type2tc(get_uint8_type(), gen_ulong(strlen(field) + 1), false);
+    array_type2tc(get_uint8_type(), gen_ulong(field.size() + 1), false);
   return with2tc(
     source->type,
     source,

--- a/unit/goto-symex/constant_propagation.test.cpp
+++ b/unit/goto-symex/constant_propagation.test.cpp
@@ -92,6 +92,14 @@ type2tc pair_struct()
   return struct_type2tc(members, names, names, "pair");
 }
 
+/** `struct { int i; int *p; }`, a counter beside a pointer member. */
+type2tc counter_and_pointer_struct()
+{
+  std::vector<type2tc> members{int_type2(), pointer_type2tc(int_type2())};
+  std::vector<irep_idt> names{"i", "p"};
+  return struct_type2tc(members, names, names, "held");
+}
+
 /** `struct { pair inner; }`, to build a nested member read. */
 type2tc nest_struct()
 {
@@ -227,6 +235,28 @@ TEST_CASE(
     CAPTURE(get_expr_id(leaf));
     REQUIRE_FALSE(e.state().constant_propagation(with_field(base, "r", leaf)));
   }
+}
+
+TEST_CASE("a pointer leaf is not immutable", "[symex][constant-propagation]")
+{
+  engine e;
+  const expr2tc base = symbol_at(
+    counter_and_pointer_struct(),
+    "c:test.c@F@main@VAR",
+    symbol_renaming_level::level2);
+
+  // The pointer is assigned-once, so it is as fixed as any other leaf, and it
+  // is still refused: carrying one resolves a later dereference against the
+  // wrong object (#7605).
+  const expr2tc ptr = symbol_at(
+    pointer_type2tc(int_type2()),
+    "c:test.c@F@main@q",
+    symbol_renaming_level::level2);
+  REQUIRE_FALSE(e.state().constant_propagation(with_field(base, "p", ptr)));
+
+  // Its integer sibling in the same struct still carries, so what the chain
+  // refuses is the type and not the write.
+  REQUIRE(e.state().constant_propagation(with_field(base, "i", l2_int())));
 }
 
 TEST_CASE(

--- a/unit/goto-symex/constant_propagation.test.cpp
+++ b/unit/goto-symex/constant_propagation.test.cpp
@@ -299,24 +299,27 @@ TEST_CASE(
   "a chain of symbolic updates is carried only up to the bound",
   "[symex][constant-propagation]")
 {
+  // goto_symex_state.cpp's symbolic_chain_bound, which is file-local there.
+  constexpr unsigned bound = 1024;
+
   engine e;
   const expr2tc arr = symbol_at(
-    int_array(4096), "c:test.c@F@main@A", symbol_renaming_level::level2);
+    int_array(bound + 2), "c:test.c@F@main@A", symbol_renaming_level::level2);
 
-  // Carrying a chain is quadratic in its length, so the updates only
+  // A carried chain is walked again at every write, so the updates only
   // is_immutable_value accepts are counted and capped (#7597).
   expr2tc chain = arr;
-  for (unsigned i = 0; i < 128; i++)
+  for (unsigned i = 0; i < bound; i++)
     chain = with_index(chain, int_const(i), nondet_int_symbol());
   REQUIRE(e.state().constant_propagation(chain));
 
   REQUIRE_FALSE(e.state().constant_propagation(
-    with_index(chain, int_const(128), nondet_int_symbol())));
+    with_index(chain, int_const(bound), nondet_int_symbol())));
 
   // Updates that propagate on their own are not counted, so a chain of them
   // is carried at any length -- pre-#7597 behaviour is unchanged.
   expr2tc literals = arr;
-  for (unsigned i = 0; i < 400; i++)
+  for (unsigned i = 0; i < bound + 2; i++)
     literals = with_index(literals, int_const(i), int_const(i));
   REQUIRE(e.state().constant_propagation(literals));
 }

--- a/unit/goto-symex/slice.test.cpp
+++ b/unit/goto-symex/slice.test.cpp
@@ -200,15 +200,21 @@ TEST_CASE("closure survives constant array indices", "[symex][slice]")
 {
   // scan_array_uses / index_reads: a store to one constant index may be elided
   // only if no retained read can observe it.
+  // The values are expressions, not bare nondet symbols: a chain of immutable
+  // updates propagates instead of reaching the slicer (#7597). One shared
+  // definition, so eliding the dead stores does not strand it -- an elided
+  // store's rhs still names its operands even though its encoding no longer
+  // does, and the audit below reads the rhs.
   symex_run::equation run(R"(
 int nondet_int(void);
 int main(void)
 {
   int arr[4];
-  arr[0] = nondet_int();
-  arr[1] = nondet_int();
-  arr[2] = nondet_int();
-  arr[3] = nondet_int();
+  int x = nondet_int();
+  arr[0] = x + 1;
+  arr[1] = x + 2;
+  arr[2] = x + 3;
+  arr[3] = x + 4;
   __ESBMC_assert(arr[1] != 424242, "read one index");
   return 0;
 }
@@ -229,16 +235,19 @@ int main(void)
 TEST_CASE("a symbolic array index disqualifies the array", "[symex][slice]")
 {
   // The shape H-A4's twin targets: with a symbolic index the slicer cannot know
-  // which element is read, so it must retain every store to that array.
+  // which element is read, so it must retain every store to that array. Same
+  // non-propagating stores as the case above, so the two differ only in the
+  // index and `elided_stores == 0` cannot hold for want of a store.
   symex_run::equation run(R"(
 int nondet_int(void);
 int main(void)
 {
   int arr[4];
-  arr[0] = nondet_int();
-  arr[1] = nondet_int();
-  arr[2] = nondet_int();
-  arr[3] = nondet_int();
+  int x = nondet_int();
+  arr[0] = x + 1;
+  arr[1] = x + 2;
+  arr[2] = x + 3;
+  arr[3] = x + 4;
   int i = nondet_int();
   __ESBMC_assume(i >= 0 && i < 4);
   __ESBMC_assert(arr[i] != 424242, "symbolic read");


### PR DESCRIPTION
Constant propagation is decided per symbol, but `symex_assign_member` lowers a
member write to `obj = with(obj, "f", v)`, so one symbolically-valued member
write dropped the whole object, including a sibling loop counter. The guard
never folded and symex unwound forever. Treat a member or fixed-index read of
an assigned-once value as immutable and carry it on the struct, array and
aggregate-literal paths, not only the union one.

This covers numeric and boolean members only. A carried pointer resolves a
later dereference against the wrong object, so a pointer-valued sibling write
still ends the chain and #7597's hang persists for that shape -- as it does on
master.

On the reporter's PLC model: 300s timeout / 790MB before, `VERIFICATION FAILED`
in 1.4s / 128MB after, the violation CBMC also reports. A carried chain costs
O(M * bound) on a loop writing M elements of one aggregate, so the newly
admitted updates are counted and capped at 1024; chains that propagated before
are untouched.

Fixes #7597
