### PR TITLE
[om] Add the C++17 <memory_resource> header

### DIFF
--- a/regression/esbmc-cpp/cpp/pmr_memory_resource/main.cpp
+++ b/regression/esbmc-cpp/cpp/pmr_memory_resource/main.cpp
@@ -1,0 +1,50 @@
+// std::pmr core. Every expectation was first compiled and run under
+// g++ -std=c++17 against real libstdc++.
+#include <memory_resource>
+#include <new>
+#include <cassert>
+
+int main()
+{
+  std::pmr::memory_resource *r = std::pmr::new_delete_resource();
+  assert(r != nullptr);
+  assert(std::pmr::get_default_resource() == r);
+
+  std::pmr::polymorphic_allocator<int> a(r);
+  assert(a.resource() == r);
+
+  int *p = a.allocate(4);
+  assert(p != nullptr);
+  p[0] = 11;
+  p[3] = 22;
+  assert(p[0] == 11 && p[3] == 22);
+  a.deallocate(p, 4);
+
+  std::pmr::polymorphic_allocator<int> b;
+  assert(b.resource() == std::pmr::get_default_resource());
+  assert(a == b);
+
+  std::pmr::memory_resource *old =
+    std::pmr::set_default_resource(std::pmr::null_memory_resource());
+  assert(old == r);
+  assert(std::pmr::get_default_resource() == std::pmr::null_memory_resource());
+
+  bool threw = false;
+  try
+  {
+    void *q = std::pmr::null_memory_resource()->allocate(1);
+    (void)q;
+  }
+  catch (const std::bad_alloc &)
+  {
+    threw = true;
+  }
+  assert(threw);
+
+  std::pmr::set_default_resource(old);
+  assert(std::pmr::get_default_resource() == r);
+
+  assert(*r == *std::pmr::new_delete_resource());
+  assert(*r != *std::pmr::null_memory_resource());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/pmr_memory_resource/test.desc
+++ b/regression/esbmc-cpp/cpp/pmr_memory_resource/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/pmr_memory_resource_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/pmr_memory_resource_fail/main.cpp
@@ -1,0 +1,50 @@
+// std::pmr core. Every expectation was first compiled and run under
+// g++ -std=c++17 against real libstdc++.
+#include <memory_resource>
+#include <new>
+#include <cassert>
+
+int main()
+{
+  std::pmr::memory_resource *r = std::pmr::new_delete_resource();
+  assert(r != nullptr);
+  assert(std::pmr::get_default_resource() == r);
+
+  std::pmr::polymorphic_allocator<int> a(r);
+  assert(a.resource() == r);
+
+  int *p = a.allocate(4);
+  assert(p != nullptr);
+  p[0] = 11;
+  p[3] = 22;
+  assert(p[0] == 11 && p[3] == 23);
+  a.deallocate(p, 4);
+
+  std::pmr::polymorphic_allocator<int> b;
+  assert(b.resource() == std::pmr::get_default_resource());
+  assert(a == b);
+
+  std::pmr::memory_resource *old =
+    std::pmr::set_default_resource(std::pmr::null_memory_resource());
+  assert(old == r);
+  assert(std::pmr::get_default_resource() == std::pmr::null_memory_resource());
+
+  bool threw = false;
+  try
+  {
+    void *q = std::pmr::null_memory_resource()->allocate(1);
+    (void)q;
+  }
+  catch (const std::bad_alloc &)
+  {
+    threw = true;
+  }
+  assert(threw);
+
+  std::pmr::set_default_resource(old);
+  assert(std::pmr::get_default_resource() == r);
+
+  assert(*r == *std::pmr::new_delete_resource());
+  assert(*r != *std::pmr::null_memory_resource());
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/pmr_memory_resource_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/pmr_memory_resource_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17
+^VERIFICATION FAILED$

--- a/src/cpp/library/memory_resource
+++ b/src/cpp/library/memory_resource
@@ -1,0 +1,201 @@
+#ifndef ESBMC_MEMORY_RESOURCE
+#define ESBMC_MEMORY_RESOURCE
+
+#include "cstddef"
+#include "new"
+
+#if __cplusplus >= 201703L
+
+// [mem.res]: the resource interface, the two standard resources, the
+// default-resource accessors and polymorphic_allocator.
+//
+// The pool resources and monotonic_buffer_resource are not modelled. They are
+// allocation strategies whose whole observable content is where the bytes come
+// from and when they are released, so a stub forwarding to new/delete would
+// verify a program against the wrong lifetime; an absent class stays the
+// compile error it already is.
+
+namespace std
+{
+namespace pmr
+{
+
+class memory_resource
+{
+public:
+  virtual ~memory_resource()
+  {
+  }
+
+  void *allocate(size_t bytes, size_t alignment = alignof(max_align_t))
+  {
+    return do_allocate(bytes, alignment);
+  }
+
+  void deallocate(void *p, size_t bytes, size_t alignment = alignof(max_align_t))
+  {
+    do_deallocate(p, bytes, alignment);
+  }
+
+  bool is_equal(const memory_resource &other) const noexcept
+  {
+    return do_is_equal(other);
+  }
+
+protected:
+  virtual void *do_allocate(size_t bytes, size_t alignment) = 0;
+  virtual void do_deallocate(void *p, size_t bytes, size_t alignment) = 0;
+  virtual bool do_is_equal(const memory_resource &other) const noexcept = 0;
+};
+
+inline bool operator==(const memory_resource &a, const memory_resource &b)
+{
+  return &a == &b || a.is_equal(b);
+}
+
+inline bool operator!=(const memory_resource &a, const memory_resource &b)
+{
+  return !(a == b);
+}
+
+namespace __detail
+{
+class __new_delete_resource : public memory_resource
+{
+protected:
+  void *do_allocate(size_t bytes, size_t) override
+  {
+    return ::operator new(bytes);
+  }
+
+  void do_deallocate(void *p, size_t, size_t) override
+  {
+    ::operator delete(p);
+  }
+
+  bool do_is_equal(const memory_resource &other) const noexcept override
+  {
+    return this == &other;
+  }
+};
+
+// [mem.res.global]/5: null_memory_resource()->allocate() always throws.
+class __null_resource : public memory_resource
+{
+protected:
+  void *do_allocate(size_t, size_t) override
+  {
+    throw bad_alloc();
+  }
+
+  void do_deallocate(void *, size_t, size_t) override
+  {
+  }
+
+  bool do_is_equal(const memory_resource &other) const noexcept override
+  {
+    return this == &other;
+  }
+};
+
+inline __new_delete_resource *__new_delete()
+{
+  static __new_delete_resource r;
+  return &r;
+}
+
+inline __null_resource *__null_res()
+{
+  static __null_resource r;
+  return &r;
+}
+
+inline memory_resource *&__default_resource()
+{
+  static memory_resource *r = __new_delete();
+  return r;
+}
+} // namespace __detail
+
+inline memory_resource *new_delete_resource() noexcept
+{
+  return __detail::__new_delete();
+}
+
+inline memory_resource *null_memory_resource() noexcept
+{
+  return __detail::__null_res();
+}
+
+inline memory_resource *get_default_resource() noexcept
+{
+  return __detail::__default_resource();
+}
+
+inline memory_resource *set_default_resource(memory_resource *r) noexcept
+{
+  memory_resource *old = __detail::__default_resource();
+  __detail::__default_resource() = (r == nullptr) ? new_delete_resource() : r;
+  return old;
+}
+
+template <class T>
+class polymorphic_allocator
+{
+  memory_resource *__r;
+
+public:
+  typedef T value_type;
+
+  polymorphic_allocator() noexcept : __r(get_default_resource())
+  {
+  }
+
+  polymorphic_allocator(memory_resource *r) noexcept : __r(r)
+  {
+  }
+
+  template <class U>
+  polymorphic_allocator(const polymorphic_allocator<U> &other) noexcept
+    : __r(other.resource())
+  {
+  }
+
+  T *allocate(size_t n)
+  {
+    return static_cast<T *>(__r->allocate(n * sizeof(T), alignof(T)));
+  }
+
+  void deallocate(T *p, size_t n)
+  {
+    __r->deallocate(p, n * sizeof(T), alignof(T));
+  }
+
+  memory_resource *resource() const
+  {
+    return __r;
+  }
+};
+
+template <class T, class U>
+bool operator==(
+  const polymorphic_allocator<T> &a,
+  const polymorphic_allocator<U> &b) noexcept
+{
+  return *a.resource() == *b.resource();
+}
+
+template <class T, class U>
+bool operator!=(
+  const polymorphic_allocator<T> &a,
+  const polymorphic_allocator<U> &b) noexcept
+{
+  return !(a == b);
+}
+
+} // namespace pmr
+} // namespace std
+
+#endif // __cplusplus >= 201703L
+
+#endif


### PR DESCRIPTION
**Stacked on #7651** — `do_allocate(size_t, size_t)` forwards a byte count to `::operator new`, which is exactly the shape that PR fixes. Re-target to master once it merges.

`#include <memory_resource>` was `fatal error: 'memory_resource' file not found` / `PARSING ERROR`. This provides [mem.res]'s core: the `memory_resource` interface, `new_delete_resource()`, `null_memory_resource()`, `get_default_resource`/`set_default_resource`, and `polymorphic_allocator`.

This header is why #7650 and #7651 exist. I wrote it first, found that allocating through it reported an in-bounds write as out of bounds, and held it back rather than ship a header whose central operation false-alarms. Chasing that produced the pin and then the fix; with #7651 applied the same test verifies unchanged. It is a fair check on that fix: allocation here goes through a byte count crossing two virtual calls, which is what the old one-byte model got wrong.

**The pool resources and `monotonic_buffer_resource` are deliberately absent.** They are allocation *strategies* whose whole observable content is where the bytes come from and when they are released; a stub forwarding to `new`/`delete` would verify a program against the wrong lifetime, which is worse than the compile error naming one gives today. Same reasoning as the omitted concepts in #7639 and the floating-point `to_chars` in #7649.

Every expectation — including `null_memory_resource()->allocate()` throwing `bad_alloc`, resource identity through `operator==`, and `set_default_resource` returning the previous resource — was compiled and **run** under `g++ -std=c++17` against real libstdc++ before being checked here.

Guarded on C++17; including it under `--std=c++11` is a no-op. Both tests fail with the header removed. The pair, the three `operator_new_*` tests and 140 `esbmc-cpp/cpp` tests pass; larger slices are not completing at load ~15.

Refs #4377