### PR TITLE
[esbmc-cpp] Pin the surplus destructor of an aggregate-initialised member

### DIFF
--- a/regression/esbmc-cpp/cpp/aggregate_init_named_double_destroy/main.cpp
+++ b/regression/esbmc-cpp/cpp/aggregate_init_named_double_destroy/main.cpp
@@ -1,0 +1,41 @@
+// KNOWNBUG, the named-argument half of aggregate_init_temp_double_destroy: the
+// imbalance is not caused by a temporary in the initialiser. Here the argument
+// is an ordinary named object, and ESBMC still runs 2 constructors and 3
+// destructors where g++ runs 2 and 2, because the member is copied through a
+// helper that is destroyed in addition to the member.
+#include <cassert>
+
+int c = 0, d = 0;
+
+struct M
+{
+  int v;
+  M(int x) : v(x)
+  {
+    ++c;
+  }
+  M(const M &o) : v(o.v)
+  {
+    ++c;
+  }
+  ~M()
+  {
+    ++d;
+  }
+};
+
+struct W
+{
+  M m;
+};
+
+int main()
+{
+  {
+    M t(5);
+    W a{t};
+    assert(a.m.v == 5); // the stored value is correct
+  }
+  assert(c == d);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/aggregate_init_named_double_destroy/test.desc
+++ b/regression/esbmc-cpp/cpp/aggregate_init_named_double_destroy/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std=c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/aggregate_init_temp_controls/main.cpp
+++ b/regression/esbmc-cpp/cpp/aggregate_init_temp_controls/main.cpp
@@ -1,0 +1,58 @@
+// The controls for aggregate_init_temp_double_destroy: constructing and
+// copying the member directly stays balanced, and so does a member with no
+// destructor, so the defect is specific to aggregate-initialising a wrapper
+// from a temporary whose type has a destructor.
+#include <cassert>
+
+int ctors = 0, dtors = 0;
+
+struct M
+{
+  int v;
+  M(int x) : v(x)
+  {
+    ++ctors;
+  }
+  M(const M &o) : v(o.v)
+  {
+    ++ctors;
+  }
+  ~M()
+  {
+    ++dtors;
+  }
+};
+
+int plain_copies = 0;
+
+struct N
+{
+  int v;
+  N(int x) : v(x)
+  {
+  }
+  N(const N &o) : v(o.v)
+  {
+    ++plain_copies;
+  }
+};
+
+struct WN
+{
+  N n;
+};
+
+int main()
+{
+  {
+    M a(5);
+    M b = a;
+    assert(b.v == 5);
+  }
+  assert(ctors == dtors);
+
+  // a member without a destructor: the wrapper shape itself is fine
+  WN w{N(7)};
+  assert(w.n.v == 7);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/aggregate_init_temp_controls/test.desc
+++ b/regression/esbmc-cpp/cpp/aggregate_init_temp_controls/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/aggregate_init_temp_double_destroy/main.cpp
+++ b/regression/esbmc-cpp/cpp/aggregate_init_temp_double_destroy/main.cpp
@@ -1,0 +1,49 @@
+// KNOWNBUG. Aggregate-initialising a class from a temporary of a member type
+// that has a destructor destroys that member TWICE: ESBMC runs 1 constructor
+// and 2 destructors here, where g++ runs 1 and 1 ([class.temporary] and the
+// C++17 guaranteed elision of a prvalue initialiser mean one object exists).
+//
+// The elided temporary keeps its destructor call in addition to the member's,
+// so the count is unbalanced rather than merely imprecise. It is a genuine
+// double-destroy, which is why it corrupts anything doing lifetime accounting:
+// for std::shared_ptr the extra call is a second __release(), the refcount
+// underflows, the control block is deleted while an owner still holds it, and
+// the read is reported as an "invalidated dynamic object"
+// (regression/esbmc-cpp/cpp/shared_ptr_member_copy).
+//
+// Neither templates nor a copy are involved -- aggregate_init_temp_controls
+// pins the shapes that stay balanced.
+#include <cassert>
+
+int ctors = 0, dtors = 0;
+
+struct M
+{
+  int v;
+  M(int x) : v(x)
+  {
+    ++ctors;
+  }
+  M(const M &o) : v(o.v)
+  {
+    ++ctors;
+  }
+  ~M()
+  {
+    ++dtors;
+  }
+};
+
+struct W
+{
+  M m;
+};
+
+int main()
+{
+  {
+    W a{M(5)};
+  }
+  assert(ctors == dtors);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/aggregate_init_temp_double_destroy/main.cpp
+++ b/regression/esbmc-cpp/cpp/aggregate_init_temp_double_destroy/main.cpp
@@ -1,18 +1,32 @@
-// KNOWNBUG. Aggregate-initialising a class from a temporary of a member type
-// that has a destructor destroys that member TWICE: ESBMC runs 1 constructor
-// and 2 destructors here, where g++ runs 1 and 1 ([class.temporary] and the
-// C++17 guaranteed elision of a prvalue initialiser mean one object exists).
+// KNOWNBUG. Aggregate-initialising a class whose member type has a destructor
+// runs one destructor too many. ESBMC materialises a temporary for the member,
+// copies it into the object bitwise, and then destroys BOTH:
 //
-// The elided temporary keeps its destructor call in addition to the member's,
-// so the count is unbalanced rather than merely imprecise. It is a genuine
-// double-destroy, which is why it corrupts anything doing lifetime accounting:
-// for std::shared_ptr the extra call is a second __release(), the refcount
-// underflows, the control block is deleted while an owner still holds it, and
-// the read is reported as an "invalidated dynamic object"
-// (regression/esbmc-cpp/cpp/shared_ptr_member_copy).
+//     DECL M t;      FUNCTION_CALL: M(&t, 5)          <- construct t
+//     DECL W a;
+//     DECL M tmp$1;  FUNCTION_CALL: M(&tmp$1, &t)     <- copy into a helper
+//                    ASSIGN a = { .m = tmp$1 }        <- copied into the object
+//                    FUNCTION_CALL: ~M(&tmp$1)        <- helper destroyed
+//                    FUNCTION_CALL: ~W(&a)            <- a.m destroyed too
+//                    FUNCTION_CALL: ~M(&t)
 //
-// Neither templates nor a copy are involved -- aggregate_init_temp_controls
-// pins the shapes that stay balanced.
+// C++ constructs the member in place, so g++ runs two constructors and two
+// destructors here; ESBMC runs two and three. The stored VALUE is correct --
+// a.m.v == 5 verifies -- so only the lifetime accounting is wrong, which is
+// why it shows up as a resource bug rather than a wrong result.
+//
+// It is not about temporaries: `M t(5); W a{t};` with a named argument is
+// equally unbalanced (2 constructors, 3 destructors), as is `W a = W{M(5)}`.
+// The counts below are for the temporary form, which is the smallest.
+//
+// This is the mechanism under regression/esbmc-cpp/cpp/shared_ptr_member_copy:
+// the surplus ~M is a second shared_ptr __release(), so the refcount underflows
+// and the control block is freed while an owner still holds it.
+//
+// The fix is to construct the member in place rather than through a helper --
+// the same elision the existing array_init$ guard in convert_decl approximates
+// for its own construction helper. aggregate_init_temp_controls pins the
+// shapes that stay balanced.
 #include <cassert>
 
 int ctors = 0, dtors = 0;

--- a/regression/esbmc-cpp/cpp/aggregate_init_temp_double_destroy/test.desc
+++ b/regression/esbmc-cpp/cpp/aggregate_init_temp_double_destroy/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std=c++17
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Aggregate-initialising a class whose member type has a destructor runs one destructor too many. The GOTO shows the mechanism exactly:

```
DECL M t;      FUNCTION_CALL: M(&t, 5)          <- construct t
DECL W a;
DECL M tmp$1;  FUNCTION_CALL: M(&tmp$1, &t)     <- copy into a helper
               ASSIGN a = { .m = tmp$1 }        <- copied into the object
               FUNCTION_CALL: ~M(&tmp$1)        <- helper destroyed
               FUNCTION_CALL: ~W(&a)            <- a.m destroyed too
               FUNCTION_CALL: ~M(&t)
```

C++ constructs the member in place, so g++ runs two constructors and two destructors; ESBMC runs two and three. Counts measured exactly, not inferred.

**The stored value is correct** — `a.m.v == 5` verifies — so only the lifetime accounting is wrong. That is why it surfaces as a resource bug rather than a wrong result, and why it is easy to miss.

**It is not caused by a temporary in the initialiser.** `M t(5); W a{t};` with an ordinary named argument is equally unbalanced, and ships here as the second pinned case. So does `W a = W{M(5)}`. What matters is a member type with a destructor being aggregate-initialised at all.

**This is the mechanism under #7654**: the surplus `~M` is a second `shared_ptr::__release()`, so the refcount underflows and the control block is freed while an owner still holds it, which is reported as an `invalidated dynamic object`. Fixing this should retire that pin too.

The fix is to construct the member in place rather than through a helper — the same elision the existing `array_init$` guard in `convert_decl` approximates for its own construction helper. I did not attempt it: it is a frontend change in the aggregate-init path, and I cannot run the full C++ suite on this machine to validate one.

Three tests: the temporary form, the named form, and the controls (constructing and copying the member directly, and a member with no destructor, both balanced). All were compiled and run under g++ first.
