### PR TITLE
[python] Consume a keyword moved into a positional slot

### DIFF
--- a/regression/python/github_7542/main.py
+++ b/regression/python/github_7542/main.py
@@ -1,0 +1,23 @@
+# A keyword moved into a positional slot stayed in node.keywords too, so the
+# node claimed the same parameter twice. A range loop visits its body a second
+# time, and the duplicate check then rejected the frontend's own output (#7542).
+def rslice(n: int, allow_empty: bool = False) -> int:
+    return n if allow_empty else 0
+
+
+def main() -> None:
+    total = 0
+    for _ in range(2):
+        total += rslice(3, allow_empty=True)
+    assert total == 6
+
+    once = 0
+    for _ in range(1):
+        once += rslice(3, allow_empty=True)
+    assert once == 3
+
+    assert rslice(3, allow_empty=True) == 3
+    assert rslice(3) == 0
+
+
+main()

--- a/regression/python/github_7542/test.desc
+++ b/regression/python/github_7542/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7542_fail/main.py
+++ b/regression/python/github_7542_fail/main.py
@@ -1,0 +1,14 @@
+# The keyword must still reach its parameter after the rewrite: with
+# allow_empty=True the call is 3, not 0 (#7542).
+def rslice(n: int, allow_empty: bool = False) -> int:
+    return n if allow_empty else 0
+
+
+def main() -> None:
+    total = 0
+    for _ in range(2):
+        total += rslice(3, allow_empty=True)
+    assert total == 0
+
+
+main()

--- a/regression/python/github_7542_fail/test.desc
+++ b/regression/python/github_7542_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/core_visitors_mixin.py
+++ b/src/python-frontend/preprocessor/core_visitors_mixin.py
@@ -918,9 +918,11 @@ class CoreVisitorsMixin:
             raise TypeError(
                 f"{display_name}() missing {len(missing_args)} required positional arguments: {args_str}"
             )
+        consumed = set()
         for i in range(len(node.args), len(expected_args)):
             if expected_args[i] in keywords:
                 node.args.append(keywords[expected_args[i]])
+                consumed.add(expected_args[i])
                 continue
             default_val = self.functionDefaults[(function_name, expected_args[i])]
             if isinstance(default_val, ast.AST):
@@ -930,6 +932,13 @@ class CoreVisitorsMixin:
                 node.args.append(default_expr)
             else:
                 node.args.append(ast.Constant(value=default_val))
+
+        # A keyword moved into a positional slot must leave node.keywords, or
+        # the node claims the same parameter twice. A range loop visits its body
+        # a second time, and the duplicate check then rejects the frontend's own
+        # output (#7542).
+        if consumed:
+            node.keywords = [kw for kw in node.keywords if kw.arg not in consumed]
 
     def _apply_call_signature_defaults(self, node):
         function_name, expected_args, kwonly_args = self._resolve_function_signature(node)


### PR DESCRIPTION
The rewrite appended the keyword's value to `node.args` but left the keyword in
`node.keywords`, so the node claimed the same parameter both positionally and by
keyword. A `range`-based `for` loop visits its body a second time, and the
duplicate-argument check then rejected the frontend's own output with a
`SyntaxError` on valid code.

Refs #7542