### PR TITLE
[clang-c-frontend] Separate two lambdas from one macro expansion

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7528/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7528/main.cpp
@@ -1,0 +1,39 @@
+// A closure's name was keyed by file/line/column plus, since #6969, the
+// enclosing *function* template's specialisation. A lambda in a class-template
+// member (#7528) and a nested lambda (#7529) have no specialisation args on
+// their immediate context, so every instantiation but the first reused one
+// closure record and got an operator() with no body.
+#include <cassert>
+
+template <class T>
+struct S
+{
+  int g(int x)
+  {
+    auto a = [](int i) -> int { return i; };
+    auto b = [&](int i) -> int { return i + x + (int)sizeof(T); };
+    return a(1) + b(1);
+  }
+};
+
+template <unsigned long N>
+int f(int x)
+{
+  auto outer = [&](int i) -> int {
+    auto inner = [&](int j) -> int { return j + x + (int)N; };
+    return inner(i);
+  };
+  return outer(1);
+}
+
+int main()
+{
+  S<char> sc;
+  S<int> si;
+  assert(sc.g(5) == 1 + (1 + 5 + 1));
+  assert(si.g(5) == 1 + (1 + 5 + 4));
+
+  assert(f<2>(5) == 1 + 5 + 2);
+  assert(f<3>(5) == 1 + 5 + 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7528/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7528/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7528_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7528_fail/main.cpp
@@ -1,0 +1,20 @@
+// Each instantiation must get its own closure, so S<int>'s lambda sees
+// sizeof(int), not sizeof(char) (#7528).
+#include <cassert>
+
+template <class T>
+struct S
+{
+  int g(int x)
+  {
+    auto b = [&](int i) -> int { return i + x + (int)sizeof(T); };
+    return b(1);
+  }
+};
+
+int main()
+{
+  S<int> si;
+  assert(si.g(5) == 1 + 5 + 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7528_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7528_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_7530/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7530/main.cpp
@@ -1,0 +1,23 @@
+// Everything a macro expands reports the expansion location, so two lambdas in
+// one macro body shared a file, line and column; the second reused the first's
+// closure record and got an operator() with no body (#7530).
+#include <cassert>
+
+static int use(int (*p)(int), int (*q)(int), int x)
+{
+  return p(x) + q(x);
+}
+
+#define PAIR                                                                   \
+  [](int i) -> int { return i + 1; }, [](int i) -> int { return i - 1; }
+
+static int f(int x)
+{
+  return use(PAIR, x);
+}
+
+int main()
+{
+  assert(f(5) == (5 + 1) + (5 - 1));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7530/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7530/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7530_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7530_fail/main.cpp
@@ -1,0 +1,22 @@
+// The two lambdas must stay distinct: their results are 6 and 4, not 6 and 6
+// (#7530).
+#include <cassert>
+
+static int use(int (*p)(int), int (*q)(int), int x)
+{
+  return p(x) + q(x);
+}
+
+#define PAIR                                                                   \
+  [](int i) -> int { return i + 1; }, [](int i) -> int { return i - 1; }
+
+static int f(int x)
+{
+  return use(PAIR, x);
+}
+
+int main()
+{
+  assert(f(5) == (5 + 1) + (5 + 1));
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7530_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7530_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++17
+^VERIFICATION FAILED$

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -4951,6 +4951,18 @@ void clang_c_convertert::get_decl_name(
         name += "_" + parent_id;
       }
 
+      /* Everything a macro expands reports the expansion location, so two
+       * lambdas in one macro body share a file, line and column and the second
+       * reuses the first's record (esbmc/esbmc#7530). Their spelling locations
+       * inside the macro body differ, so add that offset. Clang's lambda
+       * mangling number does not help: it is 0 for both. */
+      const clang::SourceLocation dloc = rd.getLocation();
+      if (dloc.isMacroID() && sm)
+      {
+        const clang::SourceLocation spelling = sm->getSpellingLoc(dloc);
+        name += "_m" + std::to_string(sm->getFileOffset(spelling));
+      }
+
       std::replace(name.begin(), name.end(), '.', '_');
     }
     else if (

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -4919,12 +4919,35 @@ void clang_c_convertert::get_decl_name(
        * symex assigns a nondet return and the verdict is silently wrong
        * (esbmc/esbmc#6969). Qualify with the enclosing specialisation, which
        * is what clang's own USRs for the closure's methods already carry. */
-      const auto *parent =
-        llvm::dyn_cast_or_null<clang::FunctionDecl>(rd.getDeclContext());
-      if (parent && parent->getTemplateSpecializationArgs())
+      /* The same collision arises one level out: a lambda in a member function
+       * of a *class* template is a distinct type per instantiation, but the
+       * member carries no specialisation args -- the class does (#7528). A
+       * nested lambda adds a third shape: its context is the enclosing
+       * lambda's operator(), which carries none either (#7529). So walk out
+       * until a specialised context is found rather than testing only the
+       * immediate parent. */
+      const clang::FunctionDecl *qualifier = nullptr;
+      for (const clang::DeclContext *dc = rd.getDeclContext(); dc;
+           dc = dc->getParent())
+      {
+        const auto *fn = llvm::dyn_cast<clang::FunctionDecl>(dc);
+        if (!fn)
+          continue;
+        const auto *method = llvm::dyn_cast<clang::CXXMethodDecl>(fn);
+        if (
+          fn->getTemplateSpecializationArgs() ||
+          (method && llvm::isa<clang::ClassTemplateSpecializationDecl>(
+                       method->getParent())))
+        {
+          qualifier = fn;
+          break;
+        }
+      }
+
+      if (qualifier)
       {
         std::string parent_name, parent_id;
-        get_decl_name(*parent, parent_name, parent_id);
+        get_decl_name(*qualifier, parent_name, parent_id);
         name += "_" + parent_id;
       }
 


### PR DESCRIPTION
Everything a macro expands reports the expansion location, so two lambdas in one
macro body share a file, line and column: the second reused the first's closure
record and its `operator()` was left with no body, a false alarm on a program
g++ accepts. Their spelling locations inside the macro body differ, so add that
offset.

Clang's lambda mangling number does not help here — measured 0 for both.

Fixes #7530 — stacked on #7623, which fixes the sibling collisions #7528 and
#7529 in the same naming block; retarget to master once that merges.