### PR TITLE
[esbmc-cpp] Pin the false alarm on copying a shared_ptr-holding class

### DIFF
--- a/regression/esbmc-cpp/cpp/shared_ptr_copy_controls/main.cpp
+++ b/regression/esbmc-cpp/cpp/shared_ptr_copy_controls/main.cpp
@@ -1,0 +1,38 @@
+// The controls for shared_ptr_member_copy: the neighbouring shapes that do
+// verify, so the defect stays localised to copying a class that holds a
+// shared_ptr rather than to shared_ptr generally.
+#include <memory>
+#include <cassert>
+
+struct H
+{
+  std::shared_ptr<int> p;
+};
+
+H make_wrapper(const std::shared_ptr<int> &q)
+{
+  return H{q};
+}
+
+std::shared_ptr<int> make_bare()
+{
+  return std::make_shared<int>(3);
+}
+
+int main()
+{
+  // copying the shared_ptr itself
+  std::shared_ptr<int> a = std::make_shared<int>(1);
+  std::shared_ptr<int> b = a;
+  assert(*b == 1);
+
+  // a wrapper returned by value, rather than copied from an existing one
+  std::shared_ptr<int> q = std::make_shared<int>(2);
+  H w = make_wrapper(q);
+  assert(*w.p == 2);
+
+  // a bare shared_ptr returned by value
+  std::shared_ptr<int> r = make_bare();
+  assert(*r == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/shared_ptr_copy_controls/test.desc
+++ b/regression/esbmc-cpp/cpp/shared_ptr_copy_controls/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++20
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/shared_ptr_member_copy/main.cpp
+++ b/regression/esbmc-cpp/cpp/shared_ptr_member_copy/main.cpp
@@ -1,0 +1,28 @@
+// KNOWNBUG. Copying a class that holds a shared_ptr member reports
+// "invalidated dynamic object" inside shared_ptr's __release: the implicit
+// copy constructor does not keep the control block alive, so the shared
+// object is treated as freed while a live owner still refers to it.
+// g++ runs this program with the assertion holding.
+//
+// It is the copy of the WRAPPER, not shared_ptr itself -- shared_ptr_copy_controls
+// pins the neighbouring shapes that work: copying a shared_ptr directly,
+// returning a wrapper by value from a function, and returning a bare
+// shared_ptr.
+//
+// Any class holding a shared_ptr by value hits this, which is the ordinary way
+// shared ownership is written.
+#include <memory>
+#include <cassert>
+
+struct H
+{
+  std::shared_ptr<int> p;
+};
+
+int main()
+{
+  H a{std::make_shared<int>(1)};
+  H b = a;
+  assert(*b.p == 1);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/shared_ptr_member_copy/test.desc
+++ b/regression/esbmc-cpp/cpp/shared_ptr_member_copy/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std=c++20
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
A false alarm on a pattern that is hard to avoid in ordinary C++:

```cpp
struct H { std::shared_ptr<int> p; };

H a{std::make_shared<int>(1)};
H b = a;                 // implicit copy
assert(*b.p == 1);       // FAILED: invalidated dynamic object, in __release
```

g++ runs it with the assertion holding. The implicit copy constructor does not keep the control block alive, so the shared object is treated as freed while a live owner still refers to it.

**It is the copy of the wrapper, not `shared_ptr` itself.** All three neighbours verify and ship as the control test:

| shape | verdict |
|---|---|
| copying a `shared_ptr` directly | SUCCESSFUL |
| a wrapper **returned by value** from a function | SUCCESSFUL |
| a bare `shared_ptr` returned by value | SUCCESSFUL |
| **copying an existing wrapper** | **FAILED** |

So it is specifically the implicitly-generated copy of a class holding a `shared_ptr` by value — which is how shared ownership is normally written, so any program using it that way is affected.

Found while modelling `<stop_token>`, whose `stop_token` and `stop_source` each hold shared state by `shared_ptr`; that header is written but held back rather than shipped against a false alarm, exactly as `<memory_resource>` was held back over #7650 until #7651 fixed it.

This PR does not fix it — it pins it, with the discriminator recorded and the working shapes guarded so they cannot regress. Both programs were compiled and run under g++ first.
