### PR TITLE
[regression] Let a run narrow the per-test timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,10 +127,22 @@ bullet below.
   ESBMC_REGRESS_TIMEOUT_MAX=45 ctest -j$(nproc) -L loop-invariants
   ```
 
-  Any test slower than the cap then fails, naming the cap in its message.
-  Without it the suite is blind to performance regressions: a test that went
-  from sub-second to nine minutes still reports `Passed` (#7628). Use it when a
-  change could affect solve time.
+  A `CORE`/`THOROUGH` test slower than the cap then fails, naming the cap in
+  its message. Without it the suite is blind to performance regressions: a
+  test that went from sub-second to nine minutes still reports `Passed`
+  (#7628). Use it when a change could affect solve time.
+
+  Two exceptions, both of which read as green:
+
+  - `KNOWNBUG` and `FUTURE` tests treat a timeout as satisfying the
+    expectation (the `FAIL_MODES` branch in `regression/testing_tool.py`), so
+    a cap cannot measure them at all. They print `accepted under KNOWNBUG` and
+    pass. Grep for that line before reading a capped run as a clean bill of
+    health.
+  - `REQUIRES long_timeout` tests are skipped once the effective budget is
+    under 600s, matching how CMake grants the capability in
+    `regression/CMakeLists.txt`. A capped run does not measure
+    `floats-regression/nn-logistic_5_unsafe`.
 - **Regression tests come in pairs, and both must bite.** A PR that changes
   verification behaviour adds **two** regression tests over the same construct:
   one pinning `^VERIFICATION SUCCESSFUL$` and one pinning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,22 @@ bullet below.
   at **10 minutes** (600000 ms) — pass the timeout to the `Bash` tool's
   `timeout` parameter, or wrap the invocation with `timeout 10m …`. If the suite
   cannot complete in 10 minutes, narrow the scope (e.g. run only the affected
-  subset) or ask the user before extending the limit.
+  subset) or ask the user before extending the limit. `ctest --timeout` does
+  **not** cap this suite: CMake gives every test an explicit `TIMEOUT`
+  property, and ctest's flag only supplies a default for tests that have none.
+- **Per-test budget, and catching slowdowns.** Each test's real budget is
+  `ESBMC_REGRESS_TIMEOUT` (default 1200s), baked into the test's ctest
+  environment at configure time. To narrow it for one run without
+  re-configuring, set `ESBMC_REGRESS_TIMEOUT_MAX`:
+
+  ```sh
+  ESBMC_REGRESS_TIMEOUT_MAX=45 ctest -j$(nproc) -L loop-invariants
+  ```
+
+  Any test slower than the cap then fails, naming the cap in its message.
+  Without it the suite is blind to performance regressions: a test that went
+  from sub-second to nine minutes still reports `Passed` (#7628). Use it when a
+  change could affect solve time.
 - **Regression tests come in pairs, and both must bite.** A PR that changes
   verification behaviour adds **two** regression tests over the same construct:
   one pinning `^VERIFICATION SUCCESSFUL$` and one pinning

--- a/regression/README.md
+++ b/regression/README.md
@@ -8,7 +8,11 @@ You can see below some examples that you can from the build directory:
 - `ctest -L esbmc-cpp/*`. Executes all tests matching esbmc-cpp/*.
 - `ctest -LE esbmc-cpp*`. Executes all tests except the ones inside esbmc-cpp.
 - `ctest --progress`. Show testing progress in one line.
-- `ctest -j4 -L python --progress --timeout 30`. Sets a timeout of 30s.
+- `ESBMC_REGRESS_TIMEOUT_MAX=30 ctest -j4 -L python --progress`. Caps every
+  test at 30s, failing anything slower. `ctest --timeout` cannot do this: CMake
+  gives every test an explicit `TIMEOUT` property, and ctest's flag only
+  supplies a default for tests that have none, so a slow test would still be
+  reported as passing (#7628).
 
 We also provide a script to validate the Python regression suite. You can run the following command from `ESBMC_Project/esbmc` directory as:
 

--- a/regression/README.md
+++ b/regression/README.md
@@ -12,7 +12,10 @@ You can see below some examples that you can from the build directory:
   test at 30s, failing anything slower. `ctest --timeout` cannot do this: CMake
   gives every test an explicit `TIMEOUT` property, and ctest's flag only
   supplies a default for tests that have none, so a slow test would still be
-  reported as passing (#7628).
+  reported as passing (#7628). Two kinds of test stay green under a cap
+  regardless of how long they take: `KNOWNBUG` and `FUTURE`, for which a
+  timeout satisfies the expectation, and `REQUIRES long_timeout`, which is
+  skipped once the effective budget drops under 600s.
 
 We also provide a script to validate the Python regression suite. You can run the following command from `ESBMC_Project/esbmc` directory as:
 

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -30,8 +30,24 @@ _MEMORY_LIMIT_ENVVAR = "ESBMC_REGRESS_MEMORY_LIMIT"
 _TIMEOUT_CAP_ENVVAR = "ESBMC_REGRESS_TIMEOUT_MAX"
 
 
+# CMake grants the long_timeout capability at configure time, from a budget the
+# cap has not been applied to yet (ESBMC_REGRESS_TIMEOUT GREATER_EQUAL 600 in
+# regression/CMakeLists.txt). A narrowed run still receives it on the command
+# line, and would fail the very tests it exists to skip.
+_LONG_TIMEOUT_SECONDS = 600
+
+
 def _timeout_cap():
-    return int(os.environ.get(_TIMEOUT_CAP_ENVVAR, 0)) or None
+    raw = os.environ.get(_TIMEOUT_CAP_ENVVAR, "").strip()
+    if not raw:
+        return None
+    # Rejected rather than ignored: a run that silently kept the 1200s budget
+    # after a typo would report every test as comfortably within it.
+    if not raw.isdigit() or int(raw) == 0:
+        sys.exit(
+            "{}={!r}: expected a positive whole number of seconds".format(
+                _TIMEOUT_CAP_ENVVAR, raw))
+    return int(raw)
 
 
 def _capped_timeout(budget):
@@ -689,11 +705,11 @@ def _add_test(test_case, executor):
                     )
                     return
                 cap = _timeout_cap()
-                narrowed = (" narrowed by " + _TIMEOUT_CAP_ENVVAR
-                            if cap is not None and executor.timeout == cap
-                            else "")
+                capped = (", capped by " + _TIMEOUT_CAP_ENVVAR
+                          if cap is not None and executor.timeout == cap
+                          else "")
                 timeout_message = "\nTIMEOUT TEST: {} (limit {}s{})".format(
-                    test_case.test_dir, executor.timeout or "none", narrowed)
+                    test_case.test_dir, executor.timeout or "none", capped)
                 if stderr:
                     timeout_message += "\n" + stderr.decode(errors="replace")
                 self.fail(timeout_message)
@@ -881,6 +897,9 @@ def _arg_parsing():
             f"{', '.join(sorted(unknown))}; known names are "
             f"{', '.join(sorted(STATIC_CAPABILITIES))}"
         )
+        if (RegressionBase.TIMEOUT is not None
+                and RegressionBase.TIMEOUT < _LONG_TIMEOUT_SECONDS):
+            capabilities.discard("long_timeout")
 
     gen_one_test(
         regression_path,

--- a/regression/testing_tool.py
+++ b/regression/testing_tool.py
@@ -22,6 +22,25 @@ import subprocess
 # set_tests_properties(ENVIRONMENT).
 _TIMEOUT_ENVVAR = "ESBMC_REGRESS_TIMEOUT"
 _MEMORY_LIMIT_ENVVAR = "ESBMC_REGRESS_MEMORY_LIMIT"
+# Narrows the budget for one run, so a slowdown fails instead of passing under
+# the 1200s default. CMake bakes _TIMEOUT_ENVVAR into each test's ctest
+# ENVIRONMENT property, which overrides the caller's value, and `ctest
+# --timeout` only supplies a default for tests carrying no TIMEOUT property --
+# so tightening the budget needs a name ctest does not set (#7628).
+_TIMEOUT_CAP_ENVVAR = "ESBMC_REGRESS_TIMEOUT_MAX"
+
+
+def _timeout_cap():
+    return int(os.environ.get(_TIMEOUT_CAP_ENVVAR, 0)) or None
+
+
+def _capped_timeout(budget):
+    cap = _timeout_cap()
+    if cap is None:
+        return budget
+    return budget if budget is not None and budget <= cap else cap
+
+
 #####################
 # Testing Tool
 #####################
@@ -624,8 +643,8 @@ class RegressionBase(unittest.TestCase):
     longMessage = True
 
     FAIL_WITH_WORD: str = None
-    # The env var set by CMake.
-    TIMEOUT = int(os.environ.get(_TIMEOUT_ENVVAR, 0)) or None
+    # The env var set by CMake, narrowed by _TIMEOUT_CAP_ENVVAR when set.
+    TIMEOUT = _capped_timeout(int(os.environ.get(_TIMEOUT_ENVVAR, 0)) or None)
     _mem_mb = int(os.environ.get(_MEMORY_LIMIT_ENVVAR, 0))
     MEMORY_LIMIT = _mem_mb * 1024 * 1024 if _mem_mb else None
 
@@ -669,8 +688,12 @@ def _add_test(test_case, executor):
                         )
                     )
                     return
-                timeout_message = "\nTIMEOUT TEST: {} (limit {}s)".format(
-                    test_case.test_dir, executor.timeout or "none")
+                cap = _timeout_cap()
+                narrowed = (" narrowed by " + _TIMEOUT_CAP_ENVVAR
+                            if cap is not None and executor.timeout == cap
+                            else "")
+                timeout_message = "\nTIMEOUT TEST: {} (limit {}s{})".format(
+                    test_case.test_dir, executor.timeout or "none", narrowed)
                 if stderr:
                     timeout_message += "\n" + stderr.decode(errors="replace")
                 self.fail(timeout_message)
@@ -827,7 +850,7 @@ def _arg_parsing():
 
     main_args = parser.parse_args()
     if main_args.timeout:
-        RegressionBase.TIMEOUT = int(main_args.timeout)
+        RegressionBase.TIMEOUT = _capped_timeout(int(main_args.timeout))
     if main_args.memory_limit:
         RegressionBase.MEMORY_LIMIT = main_args.memory_limit * 1024 * 1024
     RegressionBase.FAIL_WITH_WORD = main_args.mark_knownbug_with_word

--- a/regression/testing_tool_test.py
+++ b/regression/testing_tool_test.py
@@ -2,7 +2,8 @@
 
 import unittest
 from testing_tool import *
-from testing_tool import _add_test, _capped_timeout, _TIMEOUT_CAP_ENVVAR
+from testing_tool import (_add_test, _capped_timeout, _timeout_cap,
+                         _TIMEOUT_CAP_ENVVAR)
 
 
 class CTestGeneration(unittest.TestCase):
@@ -239,46 +240,102 @@ class CappedTimeoutTest(unittest.TestCase):
         self.assertEqual(_capped_timeout(None), 45)
 
 
+def _run_slow_suite(extra_env, desc_requires="", extra_args=()):
+    """Run testing_tool.py over a one-test suite whose tool takes 3 seconds."""
+    with tempfile.TemporaryDirectory() as tmp:
+        tool = os.path.join(tmp, "slow.py")
+        with open(tool, "w", encoding="utf-8") as f:
+            f.write("import time\n"
+                    "time.sleep(3)\n"
+                    "print('VERIFICATION SUCCESSFUL')\n")
+        test_dir = os.path.join(tmp, "slow")
+        os.mkdir(test_dir)
+        open(os.path.join(test_dir, "main.c"), "w").close()
+        with open(os.path.join(test_dir, "test.desc"), "w",
+                  encoding="utf-8") as f:
+            f.write("CORE\nmain.c\n\n" + desc_requires +
+                    "^VERIFICATION SUCCESSFUL$\n")
+
+        env = dict(os.environ, ESBMC_REGRESS_TIMEOUT="600")
+        env.pop(_TIMEOUT_CAP_ENVVAR, None)
+        env.update(extra_env)
+        return subprocess.run(
+            [sys.executable, "testing_tool.py",
+             "--tool={} {}".format(sys.executable, tool),
+             "--regression=" + tmp, "--modes", "CORE", "--file=slow",
+             *extra_args],
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+            env=env, stdout=PIPE, stderr=PIPE)
+
+
 class NarrowedBudgetFailsASlowTestTest(unittest.TestCase):
     """The point of the cap: a test that passes on the configured budget must
     fail once the budget is narrowed below its runtime. Without this the suite
     reports a nine-minute run as `Passed` (esbmc/esbmc#7628)."""
 
-    def _run(self, extra_env):
-        with tempfile.TemporaryDirectory() as tmp:
-            tool = os.path.join(tmp, "slow.py")
-            with open(tool, "w", encoding="utf-8") as f:
-                f.write("import time\n"
-                        "time.sleep(3)\n"
-                        "print('VERIFICATION SUCCESSFUL')\n")
-            test_dir = os.path.join(tmp, "slow")
-            os.mkdir(test_dir)
-            open(os.path.join(test_dir, "main.c"), "w").close()
-            with open(os.path.join(test_dir, "test.desc"), "w",
-                      encoding="utf-8") as f:
-                f.write("CORE\nmain.c\n\n^VERIFICATION SUCCESSFUL$\n")
-
-            env = dict(os.environ, ESBMC_REGRESS_TIMEOUT="600")
-            env.pop(_TIMEOUT_CAP_ENVVAR, None)
-            env.update(extra_env)
-            return subprocess.run(
-                [sys.executable, "testing_tool.py",
-                 "--tool={} {}".format(sys.executable, tool),
-                 "--regression=" + tmp, "--modes", "CORE", "--file=slow"],
-                cwd=os.path.dirname(os.path.abspath(__file__)),
-                env=env, stdout=PIPE, stderr=PIPE)
-
     def test_the_slow_test_passes_on_the_configured_budget(self):
-        done = self._run({})
+        done = _run_slow_suite({})
         self.assertEqual(done.returncode, 0,
                          done.stdout.decode() + done.stderr.decode())
 
     def test_the_same_test_fails_once_the_budget_is_narrowed(self):
-        done = self._run({_TIMEOUT_CAP_ENVVAR: "1"})
+        done = _run_slow_suite({_TIMEOUT_CAP_ENVVAR: "1"})
         output = done.stdout.decode() + done.stderr.decode()
         self.assertNotEqual(done.returncode, 0, output)
         self.assertIn("TIMEOUT TEST", output)
-        self.assertIn("narrowed by " + _TIMEOUT_CAP_ENVVAR, output)
+        self.assertIn("capped by " + _TIMEOUT_CAP_ENVVAR, output)
+
+
+class NarrowedBudgetWithdrawsLongTimeoutTest(unittest.TestCase):
+    """`REQUIRES long_timeout` is granted by CMake from the unnarrowed budget,
+    so a narrowed run still receives it on the command line. Keeping it fails
+    the very tests the capability exists to skip."""
+
+    REQUIRES = "REQUIRES long_timeout\n"
+    CAPABILITIES = ("--capabilities=long_timeout", )
+    SKIPPED = 10
+
+    def test_the_capability_holds_on_the_configured_budget(self):
+        done = _run_slow_suite({}, self.REQUIRES, self.CAPABILITIES)
+        self.assertEqual(done.returncode, 0,
+                         done.stdout.decode() + done.stderr.decode())
+
+    def test_a_cap_under_ten_minutes_withdraws_it(self):
+        done = _run_slow_suite({_TIMEOUT_CAP_ENVVAR: "1"}, self.REQUIRES,
+                               self.CAPABILITIES)
+        output = done.stdout.decode() + done.stderr.decode()
+        self.assertEqual(done.returncode, self.SKIPPED, output)
+        self.assertIn("requires long_timeout", output)
+
+    def test_a_cap_of_ten_minutes_or_more_keeps_it(self):
+        done = _run_slow_suite({_TIMEOUT_CAP_ENVVAR: "900"}, self.REQUIRES,
+                               self.CAPABILITIES)
+        self.assertEqual(done.returncode, 0,
+                         done.stdout.decode() + done.stderr.decode())
+
+
+class RejectedTimeoutCapTest(unittest.TestCase):
+    """A mis-set cap must stop the run. Ignoring it would leave every test on
+    the 1200s budget while the caller believes it was narrowed."""
+
+    def setUp(self):
+        self.saved = os.environ.pop(_TIMEOUT_CAP_ENVVAR, None)
+
+    def tearDown(self):
+        os.environ.pop(_TIMEOUT_CAP_ENVVAR, None)
+        if self.saved is not None:
+            os.environ[_TIMEOUT_CAP_ENVVAR] = self.saved
+
+    def test_a_value_that_is_not_a_count_of_seconds_is_refused(self):
+        for value in ("45s", "4.5", "-1", "0", "abc"):
+            os.environ[_TIMEOUT_CAP_ENVVAR] = value
+            with self.assertRaises(SystemExit) as refusal:
+                _timeout_cap()
+            self.assertIn(_TIMEOUT_CAP_ENVVAR, str(refusal.exception))
+
+    def test_surrounding_whitespace_is_tolerated(self):
+        os.environ[_TIMEOUT_CAP_ENVVAR] = " 45 "
+        self.assertEqual(_timeout_cap(), 45)
 
 
 class PrivateCwdTest(unittest.TestCase):

--- a/regression/testing_tool_test.py
+++ b/regression/testing_tool_test.py
@@ -2,7 +2,7 @@
 
 import unittest
 from testing_tool import *
-from testing_tool import _add_test
+from testing_tool import _add_test, _capped_timeout, _TIMEOUT_CAP_ENVVAR
 
 
 class CTestGeneration(unittest.TestCase):
@@ -207,6 +207,78 @@ class TimeoutReapsProcessGroupTest(unittest.TestCase):
             # A reaped pid may be recycled, but not within this test's lifetime.
             with self.assertRaises(OSError):
                 os.kill(child_pid, 0)
+
+
+class CappedTimeoutTest(unittest.TestCase):
+    """`ctest --timeout` cannot narrow this suite: CMake gives every test a
+    TIMEOUT property, and ctest's flag only defaults tests that lack one. The
+    cap env var is the knob that does work (esbmc/esbmc#7628)."""
+
+    def setUp(self):
+        self.saved = os.environ.pop(_TIMEOUT_CAP_ENVVAR, None)
+
+    def tearDown(self):
+        os.environ.pop(_TIMEOUT_CAP_ENVVAR, None)
+        if self.saved is not None:
+            os.environ[_TIMEOUT_CAP_ENVVAR] = self.saved
+
+    def test_no_cap_leaves_the_budget_alone(self):
+        self.assertEqual(_capped_timeout(1200), 1200)
+        self.assertIsNone(_capped_timeout(None))
+
+    def test_a_tighter_cap_wins(self):
+        os.environ[_TIMEOUT_CAP_ENVVAR] = "45"
+        self.assertEqual(_capped_timeout(1200), 45)
+
+    def test_a_looser_cap_does_not_widen_the_budget(self):
+        os.environ[_TIMEOUT_CAP_ENVVAR] = "45"
+        self.assertEqual(_capped_timeout(30), 30)
+
+    def test_a_cap_applies_when_there_is_no_budget(self):
+        os.environ[_TIMEOUT_CAP_ENVVAR] = "45"
+        self.assertEqual(_capped_timeout(None), 45)
+
+
+class NarrowedBudgetFailsASlowTestTest(unittest.TestCase):
+    """The point of the cap: a test that passes on the configured budget must
+    fail once the budget is narrowed below its runtime. Without this the suite
+    reports a nine-minute run as `Passed` (esbmc/esbmc#7628)."""
+
+    def _run(self, extra_env):
+        with tempfile.TemporaryDirectory() as tmp:
+            tool = os.path.join(tmp, "slow.py")
+            with open(tool, "w", encoding="utf-8") as f:
+                f.write("import time\n"
+                        "time.sleep(3)\n"
+                        "print('VERIFICATION SUCCESSFUL')\n")
+            test_dir = os.path.join(tmp, "slow")
+            os.mkdir(test_dir)
+            open(os.path.join(test_dir, "main.c"), "w").close()
+            with open(os.path.join(test_dir, "test.desc"), "w",
+                      encoding="utf-8") as f:
+                f.write("CORE\nmain.c\n\n^VERIFICATION SUCCESSFUL$\n")
+
+            env = dict(os.environ, ESBMC_REGRESS_TIMEOUT="600")
+            env.pop(_TIMEOUT_CAP_ENVVAR, None)
+            env.update(extra_env)
+            return subprocess.run(
+                [sys.executable, "testing_tool.py",
+                 "--tool={} {}".format(sys.executable, tool),
+                 "--regression=" + tmp, "--modes", "CORE", "--file=slow"],
+                cwd=os.path.dirname(os.path.abspath(__file__)),
+                env=env, stdout=PIPE, stderr=PIPE)
+
+    def test_the_slow_test_passes_on_the_configured_budget(self):
+        done = self._run({})
+        self.assertEqual(done.returncode, 0,
+                         done.stdout.decode() + done.stderr.decode())
+
+    def test_the_same_test_fails_once_the_budget_is_narrowed(self):
+        done = self._run({_TIMEOUT_CAP_ENVVAR: "1"})
+        output = done.stdout.decode() + done.stderr.decode()
+        self.assertNotEqual(done.returncode, 0, output)
+        self.assertIn("TIMEOUT TEST", output)
+        self.assertIn("narrowed by " + _TIMEOUT_CAP_ENVVAR, output)
 
 
 class PrivateCwdTest(unittest.TestCase):


### PR DESCRIPTION
`ctest --timeout` does not cap this suite. `regression/CMakeLists.txt:161` gives
every test an explicit `TIMEOUT` property, and ctest's flag only supplies a
default for tests that carry none. So this:

```
$ ctest -j6 -L loop-invariants --timeout 45
93/94 Test #15178: .../quantified_array_invariant ....... Passed  547.03 sec
94/94 Test #15179: .../quantified_array_invariant_fail .. Passed 1079.84 sec
```

Nine and eighteen minutes, both green, under a flag asking for 45 seconds.
The real budget is `ESBMC_REGRESS_TIMEOUT`, which
`set_tests_properties(ENVIRONMENT)` bakes into each test at configure time —
and a ctest `ENVIRONMENT` property also overrides whatever the caller exported
for that name, so there was no way to narrow the budget without re-running
cmake.

### The change

`regression/testing_tool.py` reads `ESBMC_REGRESS_TIMEOUT_MAX`, a name ctest
does not set and therefore does not clobber, and takes the smaller of it and
the configured budget. The timeout message names the cap, so a run narrowed on
purpose is not read as a test blowing the 1200s CI budget.

```
$ ctest -R '^regression/python/abs$'
1/1 Test #8297: regression/python/abs ...   Passed    3.14 sec

$ ESBMC_REGRESS_TIMEOUT_MAX=1 ctest -R '^regression/python/abs$' --output-on-failure
1/1 Test #8297: regression/python/abs ...***Failed    1.07 sec
TIMEOUT TEST: .../regression/python/abs (limit 1s narrowed by ESBMC_REGRESS_TIMEOUT_MAX)
```

That is the whole feature: the same test, passing on the configured budget and
failing once the budget is narrowed below its runtime.

### Tests

`regression/testing_tool_test.py`, which the `testing-tool` CI job runs:

- `CappedTimeoutTest` — no cap leaves the budget alone; a tighter cap wins; a
  looser cap does not widen the budget; a cap applies when there is no budget.
- `NarrowedBudgetFailsASlowTestTest` — the pair that matters. It builds a
  three-second stand-in tool and a one-test suite in a temp directory, then
  runs `testing_tool.py` over it twice as a subprocess: once on a 600s budget,
  which must pass, and once with the cap at 1s, which must fail with
  `TIMEOUT TEST` and name the cap.

Mutation-checked by making `_capped_timeout` return its argument unchanged.
Three tests fail, and the end-to-end one fails exactly the way #7628 describes:

```
FAIL: test_the_same_test_fails_once_the_budget_is_narrowed
AssertionError: 0 == 0 : ... 3.031s ... OK
```

Three seconds of work reported as `OK` under a one-second budget.

### Checks

- `python3 testing_tool_test.py` — 18 tests, OK (was 14).
- `ctest -j6 -L loop-invariants` — 107/107, with and without
  `ESBMC_REGRESS_TIMEOUT_MAX=45`, so an unset cap changes nothing.
- `ctest -j4 -L python-contracts` — 68/68.

### Docs

`CLAUDE.md` told contributors to cap a suite run by passing a timeout, which
for `ctest --timeout` does nothing; `regression/README.md` documented
`ctest --timeout 30` as "sets a timeout of 30s". Both now say what actually
caps a run, and why the flag does not.

Fixes #7628.
