### PR TITLE
[om] Declare streamoff and streampos at namespace scope

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7540/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7540/main.cpp
@@ -1,0 +1,22 @@
+// [iosfwd.syn] declares streamoff and streampos at namespace scope; the model
+// had them only inside class ios, so the standard spelling did not parse
+// (#7540). Their width is unchanged and still not standard-conforming.
+#include <cassert>
+#include <ios>
+
+std::streamoff offset = 0;
+std::streampos position = 0;
+
+int main()
+{
+  assert(offset == 0);
+  assert(position == 0);
+
+  std::ios::pos_type p = 0;
+  std::ios::off_type o = 0;
+  assert(p == 0 && o == 0);
+
+  std::streamoff moved = offset + 7;
+  assert(moved == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7540/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7540/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7540_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7540_fail/main.cpp
@@ -1,0 +1,11 @@
+// The namespace-scope types must carry a real value, not merely parse: 7 is
+// not 0 (#7540).
+#include <cassert>
+#include <ios>
+
+int main()
+{
+  std::streamoff offset = 7;
+  assert(offset == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7540_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7540_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/src/cpp/library/ios
+++ b/src/cpp/library/ios
@@ -11,6 +11,14 @@ namespace std
 // definitions.h (github #6063).
 using ::streamsize;
 
+// [iosfwd.syn] declares both at namespace scope, and every seekoff/seekpos
+// signature spells them there; the model had them only inside class ios.
+// Their width is left as the model's int: the standard wants an offset wide
+// enough for the target's largest file, but widening them here changes every
+// out-of-line seekg/seekp signature in <istream>/<ostream> (#7540).
+typedef int streamoff;
+typedef int streampos;
+
 enum _Ios_Fmtflags
 {
   __boolalpha = 1L << 0,
@@ -159,8 +167,8 @@ public:
 class ios : public ios_base
 {
 public:
-  typedef int streampos;
-  typedef int streamoff;
+  typedef std::streampos streampos;
+  typedef std::streamoff streamoff;
 
   /* [ios.overview]. pos_type/off_type follow the model's int stream positions
    * (istream::tellg, ostream::tellp) rather than the traits' size_t/ptrdiff_t. */


### PR DESCRIPTION
The model declared both only inside `class ios`, so the standard spelling
`std::streamoff` did not parse. Declare them where [iosfwd.syn] puts them and
let `ios` alias them.

Refs #7540 — the width half is deliberately left out. Both are still `int`, which
cannot represent offsets past 2 GiB, but widening them changes every out-of-line
`seekg`/`seekp` signature in `<istream>`/`<ostream>`; `streampos` should also be
`fpos<...>`, a class type, which is a larger modelling change again.