### PR TITLE
[python] Render an f-string !r/!a conversion instead of a nondet string

### DIFF
--- a/regression/python/github_7559/main.py
+++ b/regression/python/github_7559/main.py
@@ -1,0 +1,12 @@
+# !r and !a render repr(): an int's digits, a string in quotes. These were
+# lowered to a nondet string, so any assertion about them failed (#7559).
+def main() -> None:
+    assert f'{"a"}' == 'a'
+    assert f'{"a"!s}' == 'a'
+    assert f'{"a"!r}' == "'a'"
+    assert f'{"a"!a}' == "'a'"
+    assert f'{1!r}' == '1'
+    assert f'{42!a}' == '42'
+
+
+main()

--- a/regression/python/github_7559/test.desc
+++ b/regression/python/github_7559/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7559_fail/main.py
+++ b/regression/python/github_7559_fail/main.py
@@ -1,0 +1,6 @@
+# repr('a') is "'a'", quotes included, so this does not hold (#7559).
+def main() -> None:
+    assert f'{"a"!r}' == 'a'
+
+
+main()

--- a/regression/python/github_7559_fail/test.desc
+++ b/regression/python/github_7559_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -1338,11 +1338,46 @@ exprt string_handler::get_fstring_expr(const nlohmann::json &element)
             : -1;
         if (conversion != -1 && conversion != 's')
         {
-          log_warning(
-            "f-string conversion '!{}' is not modelled: using a nondet "
-            "string",
-            static_cast<char>(conversion));
-          part_expr = build_nondet_string_fallback(expr.location());
+          // !r and !a render repr(): an int's digits, or a string in quotes.
+          // Fold the spellings whose repr is exactly that; anything needing an
+          // escape (quote, backslash, non-printable or non-ASCII byte) keeps
+          // the nondet, since reproducing CPython's quote choice and escaping
+          // here would be easy to get subtly wrong (#7559).
+          std::string repr;
+          const nlohmann::json &operand = value["value"];
+          const bool reprs = conversion == 'r' || conversion == 'a';
+          if (reprs && operand["_type"] == "Constant")
+          {
+            const nlohmann::json &literal = operand["value"];
+            if (literal.is_string())
+            {
+              const std::string text = literal.get<std::string>();
+              if (std::none_of(text.begin(), text.end(), [](unsigned char c) {
+                    return c < 0x20 || c > 0x7e || c == '\'' || c == '"' ||
+                           c == '\\';
+                  }))
+                repr = "'" + text + "'";
+            }
+            else if (literal.is_number_integer())
+              repr = std::to_string(literal.get<long long>());
+          }
+
+          if (!repr.empty())
+          {
+            typet string_type =
+              type_handler_.build_array(char_type(), repr.size() + 1);
+            std::vector<unsigned char> chars(repr.begin(), repr.end());
+            chars.push_back('\0');
+            part_expr = make_char_array_expr(chars, string_type);
+          }
+          else
+          {
+            log_warning(
+              "f-string conversion '!{}' is not modelled: using a nondet "
+              "string",
+              static_cast<char>(conversion));
+            part_expr = build_nondet_string_fallback(expr.location());
+          }
         }
         // Handle format specification if present
         else if (

--- a/src/python-frontend/string/string_handler.cpp
+++ b/src/python-frontend/string/string_handler.cpp
@@ -535,6 +535,52 @@ bool string_handler::try_extract_const_string_expr(
   return false;
 }
 
+std::string
+string_handler::fstring_repr_of_constant(const nlohmann::json &operand)
+{
+  if (operand["_type"] != "Constant")
+    return {};
+
+  const nlohmann::json &literal = operand["value"];
+  if (literal.is_number_integer())
+    return std::to_string(literal.get<long long>());
+
+  if (!literal.is_string())
+    return {};
+
+  const std::string text = literal.get<std::string>();
+  const bool needs_escape =
+    std::any_of(text.begin(), text.end(), [](unsigned char c) {
+      return c < 0x20 || c > 0x7e || c == '\'' || c == '"' || c == '\\';
+    });
+  return needs_escape ? std::string() : "'" + text + "'";
+}
+
+exprt string_handler::build_fstring_conversion(
+  const nlohmann::json &value,
+  int conversion,
+  const locationt &location)
+{
+  // !r and !a render repr(); fold the spellings whose repr is exactly the
+  // digits or the quoted text (#7559).
+  const bool reprs = conversion == 'r' || conversion == 'a';
+  const std::string repr =
+    reprs ? fstring_repr_of_constant(value["value"]) : std::string();
+
+  if (repr.empty())
+  {
+    log_warning(
+      "f-string conversion '!{}' is not modelled: using a nondet string",
+      static_cast<char>(conversion));
+    return build_nondet_string_fallback(location);
+  }
+
+  typet string_type = type_handler_.build_array(char_type(), repr.size() + 1);
+  std::vector<unsigned char> chars(repr.begin(), repr.end());
+  chars.push_back('\0');
+  return make_char_array_expr(chars, string_type);
+}
+
 exprt string_handler::build_nondet_string_fallback(const locationt &location)
 {
   // Sound over-approximation when a str.*() handler cannot extract a
@@ -1337,48 +1383,8 @@ exprt string_handler::get_fstring_expr(const nlohmann::json &element)
             ? value["conversion"].get<int>()
             : -1;
         if (conversion != -1 && conversion != 's')
-        {
-          // !r and !a render repr(): an int's digits, or a string in quotes.
-          // Fold the spellings whose repr is exactly that; anything needing an
-          // escape (quote, backslash, non-printable or non-ASCII byte) keeps
-          // the nondet, since reproducing CPython's quote choice and escaping
-          // here would be easy to get subtly wrong (#7559).
-          std::string repr;
-          const nlohmann::json &operand = value["value"];
-          const bool reprs = conversion == 'r' || conversion == 'a';
-          if (reprs && operand["_type"] == "Constant")
-          {
-            const nlohmann::json &literal = operand["value"];
-            if (literal.is_string())
-            {
-              const std::string text = literal.get<std::string>();
-              if (std::none_of(text.begin(), text.end(), [](unsigned char c) {
-                    return c < 0x20 || c > 0x7e || c == '\'' || c == '"' ||
-                           c == '\\';
-                  }))
-                repr = "'" + text + "'";
-            }
-            else if (literal.is_number_integer())
-              repr = std::to_string(literal.get<long long>());
-          }
-
-          if (!repr.empty())
-          {
-            typet string_type =
-              type_handler_.build_array(char_type(), repr.size() + 1);
-            std::vector<unsigned char> chars(repr.begin(), repr.end());
-            chars.push_back('\0');
-            part_expr = make_char_array_expr(chars, string_type);
-          }
-          else
-          {
-            log_warning(
-              "f-string conversion '!{}' is not modelled: using a nondet "
-              "string",
-              static_cast<char>(conversion));
-            part_expr = build_nondet_string_fallback(expr.location());
-          }
-        }
+          part_expr =
+            build_fstring_conversion(value, conversion, expr.location());
         // Handle format specification if present
         else if (
           value.contains("format_spec") && !value["format_spec"].is_null())

--- a/src/python-frontend/string/string_handler.h
+++ b/src/python-frontend/string/string_handler.h
@@ -80,6 +80,19 @@ public:
    * conclude a specific functional result, but we cannot wrongly conclude
    * SAFE either).
    */
+  /// repr() of a constant f-string operand under !r / !a, or empty when the
+  /// spelling is one this does not fold. Only an int's digits and a string
+  /// needing no escape are folded: reproducing CPython's quote choice and
+  /// escaping here would be easy to get subtly wrong (#7559).
+  static std::string fstring_repr_of_constant(const nlohmann::json &operand);
+
+  /// The rendered part for an f-string replacement field carrying a !r / !a
+  /// conversion: the folded repr where possible, else a sound nondet string.
+  exprt build_fstring_conversion(
+    const nlohmann::json &value,
+    int conversion,
+    const locationt &location);
+
   exprt build_nondet_string_fallback(const locationt &location);
 
   /**


### PR DESCRIPTION
The conversion was lowered to an unconstrained string, so every assertion about
it failed with nothing in the output to say a feature was missing. Fold the
spellings whose `repr` is exactly the digits or the quoted text; anything
needing an escape keeps the nondet rather than risk a wrong value.

Refs #7559 — a string containing a quote, backslash, non-printable or non-ASCII
byte still degrades to a nondet, and a bare `repr()` call is unchanged.