### PR TITLE
[esbmc-cpp] Pin the skipped destructors of array elements

### DIFF
--- a/regression/esbmc-cpp/cpp/array_element_destructors/main.cpp
+++ b/regression/esbmc-cpp/cpp/array_element_destructors/main.cpp
@@ -1,0 +1,33 @@
+// KNOWNBUG. Destructors of array elements never run: ESBMC constructs all
+// three objects and destroys none of them (c == 3 && d == 0 verifies here,
+// c == 3 && d == 3 does not). g++ runs three of each.
+//
+// array_element_destructors_control shows the same three objects declared
+// separately are destroyed correctly, so it is the array, not the class.
+// array_element_destructors_leak shows what it costs a user: an element
+// holding a heap allocation is reported as leaking, because the destructor
+// that frees it is skipped.
+#include <cassert>
+
+int c = 0, d = 0;
+
+struct M
+{
+  M()
+  {
+    ++c;
+  }
+  ~M()
+  {
+    ++d;
+  }
+};
+
+int main()
+{
+  {
+    M a[3];
+  }
+  assert(c == 3 && d == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/array_element_destructors/test.desc
+++ b/regression/esbmc-cpp/cpp/array_element_destructors/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std=c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/array_element_destructors_control/main.cpp
+++ b/regression/esbmc-cpp/cpp/array_element_destructors_control/main.cpp
@@ -1,0 +1,29 @@
+// The control for array_element_destructors: the same class, the same count of
+// objects, declared separately rather than as an array. These are destroyed
+// correctly, which localises the defect to array elements.
+#include <cassert>
+
+int c = 0, d = 0;
+
+struct M
+{
+  M()
+  {
+    ++c;
+  }
+  ~M()
+  {
+    ++d;
+  }
+};
+
+int main()
+{
+  {
+    M a;
+    M b;
+    M z;
+  }
+  assert(c == 3 && d == 3);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/array_element_destructors_control/test.desc
+++ b/regression/esbmc-cpp/cpp/array_element_destructors_control/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std=c++17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/array_element_destructors_leak/main.cpp
+++ b/regression/esbmc-cpp/cpp/array_element_destructors_leak/main.cpp
@@ -1,0 +1,26 @@
+// KNOWNBUG. The user-visible cost of the skipped array-element destructors:
+// each element frees its allocation in ~R, but the destructors do not run, so
+// --memory-leak-check reports a leak per element on a program that leaks
+// nothing. g++ runs this cleanly under valgrind.
+#include <cassert>
+
+struct R
+{
+  int *p;
+  R() : p(new int(1))
+  {
+  }
+  ~R()
+  {
+    delete p;
+  }
+};
+
+int main()
+{
+  {
+    R a[2];
+    assert(*a[0].p == 1);
+  }
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/array_element_destructors_leak/test.desc
+++ b/regression/esbmc-cpp/cpp/array_element_destructors_leak/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.cpp
+--std=c++17 --memory-leak-check
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
Destructors of array elements never run:

```cpp
struct M { M() { ++c; } ~M() { ++d; } };
{ M a[3]; }
// ESBMC: c == 3, d == 0.   g++: 3 and 3.
```

Measured exactly rather than inferred — `c == 3 && d == 0` verifies, `c == 3 && d == 3` does not.

**The control localises it to the array**, not the class: the same three objects declared separately are destroyed correctly and ship as a CORE test.

**What it costs a user**, which is the reason this is worth pinning rather than noting:

```cpp
struct R { int *p; R() : p(new int(1)) {} ~R() { delete p; } };
{ R a[2]; }
```

Under `--memory-leak-check` this reports **two leaks on a program that leaks nothing**, because the destructors that free the allocations are skipped. That is textbook RAII in an array — `std::lock_guard`, file handles, buffers — so anything holding a resource in an array is mis-verified, and the report points at the user's code rather than at the missing destructor.

Three tests: the construct/destroy count, the spurious-leak consequence, and the scalar control. All three programs were compiled and run under g++ first; 130 `esbmc-cpp/cpp` tests pass alongside.

This is a *different* defect from #7655, and in the opposite direction: there an elided temporary was destroyed twice, here elements are not destroyed at all. Both are object-lifetime accounting, so they may share an owner, but neither reproducer triggers the other.
