### PR TITLE
[python] Give quixbugs/next_permutation an unwind bound it can discharge

### DIFF
--- a/regression/quixbugs/next_permutation/test.desc
+++ b/regression/quixbugs/next_permutation/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 main.py
---unwind 3 --no-bounds-check --no-pointer-check --no-align-check --no-div-by-zero-check
+--unwind 7 --no-bounds-check --no-pointer-check --no-align-check --no-div-by-zero-check
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`regression/quixbugs/next_permutation` was `KNOWNBUG` at `--unwind 3`. At that bound the only failing property is

```
FAILED  [__ESBMC_list_eq.assertion.1]  line 334  unwinding assertion loop 6
```

— the list-equality operational model's own loop, not anything the program does. `--unwind 5` and `--unwind 6` fail on that same single property, so the expected `VERIFICATION SUCCESSFUL` was unreachable at the pinned bound however correct the program is.

At `--unwind 7` every unwinding assertion discharges, no property is left `NOT CHECKED`, and the file's two asserts are proved:

```
PASSED  [global.assertion.1]  line 24
PASSED  [global.assertion.2]  line 25
```

The proof is complete rather than truncated, and it bites: perturbing an expected element (`[3, 4, 1, 2]` → `[3, 4, 1, 3]`, which CPython also rejects) turns `global.assertion.1` `FAILED`. 23s under `testing_tool.py`.

Residual, stated because the bound moved for its sake rather than the program's: `--unwind` also governs the operational models' internal loops, so a list comparison whose length comes from the data forces the user's program bound upward. That is a separate limitation and is not addressed here.

Fixes #4792