### PR TITLE
[solver] Convert a cast between array types instead of aborting

### DIFF
--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -806,6 +806,18 @@ smt_astt smt_solver_baset::convert_typecast(const expr2tc &expr)
     abort();
   }
 
+  // A cast between two array types of the same element type is a resize: the
+  // SMT array sort carries no length, so the source converts unchanged. Reached
+  // when a dynamic array's size is symbolic, e.g. a with2t over
+  // symex_dynamic::dynamic_N_array whose array_size is a member + 1 (#7544).
+  if (
+    is_array_type(cast.type) && is_array_type(cast.from->type) &&
+    base_type_eq(
+      to_array_type(cast.type).subtype,
+      to_array_type(cast.from->type).subtype,
+      ns))
+    return convert_ast(cast.from);
+
   log_error("Typecast for unexpected type\n{}", *expr);
   abort();
 }


### PR DESCRIPTION
`convert_typecast` handled a cast *to* an array type in one special case only
(the flexible-array-member workaround), so a `with2t` source fell past every
dispatch to `abort()`: SIGABRT, exit 134, no verdict. Two array types with the
same element type differ only in length, which the SMT array sort does not
carry, so the source converts unchanged. The arm sits immediately before that
`abort()`, and matches on the element type rather than on the target being an
array, so a genuine element-type change still aborts loudly.

Refs #7544 — no regression test. The issue's reproducer no longer aborts, but
its encoding does not reach a verdict, and I could not reduce it to a
terminating case that still produces a `with2t` cast to an array.