### PR TITLE
[om] Reach <exception>, <cstdlib>, <cctype> and <new> from <iostream>

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7536/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7536/main.cpp
@@ -1,0 +1,33 @@
+// libstdc++ and libc++ both reach <exception>, <cstdlib>, <cctype> and <new>
+// from <iostream>; the OM tree did not, so programs the host toolchain accepts
+// were a PARSING ERROR (#7536).
+#include <cassert>
+#include <iostream>
+
+void handler()
+{
+}
+
+struct S
+{
+  int x;
+};
+
+int main()
+{
+  std::set_terminate(handler);
+
+  char storage[sizeof(S)];
+  S *s = new (storage) S();
+  s->x = 2;
+  assert(s->x == 2);
+
+  assert(isalnum('a'));
+  assert(isalpha('a'));
+  assert(!isdigit('a'));
+
+  // EXIT_SUCCESS resolves through <cstdlib>; its value is corrected separately.
+  int status = EXIT_SUCCESS;
+  (void)status;
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7536/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7536/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7536_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7536_fail/main.cpp
@@ -1,0 +1,10 @@
+// The <cctype> functions reached through <iostream> must carry real semantics,
+// not merely resolve: 'a' is not a digit (#7536).
+#include <cassert>
+#include <iostream>
+
+int main()
+{
+  assert(isdigit('a'));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7536_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7536_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/iostream
+++ b/src/cpp/library/iostream
@@ -5,6 +5,13 @@
 #include "definitions.h"
 #include "istream"
 #include "ostream"
+/* libstdc++ and libc++ both reach these from <iostream>; programs that compile
+   against either rely on it, so not providing them is a false PARSING ERROR on
+   valid input (#7536). */
+#include "cctype"
+#include "cstdlib"
+#include "exception"
+#include "new"
 
 namespace std
 {


### PR DESCRIPTION
libstdc++ and libc++ both make these available through `<iostream>`, so a
program the host toolchain compiles cleanly was rejected with a `PARSING ERROR`
— `std::set_terminate`, placement `new`, and the `<cctype>` predicates all
resolve now.

Refs #7536 — two of the issue's three cases. `std::max` still does not resolve:
supplying it means including `<algorithm>` from `<iostream>`, which makes a
`std::transform` call ambiguous and breaks
`regression/esbmc-cpp/cpp/algorithm8_operator++_issue`. That ambiguity looks
like a separate defect and is left alone here.