### PR TITLE
[clang-c-frontend] Give the AST importer its shared lookup table

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7556/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7556/main.cpp
@@ -1,0 +1,17 @@
+// Merging a second C++ translation unit went through
+// DeclContext::localUncachedLookup once per imported decl, which is quadratic
+// in the destination context and did not finish on real multi-file projects.
+// This pins that a two-TU C++ merge still produces a working program (#7556).
+#include <cassert>
+#include <vector>
+
+int other_sum(const std::vector<int> &v);
+
+int main()
+{
+  std::vector<int> v;
+  v.push_back(2);
+  v.push_back(3);
+  assert(other_sum(v) == 5);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/github_7556/other.cpp
+++ b/regression/esbmc-cpp/cpp/github_7556/other.cpp
@@ -1,0 +1,10 @@
+#include <string>
+#include <vector>
+
+int other_sum(const std::vector<int> &v)
+{
+  int s = 0;
+  for (std::size_t i = 0; i < v.size(); ++i)
+    s += v[i];
+  return s;
+}

--- a/regression/esbmc-cpp/cpp/github_7556/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7556/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+other.cpp --std c++17
+^VERIFICATION SUCCESSFUL$

--- a/src/clang-c-frontend/AST/build_ast.cpp
+++ b/src/clang-c-frontend/AST/build_ast.cpp
@@ -3,6 +3,7 @@
 CC_DIAGNOSTIC_PUSH()
 CC_DIAGNOSTIC_IGNORE_LLVM_CHECKS()
 #include <clang/AST/ASTImporter.h>
+#include <clang/AST/ASTImporterSharedState.h>
 #include <clang/Basic/Version.inc>
 #include <clang/Driver/Compilation.h>
 #include <clang/Driver/Driver.h>
@@ -225,12 +226,23 @@ void mergeASTs(
   FromUnit->enableSourceFileDiagnostics();
   ToUnit->enableSourceFileDiagnostics();
 
+  /* Without a shared state the importer resolves every name through
+   * DeclContext::localUncachedLookup -- a linear, deliberately uncached scan of
+   * a destination context that grows with each imported decl, so merging is
+   * quadratic and two C++ TUs do not finish (#7556). Supplying the state gives
+   * ASTImporter::findDeclsInToCtx its hash-based lookup table instead; the
+   * header notes the fallback explicitly ("If not set then the original C/C++
+   * lookup is used"). */
+  auto SharedState = std::make_shared<clang::ASTImporterSharedState>(
+    *ToUnit->getASTContext().getTranslationUnitDecl());
+
   clang::ASTImporter Importer(
     ToUnit->getASTContext(),
     ToUnit->getFileManager(),
     FromUnit->getASTContext(),
     FromUnit->getFileManager(),
-    false);
+    false,
+    SharedState);
 
   Importer.setODRHandling(clang::ASTImporter::ODRHandlingType::Liberal);
 


### PR DESCRIPTION
Without a shared state the importer resolves every name through
`DeclContext::localUncachedLookup` — a linear, deliberately uncached scan of a
destination context that grows with each imported decl, so merging is quadratic.
`ASTImporter`'s own header notes the fallback: "If not set then the original
C/C++ lookup is used."

Reproducible on `MultiSource/Benchmarks/DOE-ProxyApps-C++/CLAMR` from the LLVM
test-suite, with `esbmc <files> --std c++17 --goto-functions-only -I.`:
`clamr_cpuonly.cpp + crux.cpp` goes from 180 s (timeout) to 1.2 s.

The merged program is a strict superset, not a smaller one: on
`clamr_cpuonly.cpp + partition.cpp` the table also recovers `_exit`, `getopt`,
`lseek` and `pipe`, which the linear path dropped. Pairs that merge to an empty
program (`+ state.cpp`, `+ mesh.cpp`, `+ MallocPlus.cpp`) do so on master too —
that is a separate defect this does not address.

The added test pins that a two-TU C++ merge still yields a working program; it
does not bite on the performance change, which needs the benchmark above.

Fixes #7556