### PR TITLE
[om] Declare basic_string in <iosfwd>

### DIFF
--- a/regression/esbmc-cpp/cpp/iosfwd_basic_string/main.cpp
+++ b/regression/esbmc-cpp/cpp/iosfwd_basic_string/main.cpp
@@ -1,0 +1,14 @@
+// libstdc++ names std::basic_string from <iosfwd> alone (via <bits/stringfwd.h>),
+// so a translation unit that forward-declares only must parse. <string> is
+// deliberately not included: including it would supply the declaration and the
+// test would no longer pin <iosfwd>.
+#include <iosfwd>
+#include <cassert>
+
+std::basic_string<char> *p = 0;
+
+int main()
+{
+  assert(p == 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/iosfwd_basic_string/test.desc
+++ b/regression/esbmc-cpp/cpp/iosfwd_basic_string/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/iosfwd_basic_string_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/iosfwd_basic_string_fail/main.cpp
@@ -1,0 +1,14 @@
+// libstdc++ names std::basic_string from <iosfwd> alone (via <bits/stringfwd.h>),
+// so a translation unit that forward-declares only must parse. <string> is
+// deliberately not included: including it would supply the declaration and the
+// test would no longer pin <iosfwd>.
+#include <iosfwd>
+#include <cassert>
+
+std::basic_string<char> *p = 0;
+
+int main()
+{
+  assert(p != 0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/iosfwd_basic_string_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/iosfwd_basic_string_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++11
+^VERIFICATION FAILED$

--- a/src/cpp/library/iosfwd
+++ b/src/cpp/library/iosfwd
@@ -36,6 +36,19 @@ template <class CharT, class Traits>
 class basic_streambuf;
 typedef basic_streambuf<char, char_traits<char> > streambuf;
 
+/* libstdc++ declares basic_string from <iosfwd> (via <bits/stringfwd.h>), so
+ * `#include <iosfwd>` alone is enough to name std::basic_string<char> there.
+ * Rejecting that is a false PARSING ERROR on code the host toolchain accepts,
+ * so follow the implementation. Unlike basic_streambuf above, the default
+ * arguments live here rather than with the definition: naming
+ * basic_string<char> needs them, and clang rejects a second declaration that
+ * repeats them, so <string> declares its definition without. */
+template <
+  class CharT,
+  class Traits = char_traits<CharT>,
+  class Alloc = allocator<CharT> >
+class basic_string;
+
 template <
   class CharT,
   class Traits = char_traits<CharT>,

--- a/src/cpp/library/string
+++ b/src/cpp/library/string
@@ -2,6 +2,7 @@
 #define STL_STRING
 
 #include "definitions.h"
+#include "iosfwd" // declares basic_string with its default arguments
 #include "OM_compiler_defs.h" // OM_NOEXCEPT
 #include "char_traits.h"
 #include "iterator_tags.h"
@@ -24,10 +25,7 @@ extern "C" void itoa(int value, char *str, int base);
 
 namespace std
 {
-template <
-  class CharT,
-  class Traits = char_traits<CharT>,
-  class Alloc = allocator<CharT> >
+template <class CharT, class Traits, class Alloc>
 class basic_string
 {
 public:


### PR DESCRIPTION
```cpp
#include <iosfwd>
std::basic_string<char> *p = 0;
int main() { return p != 0; }
```

`g++ -std=c++11` and `clang++ -std=c++11` both accept this — libstdc++ declares `basic_string` from `<iosfwd>` via `<bits/stringfwd.h>` — while ESBMC reported `no template named 'basic_string' in namespace 'std'` and `PARSING ERROR`. Per the repo's rule for a library that offers more than the standard requires, that is a false rejection of valid input.

The default arguments go in `<iosfwd>` and the definition in `<string>` drops them. That is the opposite of the neighbouring `basic_streambuf`, whose defaults stay with its definition, and it is deliberate: naming `basic_string<char>` from `<iosfwd>` alone needs the defaults visible there, and clang rejects a second declaration that repeats them — the same trap #7531 documents.

The tests deliberately do **not** include `<string>`: including it supplies the declaration and they stop pinning `<iosfwd>`. Both fail on master and pass here.

`ctest -L esbmc-cpp/cpp`: **958/978**, 20 failures, none attributable to this change:

- `ch8_5`, `ch9_7` and five `github_7433*` — pre-existing failures on this checkout.
- `github_6310_typeid_dynamic` and `_fail` — abort on master with an SMT sort error (`supplied sort is (_ BitVec 64)`); verified against master.
- `github_3267_uint32_no_stdint_fail`, four `filesystem_*`, and six `vector_*` — all `--incremental-bmc` or filesystem-heavy tests timing out on a loaded machine. Verified on master: `github_3267_uint32_no_stdint_fail` times out at 500 s and `vector_emplace_back` at 240 s there too.

This completes the `<iosfwd>` gap #7531 is about; that issue's own `basic_*` stream aliases already landed separately, so this is `Refs`, not `Fixes`.

Refs #7531
