### PR TITLE
[clang-cpp-frontend] Initialise a member of an anonymous union or struct

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7560/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7560/main.cpp
@@ -1,0 +1,42 @@
+// A member reached through an anonymous union or struct is an
+// IndirectFieldDecl, a fourth CXXCtorInitializer kind the dispatch chain never
+// tested, so the constructor aborted with SIGABRT and no verdict. The member
+// also sits inside the anonymous field, not beside it (#7560).
+#include <cassert>
+
+struct WithUnion
+{
+  union
+  {
+    int a;
+    float b;
+  };
+  int tail;
+  WithUnion() : a(1), tail(2)
+  {
+  }
+};
+
+struct WithStruct
+{
+  struct
+  {
+    int x;
+    int y;
+  };
+  WithStruct() : x(3), y(4)
+  {
+  }
+};
+
+int main()
+{
+  WithUnion u;
+  assert(u.a == 1);
+  assert(u.tail == 2);
+
+  WithStruct s;
+  assert(s.x == 3);
+  assert(s.y == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7560/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7560/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7560_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7560_fail/main.cpp
@@ -1,0 +1,22 @@
+// The initializer must reach the member inside the anonymous struct, so x is
+// 3, not 4 (#7560).
+#include <cassert>
+
+struct S
+{
+  struct
+  {
+    int x;
+    int y;
+  };
+  S() : x(3), y(4)
+  {
+  }
+};
+
+int main()
+{
+  S s;
+  assert(s.x == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7560_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7560_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_convert.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_convert.cpp
@@ -2330,10 +2330,14 @@ bool clang_cpp_convertert::get_function_body(
         initializers.push_back(initializer);
         init_sym_uptodate = false;
       }
-      else if (init->isMemberInitializer())
+      else if (
+        init->isMemberInitializer() || init->isIndirectMemberInitializer())
       {
-        // parsing non-static member initializer
-        const clang::FieldDecl *member_decl = init->getMember();
+        // parsing non-static member initializer. A member reached through an
+        // anonymous union or struct is an IndirectFieldDecl, for which clang
+        // sets isIndirectMemberInitializer instead; getAnyMember() yields the
+        // underlying FieldDecl for both (#7560).
+        const clang::FieldDecl *member_decl = init->getAnyMember();
 
         exprt member;
         member.set("#member_init", 1);
@@ -2348,7 +2352,37 @@ bool clang_cpp_convertert::get_function_body(
         if (wrap_bitfield_type_if_needed(*member_decl, member.type()))
           return true;
 
-        build_member_from_component(fd, member);
+        // A member of an anonymous union/struct is not a component of the
+        // enclosing class: the anonymous field is, and the member sits inside
+        // it. IndirectFieldDecl::chain() runs outermost-first and ends at the
+        // member itself, so walking it yields this-><anon>.m; building
+        // this->m directly reads at the wrong offset (#7560).
+        if (init->isIndirectMemberInitializer())
+        {
+          exprt path;
+          bool rooted = false;
+          for (const clang::NamedDecl *nd : init->getIndirectMember()->chain())
+          {
+            const auto *link = llvm::dyn_cast<clang::FieldDecl>(nd);
+            if (!link)
+              return true;
+            exprt hop;
+            if (get_decl_ref(*link, hop))
+              return true;
+            if (!rooted)
+            {
+              build_member_from_component(fd, hop);
+              path = hop;
+              rooted = true;
+            }
+            else
+              path = member_exprt(path, hop.name(), hop.type());
+          }
+          member = path;
+        }
+        else
+          build_member_from_component(fd, member);
+
         // set #member_init flag again, as it has been cleared between the first call...
         member.set("#member_init", 1);
 


### PR DESCRIPTION
A member reached through an anonymous union or struct is an `IndirectFieldDecl`,
for which clang sets `isIndirectMemberInitializer()` — a fourth
`CXXCtorInitializer` kind the dispatch chain never tested, so the constructor
fell to the terminal `else` and aborted with SIGABRT and no verdict.

Handling the kind is not enough on its own: the member is not a component of the
enclosing class, the anonymous field is, so the access must walk
`IndirectFieldDecl::chain()`. Building `this->m` directly parses but reads at the
wrong offset and reports a spurious out-of-bounds.

Refs #7560