### PR TITLE
[clang-c-frontend] Qualify a closure by its enclosing specialisation

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7528/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7528/main.cpp
@@ -1,0 +1,39 @@
+// A closure's name was keyed by file/line/column plus, since #6969, the
+// enclosing *function* template's specialisation. A lambda in a class-template
+// member (#7528) and a nested lambda (#7529) have no specialisation args on
+// their immediate context, so every instantiation but the first reused one
+// closure record and got an operator() with no body.
+#include <cassert>
+
+template <class T>
+struct S
+{
+  int g(int x)
+  {
+    auto a = [](int i) -> int { return i; };
+    auto b = [&](int i) -> int { return i + x + (int)sizeof(T); };
+    return a(1) + b(1);
+  }
+};
+
+template <unsigned long N>
+int f(int x)
+{
+  auto outer = [&](int i) -> int {
+    auto inner = [&](int j) -> int { return j + x + (int)N; };
+    return inner(i);
+  };
+  return outer(1);
+}
+
+int main()
+{
+  S<char> sc;
+  S<int> si;
+  assert(sc.g(5) == 1 + (1 + 5 + 1));
+  assert(si.g(5) == 1 + (1 + 5 + 4));
+
+  assert(f<2>(5) == 1 + 5 + 2);
+  assert(f<3>(5) == 1 + 5 + 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7528/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7528/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7528_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7528_fail/main.cpp
@@ -1,0 +1,20 @@
+// Each instantiation must get its own closure, so S<int>'s lambda sees
+// sizeof(int), not sizeof(char) (#7528).
+#include <cassert>
+
+template <class T>
+struct S
+{
+  int g(int x)
+  {
+    auto b = [&](int i) -> int { return i + x + (int)sizeof(T); };
+    return b(1);
+  }
+};
+
+int main()
+{
+  S<int> si;
+  assert(si.g(5) == 1 + 5 + 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7528_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7528_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -4919,12 +4919,35 @@ void clang_c_convertert::get_decl_name(
        * symex assigns a nondet return and the verdict is silently wrong
        * (esbmc/esbmc#6969). Qualify with the enclosing specialisation, which
        * is what clang's own USRs for the closure's methods already carry. */
-      const auto *parent =
-        llvm::dyn_cast_or_null<clang::FunctionDecl>(rd.getDeclContext());
-      if (parent && parent->getTemplateSpecializationArgs())
+      /* The same collision arises one level out: a lambda in a member function
+       * of a *class* template is a distinct type per instantiation, but the
+       * member carries no specialisation args -- the class does (#7528). A
+       * nested lambda adds a third shape: its context is the enclosing
+       * lambda's operator(), which carries none either (#7529). So walk out
+       * until a specialised context is found rather than testing only the
+       * immediate parent. */
+      const clang::FunctionDecl *qualifier = nullptr;
+      for (const clang::DeclContext *dc = rd.getDeclContext(); dc;
+           dc = dc->getParent())
+      {
+        const auto *fn = llvm::dyn_cast<clang::FunctionDecl>(dc);
+        if (!fn)
+          continue;
+        const auto *method = llvm::dyn_cast<clang::CXXMethodDecl>(fn);
+        if (
+          fn->getTemplateSpecializationArgs() ||
+          (method && llvm::isa<clang::ClassTemplateSpecializationDecl>(
+                       method->getParent())))
+        {
+          qualifier = fn;
+          break;
+        }
+      }
+
+      if (qualifier)
       {
         std::string parent_name, parent_id;
-        get_decl_name(*parent, parent_name, parent_id);
+        get_decl_name(*qualifier, parent_name, parent_id);
         name += "_" + parent_id;
       }
 


### PR DESCRIPTION
Since #6969 a closure's name carries the enclosing *function* template's
specialisation. A lambda in a class-template member carries none on its
immediate context — the class holds the specialisation — and a nested lambda's
context is the enclosing lambda's `operator()`, which carries none either. Both
therefore shared one closure record across instantiations, and every one but the
first got an `operator()` with no body: a false alarm on a program g++ accepts.

Walk out to the first specialised context instead of testing only the immediate
parent, which covers both shapes.

Fixes #7528, fixes #7529 — #7530 is a different collision (two lambdas at one
file/line/column from a single macro expansion) and is not addressed here.