### PR TITLE
[om] Add the <version> feature-test header

### DIFF
--- a/regression/esbmc-cpp/cpp/cpp_version_macros/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp_version_macros/main.cpp
@@ -1,0 +1,66 @@
+// Each macro <version> claims is tied here to the feature actually working, so
+// the header cannot promise something the operational models do not provide.
+#include <version>
+#include <cassert>
+
+#include <optional>
+#include <variant>
+#include <any>
+#include <string_view>
+#include <span>
+#include <bit>
+#include <source_location>
+#include <expected>
+
+int main()
+{
+#ifndef __cpp_lib_optional
+#  error "<version> must claim __cpp_lib_optional"
+#endif
+  std::optional<int> o = 5;
+  assert(o.has_value() && *o == 5);
+
+#ifndef __cpp_lib_variant
+#  error "<version> must claim __cpp_lib_variant"
+#endif
+  std::variant<int, double> v = 7;
+  assert(v.index() == 0);
+
+#ifndef __cpp_lib_any
+#  error "<version> must claim __cpp_lib_any"
+#endif
+  std::any a = 5;
+  assert(a.has_value());
+
+#ifndef __cpp_lib_string_view
+#  error "<version> must claim __cpp_lib_string_view"
+#endif
+  std::string_view sv = "ab";
+  assert(sv.size() == 2);
+
+#ifndef __cpp_lib_span
+#  error "<version> must claim __cpp_lib_span"
+#endif
+  int arr[3] = {1, 2, 3};
+  std::span<int> sp(arr, 3);
+  assert(sp.size() == 3);
+
+#ifndef __cpp_lib_bit_cast
+#  error "<version> must claim __cpp_lib_bit_cast"
+#endif
+  assert(std::bit_cast<int>(1.0f) != 0);
+
+#ifndef __cpp_lib_source_location
+#  error "<version> must claim __cpp_lib_source_location"
+#endif
+  auto loc = std::source_location::current();
+  (void)loc;
+
+#ifndef __cpp_lib_expected
+#  error "<version> must claim __cpp_lib_expected"
+#endif
+  std::expected<int, int> e = 1;
+  assert(e.has_value());
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cpp_version_macros/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp_version_macros/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++23
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/cpp_version_macros_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/cpp_version_macros_fail/main.cpp
@@ -1,0 +1,66 @@
+// Each macro <version> claims is tied here to the feature actually working, so
+// the header cannot promise something the operational models do not provide.
+#include <version>
+#include <cassert>
+
+#include <optional>
+#include <variant>
+#include <any>
+#include <string_view>
+#include <span>
+#include <bit>
+#include <source_location>
+#include <expected>
+
+int main()
+{
+#ifndef __cpp_lib_optional
+#  error "<version> must claim __cpp_lib_optional"
+#endif
+  std::optional<int> o = 5;
+  assert(o.has_value() && *o == 5);
+
+#ifndef __cpp_lib_variant
+#  error "<version> must claim __cpp_lib_variant"
+#endif
+  std::variant<int, double> v = 7;
+  assert(v.index() == 0);
+
+#ifndef __cpp_lib_any
+#  error "<version> must claim __cpp_lib_any"
+#endif
+  std::any a = 5;
+  assert(a.has_value());
+
+#ifndef __cpp_lib_string_view
+#  error "<version> must claim __cpp_lib_string_view"
+#endif
+  std::string_view sv = "ab";
+  assert(sv.size() == 2);
+
+#ifndef __cpp_lib_span
+#  error "<version> must claim __cpp_lib_span"
+#endif
+  int arr[3] = {1, 2, 3};
+  std::span<int> sp(arr, 3);
+  assert(sp.size() == 4);
+
+#ifndef __cpp_lib_bit_cast
+#  error "<version> must claim __cpp_lib_bit_cast"
+#endif
+  assert(std::bit_cast<int>(1.0f) != 0);
+
+#ifndef __cpp_lib_source_location
+#  error "<version> must claim __cpp_lib_source_location"
+#endif
+  auto loc = std::source_location::current();
+  (void)loc;
+
+#ifndef __cpp_lib_expected
+#  error "<version> must claim __cpp_lib_expected"
+#endif
+  std::expected<int, int> e = 1;
+  assert(e.has_value());
+
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/cpp_version_macros_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/cpp_version_macros_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++23
+^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_3897/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3897/main.cpp
@@ -1,10 +1,12 @@
-// <version> is a macro-only libc++/libstdc++ header with no operational
-// model in ESBMC's bundled C++ library, so it is only reachable when the
-// host system headers are made visible alongside the OMs.
-#include <version>
+// <cfenv> is not covered by ESBMC's bundled OMs, so it is only reachable
+// when the host system headers are made visible alongside them. It is a thin
+// wrapper over <fenv.h>, which ESBMC's own libc does model, so mixing the two
+// trees is enough to compile it.
+#include <cfenv>
 
 int main()
 {
-  __ESBMC_assert(1, "host-only header compiled alongside ESBMC's OMs");
+  __ESBMC_assert(
+    FE_TONEAREST == FE_TONEAREST, "host-only header compiled alongside ESBMC's OMs");
   return 0;
 }

--- a/regression/esbmc-cpp/cpp/github_3897_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_3897_fail/main.cpp
@@ -1,11 +1,12 @@
 // Same as regression/esbmc-cpp/cpp/github_3897, but run WITHOUT
-// --mix-cpp-host-headers: <version> has no operational model, so the
+// --mix-cpp-host-headers: <cfenv> has no operational model, so the
 // default (opt-out) behaviour must still reject it with a parse error,
 // proving --mix-cpp-host-headers is genuinely opt-in.
-#include <version>
+#include <cfenv>
 
 int main()
 {
-  __ESBMC_assert(1, "host-only header should not be reachable by default");
+  __ESBMC_assert(
+    FE_TONEAREST == FE_TONEAREST, "host-only header should not be reachable by default");
   return 0;
 }

--- a/src/cpp/library/version
+++ b/src/cpp/library/version
@@ -1,0 +1,31 @@
+#ifndef ESBMC_VERSION
+#define ESBMC_VERSION
+
+// [version.syn]: this header defines feature-test macros only, no entities.
+//
+// A macro here is a promise that the bundled operational models really provide
+// the feature, because portable code branches on it: claiming one ESBMC cannot
+// honour sends a program down a path the models do not implement. So only
+// features exercised by regression/esbmc-cpp/cpp/cpp_version_macros are
+// claimed, and the many library features this tree does not model yet are
+// simply left undefined -- which is what a conforming program treats as
+// "unavailable", the conservative answer.
+
+#if __cplusplus >= 201703L
+#  define __cpp_lib_optional 201606L
+#  define __cpp_lib_variant 201606L
+#  define __cpp_lib_any 201606L
+#  define __cpp_lib_string_view 201803L
+#endif
+
+#if __cplusplus >= 202002L
+#  define __cpp_lib_span 202002L
+#  define __cpp_lib_bit_cast 201806L
+#  define __cpp_lib_source_location 201907L
+#endif
+
+#if __cplusplus >= 202302L
+#  define __cpp_lib_expected 202202L
+#endif
+
+#endif


### PR DESCRIPTION
`#include <version>` was `fatal error: 'version' file not found` / `PARSING ERROR`. It is the header portable code includes to ask what the library supports, so its absence blocks a whole class of programs regardless of which features they end up using.

[version.syn] defines feature-test macros and nothing else, which makes the header trivial to add and easy to get *wrong*: **a macro here is a promise**. Claiming one ESBMC cannot honour is worse than omitting it, because the program then branches into a path the operational models do not implement. So this claims only eight features, each verified by a program that actually uses it:

`__cpp_lib_optional`, `__cpp_lib_variant`, `__cpp_lib_any`, `__cpp_lib_string_view` (C++17); `__cpp_lib_span`, `__cpp_lib_bit_cast`, `__cpp_lib_source_location` (C++20); `__cpp_lib_expected` (C++23).

Everything else this tree does not model — `<ranges>`, `<format>`, `<concepts>`, `<numbers>`, and the rest — is deliberately left undefined, which a conforming program reads as "unavailable": the conservative answer.

The test is built so the header cannot drift from reality: each macro is checked with `#ifndef … #error` **and** the corresponding feature is exercised in the same translation unit, so removing a model breaks the test rather than leaving a false promise. It also compiles and runs under `g++ -std=c++23` against the real libstdc++, which defines the same macros — so the values and `__cplusplus` guards are cross-checked, not guessed.

Guarded per language level; including it under `--std=c++11` is a no-op. Both tests fail with the header removed. The new pair plus 150 `esbmc-cpp/cpp` tests pass; larger slices are not completing on a machine at load 15-21.

Found by sweeping the standard headers for `file not found`, prompted by #4377's missing-model items. Still missing after this: `<ranges>`, `<format>`, `<print>`, `<coroutine>`, `<charconv>`, `<regex>`, `<memory_resource>`, `<execution>`, `<stop_token>`, `<semaphore>`, `<latch>`, `<barrier>`, `<flat_map>`, `<mdspan>`, `<generator>`, `<stdfloat>`.

Refs #4377