### PR TITLE
[om] Add the C++20 <numbers> header

### DIFF
--- a/regression/esbmc-cpp/cpp/cpp20_numbers/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp20_numbers/main.cpp
@@ -1,0 +1,14 @@
+// [numbers.syn]: the C++20 mathematical constants. Values checked against
+// g++ -std=c++20 at runtime, not just for parseability.
+#include <numbers>
+#include <cassert>
+
+int main()
+{
+  assert(std::numbers::pi > 3.14159 && std::numbers::pi < 3.14160);
+  assert(std::numbers::e > 2.71828 && std::numbers::e < 2.71829);
+  assert(std::numbers::sqrt2 > 1.41421 && std::numbers::sqrt2 < 1.41422);
+  assert(std::numbers::ln2 < std::numbers::ln10);
+  assert(std::numbers::pi_v<float> > 3.14f);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cpp20_numbers/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp20_numbers/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/cpp20_numbers_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp20_numbers_fail/main.cpp
@@ -1,0 +1,14 @@
+// [numbers.syn]: the C++20 mathematical constants. Values checked against
+// g++ -std=c++20 at runtime, not just for parseability.
+#include <numbers>
+#include <cassert>
+
+int main()
+{
+  assert(std::numbers::pi > 3.14159 && std::numbers::pi < 3.14000);
+  assert(std::numbers::e > 2.71828 && std::numbers::e < 2.71829);
+  assert(std::numbers::sqrt2 > 1.41421 && std::numbers::sqrt2 < 1.41422);
+  assert(std::numbers::ln2 < std::numbers::ln10);
+  assert(std::numbers::pi_v<float> > 3.14f);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cpp20_numbers_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp20_numbers_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20
+^VERIFICATION FAILED$

--- a/src/cpp/library/numbers
+++ b/src/cpp/library/numbers
@@ -1,0 +1,78 @@
+#ifndef ESBMC_NUMBERS
+#define ESBMC_NUMBERS
+
+// C++20 header. libstdc++ and libc++ both expand it to nothing in an older
+// language mode rather than erroring, so a translation unit that includes it
+// unconditionally still compiles (github #3387).
+#if __cplusplus >= 202002L
+
+namespace std
+{
+namespace numbers
+{
+
+// [numbers.syn]. libstdc++ constrains each variable template with
+// `requires is_floating_point_v<T>`; that needs concepts, which the bundled
+// headers do not yet provide, so the primary templates are left unconstrained.
+// Instantiating one with a non-floating-point type is ill-formed per the
+// standard and simply is not diagnosed here.
+template <class T>
+inline constexpr T e_v =
+  static_cast<T>(2.718281828459045235360287471352662498L);
+template <class T>
+inline constexpr T log2e_v =
+  static_cast<T>(1.442695040888963407359924681001892137L);
+template <class T>
+inline constexpr T log10e_v =
+  static_cast<T>(0.434294481903251827651128918916605082L);
+template <class T>
+inline constexpr T pi_v =
+  static_cast<T>(3.141592653589793238462643383279502884L);
+template <class T>
+inline constexpr T inv_pi_v =
+  static_cast<T>(0.318309886183790671537767526745028724L);
+template <class T>
+inline constexpr T inv_sqrtpi_v =
+  static_cast<T>(0.564189583547756286948079451560772586L);
+template <class T>
+inline constexpr T ln2_v =
+  static_cast<T>(0.693147180559945309417232121458176568L);
+template <class T>
+inline constexpr T ln10_v =
+  static_cast<T>(2.302585092994045684017991454684364208L);
+template <class T>
+inline constexpr T sqrt2_v =
+  static_cast<T>(1.414213562373095048801688724209698079L);
+template <class T>
+inline constexpr T sqrt3_v =
+  static_cast<T>(1.732050807568877293527446341505872367L);
+template <class T>
+inline constexpr T inv_sqrt3_v =
+  static_cast<T>(0.577350269189625764509148780501957456L);
+template <class T>
+inline constexpr T egamma_v =
+  static_cast<T>(0.577215664901532860606512090082402431L);
+template <class T>
+inline constexpr T phi_v =
+  static_cast<T>(1.618033988749894848204586834365638118L);
+
+inline constexpr double e = e_v<double>;
+inline constexpr double log2e = log2e_v<double>;
+inline constexpr double log10e = log10e_v<double>;
+inline constexpr double pi = pi_v<double>;
+inline constexpr double inv_pi = inv_pi_v<double>;
+inline constexpr double inv_sqrtpi = inv_sqrtpi_v<double>;
+inline constexpr double ln2 = ln2_v<double>;
+inline constexpr double ln10 = ln10_v<double>;
+inline constexpr double sqrt2 = sqrt2_v<double>;
+inline constexpr double sqrt3 = sqrt3_v<double>;
+inline constexpr double inv_sqrt3 = inv_sqrt3_v<double>;
+inline constexpr double egamma = egamma_v<double>;
+inline constexpr double phi = phi_v<double>;
+
+} // namespace numbers
+} // namespace std
+
+#endif // __cplusplus >= 202002L
+
+#endif


### PR DESCRIPTION
`#include <numbers>` was `fatal error: 'numbers' file not found` / `PARSING ERROR`, so no program using `std::numbers::pi` could be verified at all. It is one of the missing-header items in #4377.

Provides [numbers.syn]'s thirteen variable templates (`pi_v<T>` … `phi_v<T>`) and their `double` shorthands, guarded on `__cplusplus >= 202002L` exactly as `<bit>` is, so including it in an older language mode stays a no-op — verified with `--std=c++11`, which both ESBMC and g++ accept.

The values are not just parseable, they are right: the test's assertions were compiled and **run** under `g++ -std=c++20` and all hold, and the `_fail` variant aborts there.

libstdc++ constrains each variable template with `requires is_floating_point_v<T>`. That needs `<concepts>`, which is not bundled (it is a separate #4377 item), so the primary templates are left unconstrained and a one-line comment records why.

Both tests fail with the header removed and pass with it. Suite: the new pair plus 260 `esbmc-cpp/cpp` tests pass; I could not get a larger slice through on a machine that is currently at load 13, and the change is a new file nothing else includes.

Refs #4377