### PR TITLE
[om] Declare the basic_* stream aliases in <iosfwd>

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7531/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7531/main.cpp
@@ -1,0 +1,25 @@
+// <iosfwd> forward-declared the concrete stream classes but none of the basic_*
+// alias templates, so a TU including only <iosfwd> could not name
+// std::basic_istream<char>. The aliases moved to <iosfwd>, where [iosfwd.syn]
+// declares them; repeating them in <istream>/<ostream>/<fstream> would declare
+// the default template argument twice, which clang rejects (#7531).
+#include <iosfwd>
+
+typedef std::basic_istream<char, std::char_traits<char> > IStream;
+typedef std::basic_ostream<char, std::char_traits<char> > OStream;
+typedef std::basic_iostream<char, std::char_traits<char> > IOStream;
+typedef std::basic_ifstream<char, std::char_traits<char> > IFStream;
+typedef std::basic_ofstream<char, std::char_traits<char> > OFStream;
+typedef std::basic_fstream<char, std::char_traits<char> > FStream;
+
+int main()
+{
+  IStream *a = 0;
+  OStream *b = 0;
+  IOStream *c = 0;
+  IFStream *d = 0;
+  OFStream *e = 0;
+  FStream *f = 0;
+  __ESBMC_assert(!a && !b && !c && !d && !e && !f, "iosfwd aliases usable");
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7531/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7531/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/src/cpp/library/fstream
+++ b/src/cpp/library/fstream
@@ -1,6 +1,7 @@
 #ifndef STL_FSTREAM
 #define STL_FSTREAM
 
+#include "iosfwd"
 #include "streambuf"
 #include "string"
 #include "istream"
@@ -155,15 +156,7 @@ public:
 };
 
 #if __cplusplus >= 201103L
-/* [fstream.syn]: the model's file streams are plain classes, so expose the
- * standard's template names as alias templates, as istream/ostream already do
- * (github #6063). Only the char instantiation is meaningful. */
-template <class CharT, class Traits = char_traits<CharT>>
-using basic_ifstream = ifstream;
-template <class CharT, class Traits = char_traits<CharT>>
-using basic_ofstream = ofstream;
-template <class CharT, class Traits = char_traits<CharT>>
-using basic_fstream = fstream;
+/* The basic_* file-stream alias templates are declared in <iosfwd> (#7531). */
 #endif
 
 //=====================fstream===================

--- a/src/cpp/library/iosfwd
+++ b/src/cpp/library/iosfwd
@@ -57,6 +57,26 @@ template <
   class Alloc = allocator<CharT> >
 class basic_stringstream;
 
+/* [iosfwd.syn] declares these alias templates here, and here only. The model's
+ * istream/ostream/file streams are concrete classes, so the standard's template
+ * names are alias templates onto them; only the char instantiation is
+ * meaningful. They must not be repeated in <istream>/<ostream>/<fstream>:
+ * clang rejects a default template argument declared twice (#7531). */
+#if __cplusplus >= 201103L
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_istream = istream;
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_ostream = ostream;
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_iostream = iostream;
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_ifstream = ifstream;
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_ofstream = ofstream;
+template <class CharT, class Traits = char_traits<CharT>>
+using basic_fstream = fstream;
+#endif
+
 typedef basic_stringbuf<char> stringbuf;
 typedef basic_istringstream<char> istringstream;
 typedef basic_ostringstream<char> ostringstream;

--- a/src/cpp/library/istream
+++ b/src/cpp/library/istream
@@ -1,6 +1,7 @@
 #ifndef STL_ISTREAM
 #define STL_ISTREAM
 
+#include "iosfwd"
 #include "ios"
 #include "definitions.h"
 #include "cstdio"
@@ -352,17 +353,9 @@ ios::streampos istream::tellg()
 {
   return _filepos;
 }
-#if __cplusplus >= 201103L
-template <class charT>
-struct char_traits;
-template <class CharT, class Traits = char_traits<CharT>>
-using basic_istream = istream;
-/* [istream.syn] declares basic_iostream here too; the model defines the class
- * itself in <iostream>, which every use that needs it complete includes. */
-class iostream;
-template <class CharT, class Traits = char_traits<CharT>>
-using basic_iostream = iostream;
-#endif
+/* basic_istream and basic_iostream are alias templates declared in <iosfwd>,
+ * which this header includes; repeating them here would declare the default
+ * template argument twice (#7531). */
 
 } // namespace std
 

--- a/src/cpp/library/ostream
+++ b/src/cpp/library/ostream
@@ -1,6 +1,7 @@
 #ifndef STL_OSTREAM
 #define STL_OSTREAM
 
+#include "iosfwd"
 #include "ios"
 #include "definitions.h"
 #include "cstring"
@@ -219,10 +220,7 @@ inline ostream &operator<<(ostream &o, const smanip &val)
 // names as alias templates so declarations mentioning
 // std::basic_ostream<CharT, Traits> parse (github #6063). Only the char
 // instantiation is meaningful.
-template <class charT>
-struct char_traits;
-template <class CharT, class Traits = char_traits<CharT>>
-using basic_ostream = ostream;
+/* basic_ostream is an alias template declared in <iosfwd> (#7531). */
 
 /* [ostream.rvalue] as amended by LWG 1203: the return type is the *derived*
  * stream, not basic_ostream, so `std::ostringstream{} << x` stays an


### PR DESCRIPTION
A TU including only `<iosfwd>` could not name `std::basic_istream<char>`: the
alias templates lived in `<istream>`/`<ostream>`/`<fstream>`. Move them to
`<iosfwd>`, where [iosfwd.syn] declares them, and include it from those headers.
Repeating them in both places would declare a default template argument twice,
which clang rejects.

Refs #7531