### PR TITLE
[esbmc] Report a violation the invariant itself refutes

### DIFF
--- a/regression/loop-invariants/11-sum_overflow/test.desc
+++ b/regression/loop-invariants/11-sum_overflow/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.c
 --loop-invariant-check
-^WARNING: every violated claim lies downstream of a loop invariant havoc
-^VERIFICATION UNKNOWN$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/2-wrong_assertion/test.desc
+++ b/regression/loop-invariants/2-wrong_assertion/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^WARNING: every violated claim lies downstream of a loop invariant havoc
-^VERIFICATION UNKNOWN$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/check_if_bug/test.desc
+++ b/regression/loop-invariants/check_if_bug/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.c
 --loop-invariant-check
-^WARNING: every violated claim lies downstream of a loop invariant havoc
-^VERIFICATION UNKNOWN$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/count_up_down_bug/test.desc
+++ b/regression/loop-invariants/count_up_down_bug/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.c
 --loop-invariant-check
-^WARNING: every violated claim lies downstream of a loop invariant havoc
-^VERIFICATION UNKNOWN$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/dirkex_unsafe/test.desc
+++ b/regression/loop-invariants/dirkex_unsafe/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.c
 --loop-invariant-check
-^WARNING: every violated claim lies downstream of a loop invariant havoc
-^VERIFICATION UNKNOWN$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_call_fail/test.desc
+++ b/regression/loop-invariants/github_7478_call_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^\s+UNKNOWN\s+\[main\.assertion\.3\]\s+line\s+19\s+assertion 0 \(loop invariant too weak
-^VERIFICATION UNKNOWN$
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+19\s+assertion 0$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_dowhile_fail/test.desc
+++ b/regression/loop-invariants/github_7478_dowhile_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^\s+UNKNOWN\s+\[main\.assertion\.3\]\s+line\s+13\s+assertion x == 4 \(loop invariant too weak
-^VERIFICATION UNKNOWN$
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+13\s+assertion x == 4$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_fail/test.desc
+++ b/regression/loop-invariants/github_7478_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^\s+UNKNOWN\s+\[main\.assertion\.3\]\s+line\s+13\s+assertion 0 \(loop invariant too weak
-^VERIFICATION UNKNOWN$
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+13\s+assertion 0$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7478_shortcircuit_fail/test.desc
+++ b/regression/loop-invariants/github_7478_shortcircuit_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.c
 --loop-invariant-check --multi-property
-^\s+UNKNOWN\s+\[main\.assertion\.3\]\s+line\s+12\s+assertion 0 \(loop invariant too weak
-^VERIFICATION UNKNOWN$
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+12\s+assertion 0$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7585/main.c
+++ b/regression/loop-invariants/github_7585/main.c
@@ -1,0 +1,29 @@
+/* Regression: GitHub #7585 -- the downgrade added in #7491 was decided by the
+ * claim's position rather than by whether the invariant pins the
+ * counterexample. Here `sn == (i - 1) * a` together with the exit condition
+ * gives `i == n + 1` and so `sn == n * a`, which contradicts the assertion for
+ * every n and a: no abstract state satisfies it, so the violation is real. */
+#include <assert.h>
+#include <stdint.h>
+
+int main(void)
+{
+  uint32_t n;
+  uint64_t a;
+  uint64_t i = 1, sn = 0;
+
+  __ESBMC_assume(n >= 1);
+
+  __ESBMC_loop_invariant(
+    (i <= (uint64_t)n || i == (uint64_t)n + 1) && i >= 1 &&
+    sn == (i - 1) * a);
+
+  while (i <= n)
+  {
+    sn = sn + a;
+    i++;
+  }
+
+  assert(sn == (uint64_t)n * a + 1);
+  return 0;
+}

--- a/regression/loop-invariants/github_7585/test.desc
+++ b/regression/loop-invariants/github_7585/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+FAILED\s+\[main\.assertion\.3\]\s+line\s+27\s+assertion sn == \(uint64_t\)n \* a \+ 1$
+^VERIFICATION FAILED$

--- a/regression/loop-invariants/github_7585_pass/main.c
+++ b/regression/loop-invariants/github_7585_pass/main.c
@@ -1,0 +1,29 @@
+/* Regression: GitHub #7585 -- the downgrade added in #7491 was decided by the
+ * claim's position rather than by whether the invariant pins the
+ * counterexample. Here `sn == (i - 1) * a` together with the exit condition
+ * gives `i == n + 1` and so `sn == n * a`, which the assertion below states, so a strong invariant proves it where
+ * every n and a: no abstract state satisfies it, so the violation is real. */
+#include <assert.h>
+#include <stdint.h>
+
+int main(void)
+{
+  uint32_t n;
+  uint64_t a;
+  uint64_t i = 1, sn = 0;
+
+  __ESBMC_assume(n >= 1);
+
+  __ESBMC_loop_invariant(
+    (i <= (uint64_t)n || i == (uint64_t)n + 1) && i >= 1 &&
+    sn == (i - 1) * a);
+
+  while (i <= n)
+  {
+    sn = sn + a;
+    i++;
+  }
+
+  assert(sn == (uint64_t)n * a);
+  return 0;
+}

--- a/regression/loop-invariants/github_7585_pass/test.desc
+++ b/regression/loop-invariants/github_7585_pass/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+PASSED\s+\[main\.assertion\.3\]\s+line\s+27\s+assertion sn == \(uint64_t\)n \* a$
+^VERIFICATION SUCCESSFUL$

--- a/regression/loop-invariants/github_7585_weak/main.c
+++ b/regression/loop-invariants/github_7585_weak/main.c
@@ -1,0 +1,18 @@
+/* Regression: GitHub #7585 -- the negative control. The invariant is true but
+ * leaves the claim open: the abstraction admits states where it holds and
+ * states where it does not, so the violation is not the invariant's and the
+ * verdict stays unknown, as #7480 requires. */
+#include <assert.h>
+
+int main(void)
+{
+  int i = 0, s = 0;
+  __ESBMC_loop_invariant(i >= 0);
+  while (i < 3)
+  {
+    s++;
+    i++;
+  }
+  assert(s == 3);
+  return 0;
+}

--- a/regression/loop-invariants/github_7585_weak/test.desc
+++ b/regression/loop-invariants/github_7585_weak/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--loop-invariant-check --multi-property
+^\s+UNKNOWN\s+\[main\.assertion\.3\]\s+line\s+16\s+assertion s == 3 \(loop invariant too weak
+^VERIFICATION UNKNOWN$

--- a/regression/loop-invariants/mode_exit_reasoning_check_fail/test.desc
+++ b/regression/loop-invariants/mode_exit_reasoning_check_fail/test.desc
@@ -1,5 +1,4 @@
 CORE
 main.c
 --loop-invariant-check
-^WARNING: every violated claim lies downstream of a loop invariant havoc
-^VERIFICATION UNKNOWN$
+^VERIFICATION FAILED$

--- a/src/esbmc/bmc.cpp
+++ b/src/esbmc/bmc.cpp
@@ -239,7 +239,8 @@ static const char *const weak_invariant_note =
 void bmct::record_satisfiable_claim(
   const claim_slicer &claim,
   const property_locationt &loc,
-  bool inductive_step)
+  bool inductive_step,
+  symex_target_equationt &local_eq)
 {
   // Neither answer refutes the program. An inductive-step run starts from an
   // arbitrary state, and a claim downstream of a loop-invariant havoc is
@@ -255,9 +256,12 @@ void bmct::record_satisfiable_claim(
     return;
   }
 
+  // A claim downstream of the havoc is unknowable only while the abstraction
+  // admits it holding (issue #7585).
   if (
     claim.claim_after_invariant_havoc &&
-    !is_loop_invariant_obligation(claim.claim_location))
+    !is_loop_invariant_obligation(claim.claim_location) &&
+    check_claim_unsatisfiable(local_eq) != P_UNSATISFIABLE)
   {
     weak_invariant_detected = true;
     goto_functionst::property_verdicts.record(
@@ -284,6 +288,7 @@ void bmct::record_violated_properties(
   // Symex emits a linear trace, so once the loop-invariant schema's havoc has
   // run every later claim on it is checked against the abstract state.
   bool seen_invariant_havoc = false;
+  size_t claim_index = 0;
 
   for (const auto &step : eq.SSA_steps)
   {
@@ -293,6 +298,8 @@ void bmct::record_violated_properties(
     if (!step.is_assert() || step.ignore)
       continue;
 
+    ++claim_index;
+
     // Same idiom as build_goto_trace: an unevaluatable condition renders as
     // violated, not as held.
     if (smt_conv.l_get(step.cond_expr).is_true())
@@ -300,8 +307,10 @@ void bmct::record_violated_properties(
 
     const locationt &location = step.source.pc->location;
     const std::string description = id2string(step.comment);
-    const bool weak_invariant =
+    const bool abstraction_derived =
       seen_invariant_havoc && !is_loop_invariant_obligation(location);
+    const bool weak_invariant =
+      abstraction_derived && !invariant_refutes(eq, claim_index);
     if (weak_invariant)
       weak_invariant_detected = true;
     goto_functionst::property_verdicts.record(
@@ -533,13 +542,39 @@ void bmct::report_violation()
   verdict_is_unknown = true;
 }
 
+/// UNSAT iff no feasible path satisfies the kept claim. A violation found
+/// downstream of a loop-invariant havoc is then one the invariant itself
+/// forces, not an artefact of the abstraction (issue #7585).
+smt_resultt
+bmct::check_claim_unsatisfiable(symex_target_equationt &local_eq) const
+{
+  std::unique_ptr<smt_convt> solver(create_solver("", ns, options));
+  local_eq.convert(
+    *solver, symex_target_equationt::assertion_modet::Satisfiable);
+  return solver->dec_solve();
+}
+
+/// Whether the invariant leaves the claim at \p claim_index no way to hold.
+/// The single-formula path has no per-claim equation, so slice one the way
+/// multi_property_check does and run the same probe.
+bool bmct::invariant_refutes(
+  const symex_target_equationt &eq,
+  size_t claim_index)
+{
+  symex_target_equationt local_eq = eq;
+  claim_slicer claim(claim_index, false, false, ns);
+  claim.run(local_eq.SSA_steps);
+  return check_claim_unsatisfiable(local_eq) == P_UNSATISFIABLE;
+}
+
 smt_resultt bmct::check_vacuity(symex_target_equationt &local_eq) const
 {
   // Re-encode in vacuity mode: each kept assertion contributes its path
   // assumption to the OR'd disjunction instead of `not(assumpt -> claim)`.
   // The result is UNSAT iff the path to every kept claim is unreachable.
   std::unique_ptr<smt_convt> solver(create_solver("", ns, options));
-  local_eq.convert(*solver, /*vacuity_mode=*/true);
+  local_eq.convert(
+    *solver, symex_target_equationt::assertion_modet::PathReachable);
   return solver->dec_solve();
 }
 
@@ -3099,7 +3134,7 @@ smt_resultt bmct::multi_property_check(
                        "invariant, requires clause, or upstream assume"
                      : "");
       else if (solver_result == P_SATISFIABLE)
-        record_satisfiable_claim(claim, claim_ploc, is);
+        record_satisfiable_claim(claim, claim_ploc, is, local_eq);
       else
       {
         // No answer at all. A coverage run suppresses the verdict that would

--- a/src/esbmc/bmc.h
+++ b/src/esbmc/bmc.h
@@ -86,6 +86,12 @@ protected:
   // discharge was vacuous: the path assumptions alone are unsatisfiable.
   smt_resultt check_vacuity(symex_target_equationt &local_eq) const;
 
+  /// Whether the kept claim can hold at all on a feasible path.
+  smt_resultt check_claim_unsatisfiable(symex_target_equationt &local_eq) const;
+
+  /// Whether the invariant leaves one claim no way to hold (issue #7585).
+  bool invariant_refutes(const symex_target_equationt &eq, size_t claim_index);
+
   // Set by the vacuity probe when at least one kept claim discharged
   // vacuously; consulted by report_result to map the final verdict from
   // SUCCESSFUL to UNKNOWN. Atomic because multi_property_check writes from
@@ -231,7 +237,8 @@ private:
   void record_satisfiable_claim(
     const claim_slicer &claim,
     const property_locationt &loc,
-    bool inductive_step);
+    bool inductive_step,
+    symex_target_equationt &local_eq);
 
   /// Record a verdict for every assertion in \p eq that \p smt_conv's model
   /// falsifies, so the report names them even when the counterexample itself

--- a/src/goto-symex/symex_main.cpp
+++ b/src/goto-symex/symex_main.cpp
@@ -163,10 +163,14 @@ void goto_symext::assertion(
   expr2tc expr = the_assertion;
   cur_state->guard.guard_expr(expr);
   cur_state->global_guard.guard_expr(expr);
+  expr2tc expr_neg = not2tc(the_assertion);
+  cur_state->guard.guard_expr(expr_neg);
+  cur_state->global_guard.guard_expr(expr_neg);
   remaining_claims++;
   target->assertion(
     cur_state->guard.as_expr(),
     expr,
+    expr_neg,
     msg,
     cur_state->gen_stack_trace(),
     cur_state->source,

--- a/src/goto-symex/symex_target.h
+++ b/src/goto-symex/symex_target.h
@@ -66,9 +66,13 @@ public:
     unsigned loop_number) = 0;
 
   // record an assertion
+  /// \p cond_neg is \p cond with the claim negated under the same guards, so
+  /// a probe can ask whether the claim *holds* on this path using the same
+  /// encoding the violation query uses (issue #7585).
   virtual void assertion(
     const expr2tc &guard,
     const expr2tc &cond,
+    const expr2tc &cond_neg,
     const std::string &msg,
     std::vector<stack_framet> stack_trace,
     const sourcet &source,

--- a/src/goto-symex/symex_target_equation.cpp
+++ b/src/goto-symex/symex_target_equation.cpp
@@ -77,6 +77,32 @@ void pre_register_addresses(
   }
 }
 
+/// PathReachable asks only whether the path is feasible, ignoring the claim:
+/// UNSAT over the kept claims means every discharge was vacuous. Satisfiable
+/// asks whether the claim can hold, in the same shape the violation query
+/// uses, so that negating the implication forces its antecedents -- conjoining
+/// `cond` instead would be satisfied by leaving the path untaken, which makes
+/// every claim look satisfiable (issue #7585).
+void encode_assertion(
+  equation_conversion_statet &state,
+  symex_target_equationt::SSA_stept &step,
+  symex_target_equationt::assertion_modet mode)
+{
+  using mode_t = symex_target_equationt::assertion_modet;
+
+  if (mode == mode_t::PathReachable)
+  {
+    step.cond_expr = state.assumpt_expr;
+    state.assertions.push_back(state.assumpt_expr);
+    return;
+  }
+
+  const expr2tc &claim =
+    mode == mode_t::Satisfiable ? step.cond_neg : step.cond;
+  step.cond_expr = implies2tc(state.assumpt_expr, claim);
+  state.assertions.push_back(not2tc(step.cond_expr));
+}
+
 void convert_internal_step(
   const namespacet &ns,
   bool ssa_trace,
@@ -85,7 +111,7 @@ void convert_internal_step(
   smt_convt &smt_conv,
   equation_conversion_statet &state,
   symex_target_equationt::SSA_stept &step,
-  bool vacuity_mode)
+  symex_target_equationt::assertion_modet mode)
 {
   if (step.ignore)
   {
@@ -144,19 +170,7 @@ void convert_internal_step(
 
   if (step.is_assert())
   {
-    if (vacuity_mode)
-    {
-      // Vacuity probe: ask whether the path to this claim is reachable at
-      // all, ignoring the claim itself. If the OR of all kept claims'
-      // path assumption is UNSAT, every discharge was vacuous.
-      step.cond_expr = state.assumpt_expr;
-      state.assertions.push_back(state.assumpt_expr);
-    }
-    else
-    {
-      step.cond_expr = implies2tc(state.assumpt_expr, step.cond);
-      state.assertions.push_back(not2tc(step.cond_expr));
-    }
+    encode_assertion(state, step, mode);
   }
   else if (step.is_assume())
   {
@@ -272,6 +286,7 @@ void symex_target_equationt::assumption(
 void symex_target_equationt::assertion(
   const expr2tc &guard,
   const expr2tc &cond,
+  const expr2tc &cond_neg,
   const std::string &msg,
   std::vector<stack_framet> stack_trace,
   const sourcet &source,
@@ -282,6 +297,7 @@ void symex_target_equationt::assertion(
 
   SSA_step.guard = guard;
   SSA_step.cond = cond;
+  SSA_step.cond_neg = cond_neg;
   SSA_step.type = goto_trace_stept::ASSERT;
   SSA_step.source = source;
   SSA_step.comment = msg;
@@ -314,7 +330,7 @@ void symex_target_equationt::renumber(
     debug_print_step(SSA_step);
 }
 
-void symex_target_equationt::convert(smt_convt &smt_conv, bool vacuity_mode)
+void symex_target_equationt::convert(smt_convt &smt_conv, assertion_modet mode)
 {
   // Pre-register address-of'd string/array literals so int-to-ptr casts see
   // them regardless of source-level declaration order (see
@@ -343,7 +359,7 @@ void symex_target_equationt::convert(smt_convt &smt_conv, bool vacuity_mode)
       smt_conv,
       state,
       SSA_step,
-      vacuity_mode);
+      mode);
 
   if (!state.assertions.empty())
     smt_conv.assert_expr(disjunction(state.assertions));
@@ -594,7 +610,7 @@ void runtime_encoded_equationt::flush_latest_instructions()
       conv,
       solver_state->states.back(),
       *run_it,
-      /*vacuity_mode=*/false);
+      assertion_modet::Violated);
 
   --run_it;
   cvt_progress = run_it;
@@ -625,16 +641,18 @@ void runtime_encoded_equationt::pop_ctx()
   solver_state->states.pop_back();
 }
 
-void runtime_encoded_equationt::convert(smt_convt &smt_conv, bool vacuity_mode)
+void runtime_encoded_equationt::convert(
+  smt_convt &smt_conv,
+  assertion_modet mode)
 {
   // The incremental path doesn't re-walk SSA_steps, so the per-assertion
   // path-assumption rewrite that vacuity mode needs cannot be applied here.
   // Fail loudly rather than producing normal-mode results under a vacuity
   // probe.
-  (void)vacuity_mode;
+  (void)mode;
   assert(
-    !vacuity_mode &&
-    "runtime_encoded_equationt::convert does not support vacuity mode");
+    mode == assertion_modet::Violated &&
+    "runtime_encoded_equationt::convert supports only the default mode");
 
   // Don't actually convert. We've already done most of the conversion by now
   // (probably), instead flush all unconverted instructions. We don't push

--- a/src/goto-symex/symex_target_equation.h
+++ b/src/goto-symex/symex_target_equation.h
@@ -67,6 +67,7 @@ public:
   void assertion(
     const expr2tc &guard,
     const expr2tc &cond,
+    const expr2tc &cond_neg,
     const std::string &msg,
     std::vector<stack_framet> stack_trace,
     const sourcet &source,
@@ -78,14 +79,26 @@ public:
     const expr2tc &size,
     const sourcet &source) override;
 
-  // When `vacuity_mode` is true, each non-ignored assertion is encoded as
-  // its path assumption alone instead of `not(assumpt -> cond)`. The final
-  // OR over the assertions vector is then UNSAT iff every kept claim's path
-  // is unreachable — i.e. the discharge is vacuous.
-  // Note: `runtime_encoded_equationt` overrides `convert` and does NOT
-  // support vacuity mode (it asserts `!vacuity_mode`); incremental BMC
-  // callers must run vacuity probes through the non-incremental path.
-  virtual void convert(smt_convt &smt_conv, bool vacuity_mode = false);
+  // `runtime_encoded_equationt` overrides `convert` and supports only the
+  // default mode; incremental BMC callers must run probes through the
+  // non-incremental path.
+  /// How an assertion is encoded.
+  ///   Violated       -- `not(assumpt -> cond)`: can the claim be violated?
+  ///   PathReachable  -- `assumpt`: is the path to it feasible at all?
+  ///   Satisfiable    -- `not(assumpt -> cond_neg)`: can the claim hold? UNSAT
+  ///                     means no feasible path satisfies it, so a violation
+  ///                     found against an over-approximation is one the
+  ///                     approximation's own constraints force (issue #7585).
+  enum class assertion_modet
+  {
+    Violated,
+    PathReachable,
+    Satisfiable
+  };
+
+  virtual void convert(
+    smt_convt &smt_conv,
+    assertion_modet mode = assertion_modet::Violated);
 
   void reconstruct_symbolic_expression(expr2tc &expr, bool keep_local_variables)
     const override;
@@ -139,6 +152,8 @@ public:
     // std::string) and dedups the payload across the many steps that share
     // a message.
     expr2tc cond;
+    /// `cond` with the claim negated under the same guards (issue #7585).
+    expr2tc cond_neg;
     irep_idt comment;
 
     // OUTPUT-step payload. OUTPUT steps are rare (only printf-family
@@ -194,6 +209,7 @@ public:
         original_lhs(o.original_lhs),
         original_rhs(o.original_rhs),
         cond(o.cond),
+        cond_neg(o.cond_neg),
         comment(o.comment),
         output_data(
           o.output_data ? std::make_unique<output_datat>(*o.output_data)
@@ -323,7 +339,9 @@ public:
 
   std::shared_ptr<symex_targett> clone() const override;
 
-  void convert(smt_convt &smt_conv, bool vacuity_mode = false) override;
+  void convert(
+    smt_convt &smt_conv,
+    assertion_modet mode = assertion_modet::Violated) override;
   void flush_latest_instructions();
 
   tvt ask_solver_question(const expr2tc &question);


### PR DESCRIPTION
Fixes #7585.

The downgrade #7491 added is decided by a claim's position: everything
downstream of the loop-invariant havoc becomes `UNKNOWN`. That is right while
the abstraction admits the claim holding, and wrong when the invariant pins the
counterexample outright — which is the case the mode exists to serve. As the
issue puts it, no post-loop assertion could be reported `VERIFICATION FAILED`,
however strong the invariant.

## The second question

Before downgrading, ask the solver whether the claim can hold at all on a
feasible path. UNSAT means no abstract state satisfies it; the concrete states
are a subset of the abstract ones, so the violation is real.

The encoding is the part worth reviewing. A claim reaches the equation already
guarded — `assumpt => (guard_exec => (G => claim))` — so conjoining `cond` asks
almost nothing: setting `guard_exec` false satisfies the implication and *every*
claim looks satisfiable, `assert(0)` included. Instead symex now records
`cond_neg`, the claim negated under the same two guards, and the probe uses the
same shape as the violation query over it:

| | asserted | expands to |
|---|---|---|
| violation query | `not(assumpt => cond)` | `assumpt ∧ guard_exec ∧ G ∧ ¬claim` |
| satisfiability probe | `not(assumpt => cond_neg)` | `assumpt ∧ guard_exec ∧ G ∧ claim` |

Negating the implication forces the antecedents in both, so the two queries
agree on which path they are talking about.

`convert`'s `vacuity_mode` flag becomes a three-valued `assertion_modet`, since
there are now three questions to ask of an assertion rather than two.

Both verdict paths are covered: `multi_property_check` runs the probe on the
per-claim equation it already builds, and the single-formula path slices one the
same way, which is what the issue's own command line exercises.

## Caveat

"Every abstract state violates the claim" gives a real violation only if a
concrete post-loop state exists at all — that is, if the loop is entered and
terminates. Entry is established by the base case, which is checked against the
concrete pre-loop state. Termination is not, and is not established anywhere
else in this mode either.

## Tests

| test | pins |
|---|---|
| `github_7585` | the issue's program: strong invariant, claim genuinely false → FAILED |
| `github_7585_pass` | the same loop asserting what the invariant does prove → SUCCESSFUL |
| `github_7585_weak` | #7480's program: true but weak invariant → still UNKNOWN |

Mutation matrix:

| mutation | fails |
|---|---|
| revert the change | `github_7585` |
| probe always returns UNSAT | `github_7585_weak` |

One gate in each direction: without the probe a refuted claim stays unknown,
and with an over-eager probe a weak invariant starts reporting bugs.

Ten existing tests move back to `VERIFICATION FAILED`: `2-wrong_assertion`,
`11-sum_overflow`, `check_if_bug`, `count_up_down_bug`, `dirkex_unsafe`,
`mode_exit_reasoning_check_fail`, and the four `github_7478_*_fail`. I changed
them to `UNKNOWN` in #7491; their invariants already refuted their claims, which
is exactly what that PR could not distinguish.

`esbmc` 2115/2115, `loop-invariants` 110/110, `function_contract` 432/432,
`k-induction` 198/198, `k-induction-parallel` 76/76, `termination` 72/72. No new
clang-format findings; complexity gate reports nothing added or worsened.
