### PR TITLE
[python] Keep a bytes literal a byte array in argument position

### DIFF
--- a/regression/python/github_7550/main.py
+++ b/regression/python/github_7550/main.py
@@ -1,0 +1,24 @@
+# A bytes literal passed directly as an argument was rebuilt as a
+# NUL-terminated char array and reinterpret-cast to the parameter's element
+# pointer, so the callee read 8-byte elements out of a 3-byte object (#7550).
+def first(b: bytes) -> int:
+    return b[0]
+
+
+def size(b: bytes) -> int:
+    return len(b)
+
+
+def main() -> None:
+    assert first(b"\x01\x02") == 1
+    assert size(b"\x01\x02") == 2
+
+    a = b"\x01\x02"
+    assert first(a) == 1
+    assert first(bytes([1, 2])) == 1
+
+    # A plain string argument must still decay as a string.
+    assert len("ab") == 2
+
+
+main()

--- a/regression/python/github_7550/test.desc
+++ b/regression/python/github_7550/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7550_fail/main.py
+++ b/regression/python/github_7550_fail/main.py
@@ -1,0 +1,10 @@
+# b"\x01\x02"[0] is 1, not 2 (#7550).
+def first(b: bytes) -> int:
+    return b[0]
+
+
+def main() -> None:
+    assert first(b"\x01\x02") == 2
+
+
+main()

--- a/regression/python/github_7550_fail/test.desc
+++ b/regression/python/github_7550_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -6138,9 +6138,16 @@ std::optional<exprt> function_call_expr::build_positional_arguments(
     const bool arg_is_complex_literal =
       arg_node["_type"] == "Constant" &&
       arg_node.value("esbmc_type_annotation", std::string()) == "complex";
+    // A bytes literal's JSON carries a string "value" too, but get_literal
+    // already built it as a raw byte array (elements are long_long_int).
+    // Rebuilding it as a NUL-terminated char array here left the callee
+    // reading 8-byte elements out of a 3-byte object -- "array bounds
+    // violated" on valid Python (#7550).
+    const bool arg_is_bytes_literal =
+      arg_node["_type"] == "Constant" && converter_.is_bytes_literal(arg_node);
     if (
-      !arg_is_complex_literal && arg_node["_type"] == "Constant" &&
-      arg_node["value"].is_string())
+      !arg_is_complex_literal && !arg_is_bytes_literal &&
+      arg_node["_type"] == "Constant" && arg_node["value"].is_string())
     {
       std::string str_value = arg_node["value"].get<std::string>();
       arg = converter_.get_string_builder().build_string_literal(str_value);
@@ -6309,7 +6316,9 @@ std::optional<exprt> function_call_expr::build_positional_arguments(
             "parameters yet");
       }
 
-      if (arg_node["_type"] == "Constant" && arg_node["value"].is_string())
+      if (
+        arg_node["_type"] == "Constant" && arg_node["value"].is_string() &&
+        !arg_is_bytes_literal)
       {
         arg = string_constantt(
           arg_node["value"].get<std::string>(),


### PR DESCRIPTION
A bytes literal's JSON carries a string `value`, so the argument path rebuilt
the already-correct byte array as a NUL-terminated char array and
reinterpret-cast it to the parameter's element pointer. The callee then read
8-byte elements out of a 3-byte object, reporting `array bounds violated` on a
program CPython runs. Exclude bytes literals at both sites, mirroring the
complex-literal guard already next to one of them.

Refs #7550