### PR TITLE
[docs] Point the VS Code extension links at its Open VSX listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d14d06e975644907a2eb9521e09ccfe4)](https://app.codacy.com/gh/esbmc/esbmc?utm_source=github.com&utm_medium=referral&utm_content=esbmc/esbmc&utm_campaign=Badge_Grade_Dashboard)
 [![codecov](https://codecov.io/gh/esbmc/esbmc/branch/master/graph/badge.svg)](https://codecov.io/gh/esbmc/esbmc)
 [![GitHub All Releases](https://img.shields.io/github/downloads/esbmc/esbmc/total.svg)](https://github.com/esbmc/esbmc/releases)
+[![Open VSX](https://img.shields.io/open-vsx/v/esbmc/vscode-esbmc?label=Open%20VSX)](https://open-vsx.org/extension/esbmc/vscode-esbmc)
 
 ESBMC (the Efficient SMT-based Context-Bounded Model Checker) is a mature, permissively licensed open-source context-bounded model checker that automatically detects or proves the absence of runtime errors in single- and multi-threaded C, C++, CUDA, CHERI, Kotlin, Python, Rust, and Solidity programs. It can automatically verify predefined safety properties (e.g., bounds check, pointer safety, overflow) and user-defined program assertions. 
 
@@ -95,7 +96,7 @@ You can also download the latest ESBMC binary for Ubuntu and Windows from the [r
 
 Three companion front-ends run ESBMC outside the terminal:
 
-- **Visual Studio Code** — the [ESBMC extension](https://github.com/esbmc/vscode-esbmc) verifies the file you are editing and reports results in the integrated terminal.
+- **Visual Studio Code** — the [ESBMC extension](https://open-vsx.org/extension/esbmc/vscode-esbmc) verifies the file you are editing and reports results in the integrated terminal.
 - **Web interface** — [ESBMC-Web](https://github.com/esbmc/esbmc-web) is a self-hosted browser GUI for C, C++ and Python, with a flag picker and an interactive dashboard for violations and counterexamples.
 - **Claude Code** — the [ESBMC plugin](https://github.com/esbmc/agent-marketplace) provides `/verify` and `/audit` commands, a verification skill, reference documentation, and examples.
 

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -16,7 +16,7 @@ requests landed in early August — Python function contracts, a user-facing
 {{< card link="https://ssvlab.github.io/" title="SSV Lab" icon="book-open" >}}
 {{< card link="https://github.com/esbmc/esbmc/releases/latest" title="Latest Release" icon="github" >}}
 {{< card link="https://github.com/esbmc/esbmc-web" title="Web Interface" icon="external-link" >}}
-{{< card link="https://github.com/esbmc/vscode-esbmc" title="VSCode Extension" icon="external-link" >}}
+{{< card link="https://open-vsx.org/extension/esbmc/vscode-esbmc" title="VSCode Extension" icon="external-link" >}}
 {{< card link="https://github.com/esbmc/agent-marketplace" title="Claude Code Plugin" icon="external-link" >}}
 {{< card link="https://esbmc.github.io/esbmc-ai" title="ESBMC-AI" icon="external-link" >}}
 {{< /cards >}}

--- a/website/content/docs/integrations.md
+++ b/website/content/docs/integrations.md
@@ -10,15 +10,15 @@ them too. For verification in CI rather than at the keyboard, see
 [GitHub Action](/docs/github-action).
 
 {{< cards >}}
-{{< card link="https://github.com/esbmc/vscode-esbmc" title="VS Code Extension" icon="external-link" >}}
+{{< card link="https://open-vsx.org/extension/esbmc/vscode-esbmc" title="VS Code Extension" icon="external-link" >}}
 {{< card link="https://github.com/esbmc/esbmc-web" title="Web Interface" icon="external-link" >}}
 {{< card link="https://github.com/esbmc/agent-marketplace" title="Claude Code Plugin" icon="external-link" >}}
 {{< /cards >}}
 
 ## Visual Studio Code
 
-[vscode-esbmc](https://github.com/esbmc/vscode-esbmc) verifies the file you are
-editing without leaving the editor. It contributes four command-palette entries:
+[vscode-esbmc](https://open-vsx.org/extension/esbmc/vscode-esbmc) verifies the
+file you are editing without leaving the editor. It contributes four command-palette entries:
 
 - `ESBMC: Verify file` — run ESBMC on the active C, C++, Python, Solidity or
   Jimple file and stream the output to the integrated terminal;
@@ -33,12 +33,12 @@ editing without leaving the editor. It contributes four command-palette entries:
 Note that it requires VS Code 1.68 or later. The install and update commands are Linux
 only; elsewhere, install ESBMC first via [Setup](/docs/setup).
 
-The extension is not on the VS Code Marketplace yet, so build the `.vsix` from
-source and install it from the Extensions view; the repository README has the
-walkthrough. Sideloading this way does not pull in the extension's dependency
-on `mindaro-dev.file-downloader`, which the install and update commands need.
-Publishing to the Marketplace and Open VSX is tracked in
-[vscode-esbmc#15](https://github.com/esbmc/vscode-esbmc/issues/15).
+Install it from [Open VSX](https://open-vsx.org/extension/esbmc/vscode-esbmc),
+which VS Codium and other VS Code derivatives use. It is not on the VS Code
+Marketplace yet; on VS Code itself, build the `.vsix` from source and install it
+from the Extensions view — the repository README has the walkthrough. Sideloading
+that way does not pull in the extension's dependency on
+`mindaro-dev.file-downloader`, which the install and update commands need.
 
 ## Web interface
 


### PR DESCRIPTION
The extension is published on Open VSX
(https://open-vsx.org/extension/esbmc/vscode-esbmc), so link the listing rather
than the repository and add the version badge.

Refs #7239 — only half of it. A Marketplace query for `esbmc` returns zero
extensions, so the listing link and install badge that issue asks for do not
exist yet; the sideload instructions stay, now scoped to VS Code itself rather
than presented as the only option.