### PR TITLE
[om] Give basic_streambuf its get and put areas

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7539/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7539/main.cpp
@@ -1,0 +1,47 @@
+// basic_streambuf declared the ten get/put area members and defined none,
+// and held no areas, so setg stored nothing and every accessor returned an
+// unconstrained pointer -- [streambuf.get.area]'s postconditions did not
+// hold after setg, on a buffer the program had just set up (#7539).
+#include <cassert>
+#include <streambuf>
+
+struct Buf : std::streambuf
+{
+  char data[4];
+  Buf()
+  {
+    data[0] = 'a';
+    data[1] = 'b';
+    data[2] = 'c';
+    data[3] = 'd';
+    setg(data, data, data + 4);
+  }
+  bool areas_set() const
+  {
+    return eback() == data && gptr() == data && egptr() == data + 4;
+  }
+  bool ordered() const
+  {
+    return eback() <= gptr() && gptr() <= egptr();
+  }
+  char cur() const
+  {
+    return *gptr();
+  }
+  void advance()
+  {
+    gbump(1);
+  }
+};
+
+int main()
+{
+  Buf b;
+  assert(b.areas_set());
+  assert(b.ordered());
+  assert(b.cur() == 'a');
+  b.advance();
+  assert(b.cur() == 'b');
+  assert(b.ordered());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7539/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7539/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7539_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7539_fail/main.cpp
@@ -1,0 +1,28 @@
+// After setg(data, data, data + 4) the get pointer is at data, so the current
+// character is 'a', not 'b' (#7539).
+#include <cassert>
+#include <streambuf>
+
+struct Buf : std::streambuf
+{
+  char data[4];
+  Buf()
+  {
+    data[0] = 'a';
+    data[1] = 'b';
+    data[2] = 'c';
+    data[3] = 'd';
+    setg(data, data, data + 4);
+  }
+  char cur() const
+  {
+    return *gptr();
+  }
+};
+
+int main()
+{
+  Buf b;
+  assert(b.cur() == 'b');
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7539_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7539_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/src/cpp/library/streambuf
+++ b/src/cpp/library/streambuf
@@ -75,24 +75,74 @@ public:
 
   //Protected member functions
 protected:
-  basic_streambuf();
+  // [streambuf.cons]: both areas start empty, i.e. all six pointers null.
+  basic_streambuf()
+    : __gbeg(0), __gnext(0), __gend(0), __pbeg(0), __pnext(0), __pend(0)
+  {
+  }
   virtual ~basic_streambuf()
   {
   }
 
+  // [streambuf.get.area] / [streambuf.put.area]. These were declared and never
+  // defined, and the class held no areas, so setg stored nothing and every
+  // accessor returned an unconstrained pointer: a derived buffer's underflow /
+  // overflow arithmetic ran over nondet rather than over the area it set up
+  // (#7539).
+  char_type *__gbeg;
+  char_type *__gnext;
+  char_type *__gend;
+  char_type *__pbeg;
+  char_type *__pnext;
+  char_type *__pend;
+
   //	Input sequence (get):
-  char_type *eback() const;
-  char_type *gptr() const;
-  char_type *egptr() const;
-  void gbump(int n);
-  void setg(char_type *gbeg, char_type *gnext, char_type *gend);
+  char_type *eback() const
+  {
+    return __gbeg;
+  }
+  char_type *gptr() const
+  {
+    return __gnext;
+  }
+  char_type *egptr() const
+  {
+    return __gend;
+  }
+  void gbump(int n)
+  {
+    __gnext += n;
+  }
+  void setg(char_type *gbeg, char_type *gnext, char_type *gend)
+  {
+    __gbeg = gbeg;
+    __gnext = gnext;
+    __gend = gend;
+  }
 
   //	Output sequence (put):
-  char_type *pbase() const;
-  char_type *pptr() const;
-  char_type *epptr() const;
-  void pbump(int n);
-  void setp(char_type *pbeg, char_type *pend);
+  char_type *pbase() const
+  {
+    return __pbeg;
+  }
+  char_type *pptr() const
+  {
+    return __pnext;
+  }
+  char_type *epptr() const
+  {
+    return __pend;
+  }
+  void pbump(int n)
+  {
+    __pnext += n;
+  }
+  void setp(char_type *pbeg, char_type *pend)
+  {
+    __pbeg = pbeg;
+    __pnext = pbeg;
+    __pend = pend;
+  }
 
   //Virtual protected member functions
   //	Locales


### PR DESCRIPTION
The ten area members were declared and never defined, and the class held no
areas, so `setg` stored nothing and every accessor returned an unconstrained
pointer: [streambuf.get.area]'s postconditions did not hold after a call to
`setg`, on a buffer the program had just set up. A derived buffer's
`underflow`/`overflow` arithmetic therefore ran over nondet rather than over its
own area. The default constructor is defined too, so both areas start empty as
[streambuf.cons] requires.

Refs #7539 — `github_7539_fail` fails on master as well, for a different reason
(nondet rather than a wrong value), so it does not distinguish the change;
`github_7539` is what pins it.