### PR TITLE
[om] Add the C++20 <concepts> header

### DIFF
--- a/regression/esbmc-cpp/cpp/cpp20_concepts/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp20_concepts/main.cpp
@@ -1,0 +1,27 @@
+#include <concepts>
+#include <cassert>
+
+template <std::integral T> T twice(T v) { return v + v; }
+template <std::floating_point T> T half(T v) { return v / 2; }
+
+struct Plain { int x = 0; bool operator==(const Plain &) const = default; };
+
+int main() {
+  static_assert(std::same_as<int, int>);
+  static_assert(!std::same_as<int, long>);
+  static_assert(std::integral<int> && !std::integral<double>);
+  static_assert(std::signed_integral<int> && std::unsigned_integral<unsigned>);
+  static_assert(std::floating_point<double>);
+  static_assert(std::convertible_to<int, long>);
+  static_assert(std::destructible<int>);
+  static_assert(std::default_initializable<Plain>);
+  static_assert(std::equality_comparable<int>);
+  static_assert(std::totally_ordered<int>);
+  static_assert(std::movable<Plain>);
+  static_assert(std::copyable<Plain>);
+  static_assert(std::semiregular<Plain>);
+  static_assert(std::regular<int>);
+  assert(twice(3) == 6);
+  assert(half(4.0) == 2.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cpp20_concepts/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp20_concepts/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/cpp20_concepts_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp20_concepts_fail/main.cpp
@@ -1,0 +1,27 @@
+#include <concepts>
+#include <cassert>
+
+template <std::integral T> T twice(T v) { return v + v; }
+template <std::floating_point T> T half(T v) { return v / 2; }
+
+struct Plain { int x = 0; bool operator==(const Plain &) const = default; };
+
+int main() {
+  static_assert(std::same_as<int, int>);
+  static_assert(!std::same_as<int, long>);
+  static_assert(std::integral<int> && !std::integral<double>);
+  static_assert(std::signed_integral<int> && std::unsigned_integral<unsigned>);
+  static_assert(std::floating_point<double>);
+  static_assert(std::convertible_to<int, long>);
+  static_assert(std::destructible<int>);
+  static_assert(std::default_initializable<Plain>);
+  static_assert(std::equality_comparable<int>);
+  static_assert(std::totally_ordered<int>);
+  static_assert(std::movable<Plain>);
+  static_assert(std::copyable<Plain>);
+  static_assert(std::semiregular<Plain>);
+  static_assert(std::regular<int>);
+  assert(twice(3) == 7);
+  assert(half(4.0) == 2.0);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cpp20_concepts_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp20_concepts_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20
+^VERIFICATION FAILED$

--- a/src/cpp/library/concepts
+++ b/src/cpp/library/concepts
@@ -1,0 +1,142 @@
+#ifndef ESBMC_CONCEPTS
+#define ESBMC_CONCEPTS
+
+#include "type_traits"
+#include "utility"
+
+// C++20 header. libstdc++ and libc++ both expand it to nothing in an older
+// language mode rather than erroring, so a translation unit that includes it
+// unconditionally still compiles (github #3387).
+#if __cplusplus >= 202002L
+
+// [concepts.syn], partially. Only the concepts whose definition follows
+// exactly from the type traits this tree already provides are declared. The
+// rest -- common_with, common_reference_with, swappable_with,
+// equality_comparable_with, totally_ordered_with, and the invocable family
+// (invocable, regular_invocable, predicate, relation, equivalence_relation,
+// strict_weak_order) -- need common_reference, is_swappable or std::invoke,
+// none of which are modelled here. They are deliberately left undeclared:
+// naming one stays the compile error it already is, whereas an approximate
+// definition would reject well-formed code (an invocable spelled as a direct
+// call rejects a pointer-to-member callable, which std::invoke accepts).
+
+namespace std
+{
+
+template <class T, class U>
+concept same_as = is_same<T, U>::value &&is_same<U, T>::value;
+
+template <class Derived, class Base>
+concept derived_from = is_base_of<Base, Derived>::value
+  &&is_convertible<const volatile Derived *, const volatile Base *>::value;
+
+template <class From, class To>
+concept convertible_to = is_convertible<From, To>::value &&requires
+{
+  static_cast<To>(declval<From>());
+};
+
+template <class T>
+concept integral = is_integral<T>::value;
+
+template <class T>
+concept signed_integral = integral<T> && is_signed<T>::value;
+
+template <class T>
+concept unsigned_integral = integral<T> && !signed_integral<T>;
+
+template <class T>
+concept floating_point = is_floating_point<T>::value;
+
+template <class T>
+concept destructible = is_nothrow_destructible<T>::value;
+
+template <class T, class... Args>
+concept constructible_from =
+  destructible<T> && is_constructible<T, Args...>::value;
+
+template <class T>
+concept default_initializable = constructible_from<T> && requires
+{
+  T{};
+};
+
+template <class T>
+concept move_constructible = constructible_from<T, T> && convertible_to<T, T>;
+
+template <class T>
+concept copy_constructible =
+  move_constructible<T> && constructible_from<T, T &> && convertible_to<T &, T>
+    &&constructible_from<T, const T &> && convertible_to<const T &, T>;
+
+template <class LHS, class RHS>
+concept assignable_from =
+  is_lvalue_reference<LHS>::value &&requires(LHS lhs, RHS &&rhs)
+{
+  {
+    lhs = static_cast<RHS &&>(rhs)
+  }
+  ->same_as<LHS>;
+};
+
+template <class T>
+concept swappable = requires(T &a, T &b)
+{
+  swap(a, b);
+};
+
+template <class T>
+concept equality_comparable = requires(const T &a, const T &b)
+{
+  {
+    a == b
+  }
+  ->convertible_to<bool>;
+  {
+    a != b
+  }
+  ->convertible_to<bool>;
+};
+
+template <class T>
+concept totally_ordered = equality_comparable<T> && requires(
+  const T &a, const T &b)
+{
+  {
+    a < b
+  }
+  ->convertible_to<bool>;
+  {
+    a > b
+  }
+  ->convertible_to<bool>;
+  {
+    a <= b
+  }
+  ->convertible_to<bool>;
+  {
+    a >= b
+  }
+  ->convertible_to<bool>;
+};
+
+template <class T>
+concept movable = is_object<T>::value &&move_constructible<T>
+  &&assignable_from<T &, T> && swappable<T>;
+
+template <class T>
+concept copyable = copy_constructible<T> && movable<T> &&
+  assignable_from<T &, T &> && assignable_from<T &, const T &> &&
+  assignable_from<T &, const T>;
+
+template <class T>
+concept semiregular = copyable<T> && default_initializable<T>;
+
+template <class T>
+concept regular = semiregular<T> && equality_comparable<T>;
+
+} // namespace std
+
+#endif // __cplusplus >= 202002L
+
+#endif


### PR DESCRIPTION
`#include <concepts>` was `fatal error: 'concepts' file not found` / `PARSING ERROR`, so no program naming `std::integral` could be verified. It is one of the missing-header items in #4377.

The frontend itself already handles concepts — `concept` declarations, constrained template parameters, `requires`-clauses and `requires`-expressions all parse and verify — so only the header was missing. (#4377 lists named concept declarations as a converter crash; that item is stale, they work.)

**What is declared:** the [concepts.syn] concepts that follow exactly from the type traits this tree already models — `same_as`, `derived_from`, `convertible_to`, the `integral`/`floating_point` family, `destructible`, `constructible_from`, `default_initializable`, `move_constructible`, `copy_constructible`, `assignable_from`, `swappable`, `equality_comparable`, `totally_ordered`, `movable`, `copyable`, `semiregular`, `regular`.

**What is deliberately not declared:** `common_with`, `common_reference_with`, `swappable_with`, `equality_comparable_with`, `totally_ordered_with`, and the `invocable` family. They need `common_reference`, `is_swappable` or `std::invoke`, none of which are modelled. Naming one stays exactly the compile error it is today, whereas an approximate definition would **reject well-formed code** — an `invocable` written as a direct call rejects a pointer-to-member callable that `std::invoke` accepts. Omitting cannot regress anything; approximating can.

The test's fourteen `static_assert`s are checked against **g++'s real `<concepts>`** as well as this one, so the definitions are verified to agree with libstdc++ rather than merely to compile. Guarded on `__cplusplus >= 202002L` like `<bit>`; including it under `--std=c++11` is a no-op.

Both tests fail with the header removed. The new pair plus 240 `esbmc-cpp/cpp` tests pass; larger slices do not complete on a machine currently at load 13.

Refs #4377