### PR TITLE
[python] Record why string-augmented-repeat cannot be fixed by unwinding

### DIFF
--- a/regression/python/string-augmented-repeat/main.py
+++ b/regression/python/string-augmented-repeat/main.py
@@ -1,3 +1,19 @@
+# KNOWNBUG. The frontend is not flow-sensitive about a symbol's type: one
+# symbol, one type. `s = "ab"` wants char[3] and the repeat yields a string of
+# statically-unknown length, so the only type fitting both assignments is a
+# bare pointer. The GOTO shows it -- with a fresh target the source stays an
+# array and the model gets a static length, with a rebind it does not:
+#
+#     t = s * 3  ->  ASSIGN s={ 97, 98, 0 };      t=__python_str_repeat(&s[0], 3)
+#     s = s * 3  ->  ASSIGN s=&{ 97, 98, 0 }[0];  s=__python_str_repeat(&s[0], 3)
+#
+# __python_str_repeat then has to walk the pointer, so its copy loop
+# (src/c2goto/library/python/string.c:1593) has no static bound -- it reached
+# iteration 9303 and was still climbing for this six-character result. Raising
+# --unwind therefore cannot fix this test; the bound is gone, not too small.
+# The fix is to mint a fresh symbol for the retyped `s`, as get_var_assign
+# already does across the numeric<->string boundary (#4770/#4774).
+# string-repeat-fresh-target pins the shape that does work.
 s = "ab"
 s *= 3
 assert s == "ababab"

--- a/regression/python/string-repeat-fresh-target/main.py
+++ b/regression/python/string-repeat-fresh-target/main.py
@@ -1,0 +1,7 @@
+# The working counterpart of string-augmented-repeat: with a fresh target the
+# source keeps its array type, so __python_str_repeat gets a static length.
+s = "ab"
+t = s * 3
+assert t == "ababab"
+assert len(t) == 6
+assert s == "ab"

--- a/regression/python/string-repeat-fresh-target/test.desc
+++ b/regression/python/string-repeat-fresh-target/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`regression/python/string-augmented-repeat` is `KNOWNBUG` with no recorded cause, which invites the wrong fix. The `--goto-functions-only` diff names it:

```
t = s * 3  ->  ASSIGN s={ 97, 98, 0 };      t=__python_str_repeat(&s[0], 3)
s = s * 3  ->  ASSIGN s=&{ 97, 98, 0 }[0];  s=__python_str_repeat(&s[0], 3)
```

The frontend is not flow-sensitive about a symbol's type — one symbol, one type. `s = "ab"` wants `char[3]` and the repeat yields a string of statically-unknown length, so the only type fitting both assignments is a bare pointer. `__python_str_repeat` then has to walk that pointer, and its copy loop (`src/c2goto/library/python/string.c:1593`) has **no static bound** — it reached iteration 9303 and was still climbing for this six-character result.

That matters because the obvious fix is the wrong one: raising `--unwind` cannot help here, unlike `quixbugs/next_permutation` where the bound was merely too small. The real fix is to mint a fresh symbol for the retyped `s`, as `get_var_assign` already does across the numeric↔string boundary (#4770/#4774). Not attempted here.

The trigger is assignment to an **existing** string variable, not the repeat and not self-reference: `s = s * 3`, `s *= 3`, `t = s * 3; s = t` and `s = "ab" * 3` all diverge, while `t = s * 3` verifies instantly. So this adds `string-repeat-fresh-target` as a CORE test pinning the shape that works, so a future fix cannot silently break it.

No source changes. The new test is CPython-sane and mutation-checked (expecting `"ababa"` turns it `VERIFICATION FAILED`); it and the documented KNOWNBUG both pass. I could not run a wider slice — the machine is at load 21 and ctest runs are being killed — but with no source touched the blast radius is the two test directories.