### PR TITLE
[python] Type a builtin exception bound as a value

### DIFF
--- a/regression/python/github_7549_builtin/main.py
+++ b/regression/python/github_7549_builtin/main.py
@@ -1,0 +1,2 @@
+exc = ValueError
+assert exc is not None

--- a/regression/python/github_7549_builtin/test.desc
+++ b/regression/python/github_7549_builtin/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7549_builtin_fail/main.py
+++ b/regression/python/github_7549_builtin_fail/main.py
@@ -1,0 +1,2 @@
+exc = ValueError
+assert exc is None

--- a/regression/python/github_7549_builtin_fail/test.desc
+++ b/regression/python/github_7549_builtin_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_7549_builtin_shadow/main.py
+++ b/regression/python/github_7549_builtin_shadow/main.py
@@ -1,0 +1,4 @@
+# The class-object fallback for a builtin exception name must sit behind
+# symbol lookup, so a name rebound to a value still resolves to that value.
+ValueError = 5
+assert ValueError == 5

--- a/regression/python/github_7549_builtin_shadow/test.desc
+++ b/regression/python/github_7549_builtin_shadow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_expr.cpp
+++ b/src/python-frontend/converter/converter_expr.cpp
@@ -1670,7 +1670,12 @@ exprt python_converter::get_expr(const nlohmann::json &element)
           // modelled, and two same-named classes in different modules compare
           // equal. This is reached only after symbol lookup fails, so a name
           // rebound to a value still resolves to that value.
-          if (is_class(var_name, *ast_json))
+          // A builtin exception is a class too, but it is declared by the
+          // exceptions model rather than by this AST, so is_class does not
+          // see it (esbmc/esbmc#7549).
+          if (
+            is_class(var_name, *ast_json) ||
+            type_utils::is_python_exceptions(var_name))
           {
             typet str_type =
               type_handler_.build_array(char_type(), var_name.size() + 1);

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -1738,7 +1738,8 @@ std::string python_annotation<Json>::get_type_from_rhs_variable(
     // default argument reach inference only through here.
     if (
       json_utils::is_class(rhs_var_name, ast_) ||
-      type_utils::is_type_identifier(rhs_var_name))
+      type_utils::is_type_identifier(rhs_var_name) ||
+      type_utils::is_python_exceptions(rhs_var_name))
       return "type";
 
     const auto &lineno = element["lineno"].template get<int>();


### PR DESCRIPTION
```python
exc = ValueError
assert exc is not None
```

aborted with `Type inference failed at line 1. Variable ValueError not found`, and after that with `Variable 'ValueError' is not defined`. Both passes already accept a class bound as a value, but they recognise one from this module's AST (`json_utils::is_class`) or from the builtin type names; a builtin exception is declared by the exceptions model, so neither saw it. `type_utils::is_python_exceptions` already lists them.

A user class (`exc = C`) and a builtin type name (`exc = int`) both already worked — only the exception names failed.

The converter arm goes in the **post-lookup** fallback, next to the existing class-as-value case. Putting it at the top of the `Name` branch instead makes `ValueError = 5; assert ValueError == 5` report `VERIFICATION FAILED` — a false alarm on a program CPython accepts. `github_7549_builtin_shadow` pins that; it passes both before and after this change, and is there because it fails against that wrong placement, which is the mistake `github_7549_shadow` already warns about.

The pair (`github_7549_builtin`, `github_7549_builtin_fail`) both fail on master and pass here. `raise`/`except ValueError` are unaffected.

Residual: constructing through the forwarded value (`exc = ValueError; raise exc("boom")`) still reports `NameError: name 'exc' is not defined`. That is the limitation the neighbouring comment already records — "Constructing through such a forwarded value is not modelled" — and is not changed here.

Fixes #7549