### PR TITLE
[esbmc-cpp] Pin the displaced sibling members of a shared virtual base

### DIFF
--- a/regression/esbmc-cpp/inheritance/vbase_diamond_member_offsets/main.cpp
+++ b/regression/esbmc-cpp/inheritance/vbase_diamond_member_offsets/main.cpp
@@ -1,0 +1,44 @@
+// KNOWNBUG. When two sibling bases share a virtual base, the siblings' OWN
+// non-virtual members read wrongly from the complete object -- no upcast
+// needed, unlike the github_7025_vbase_shared_diamond residual, which needs a
+// pointer to a non-first base.
+//
+// The failure is selective, which is the useful part:
+//
+//   o.a == 1   PASSED   the shared virtual base's member
+//   o.b == 2   FAILED   first base's own member
+//   o.c == 3   FAILED   second base's own member
+//   o.d == 4   PASSED   the most-derived member
+//
+// so the virtual base itself lands correctly and it is B::b and C::c that are
+// displaced. vbase_single_and_nonvirtual pins the neighbouring shapes that do
+// work: one virtual base, a virtual base one level down, and a non-virtual
+// diamond. g++ runs this program with all four assertions holding.
+#include <cassert>
+
+struct A
+{
+  int a = 1;
+};
+struct B : virtual A
+{
+  int b = 2;
+};
+struct C : virtual A
+{
+  int c = 3;
+};
+struct D : B, C
+{
+  int d = 4;
+};
+
+int main()
+{
+  D o;
+  assert(o.a == 1);
+  assert(o.b == 2);
+  assert(o.c == 3);
+  assert(o.d == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/vbase_diamond_member_offsets/test.desc
+++ b/regression/esbmc-cpp/inheritance/vbase_diamond_member_offsets/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std=c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/inheritance/vbase_single_and_nonvirtual/main.cpp
+++ b/regression/esbmc-cpp/inheritance/vbase_single_and_nonvirtual/main.cpp
@@ -1,0 +1,52 @@
+// The controls for vbase_diamond_member_offsets: the neighbouring shapes that
+// do read correctly, so the defect stays localised to a virtual base SHARED by
+// two siblings rather than to virtual inheritance generally.
+#include <cassert>
+
+struct A
+{
+  int a = 1;
+};
+
+// one virtual base
+struct B1 : virtual A
+{
+  int b = 2;
+};
+
+// a virtual base one level further down
+struct B2 : virtual A
+{
+  int b = 2;
+};
+struct C2 : B2
+{
+  int c = 3;
+};
+
+// a non-virtual diamond: A is duplicated, so each subobject is separate
+struct NB : A
+{
+  int b = 2;
+};
+struct NC : A
+{
+  int c = 3;
+};
+struct ND : NB, NC
+{
+  int d = 4;
+};
+
+int main()
+{
+  B1 x;
+  assert(x.a == 1 && x.b == 2);
+
+  C2 y;
+  assert(y.a == 1 && y.b == 2 && y.c == 3);
+
+  ND z;
+  assert(z.NB::a == 1 && z.b == 2 && z.NC::a == 1 && z.c == 3 && z.d == 4);
+  return 0;
+}

--- a/regression/esbmc-cpp/inheritance/vbase_single_and_nonvirtual/test.desc
+++ b/regression/esbmc-cpp/inheritance/vbase_single_and_nonvirtual/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
A false alarm on a program g++ runs with every assertion holding:

```cpp
struct A { int a = 1; };
struct B : virtual A { int b = 2; };
struct C : virtual A { int c = 3; };
struct D : B, C  { int d = 4; };
D o;                       // assert(o.b == 2) FAILS
```

**The failure is selective, and that is the useful part:**

| read | verdict |
|---|---|
| `o.a == 1` — the shared virtual base's member | PASSED |
| `o.b == 2` — first base's own member | **FAILED** |
| `o.c == 3` — second base's own member | **FAILED** |
| `o.d == 4` — the most-derived member | PASSED |

So the virtual base itself lands correctly; it is `B::b` and `C::c` that are displaced. That is a different framing from the `github_7025_vbase_shared_diamond` residual, which describes the *virtual base* having no single displacement and needs a pointer upcast to a non-first base to show it. Here there is **no upcast at all** — default-initialising `D` and reading a member is enough, which is how a user meets it.

**Narrowed against the neighbours**, all of which verify and ship as the control test:

| shape | verdict |
|---|---|
| one virtual base, `struct B : virtual A` | SUCCESSFUL |
| virtual base one level down, `struct C : B` | SUCCESSFUL |
| non-virtual diamond (A duplicated) | SUCCESSFUL |
| **virtual base shared by two siblings** | **FAILED** |

so the defect is specific to *sharing*, not to virtual inheritance generally.

This PR does not fix it — the layout work behind #7025 is not a small change. It pins it, with the localisation recorded where the next person will find it, and the control guarding the shapes that currently work. Both programs were compiled and run under g++ first. The full `esbmc-cpp/inheritance` suite (121 tests) passes.
