### PR TITLE
[esbmc-cpp] Add the regression pair for the array-to-array typecast arm

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7544/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7544/main.cpp
@@ -5,24 +5,40 @@
  * test). The shape is load-bearing -- the loop, the conditional write through
  * an undefined extern, and the strcpy all contribute; simplifying any of them
  * can stop reaching the arm while the test still passes. */
+#include <cassert>
 #include <cstring>
+
 extern bool nondet_bool();
-class a {
+
+class a
+{
   int b;
+
 public:
   char *g;
-  a() : b(2), g(new char[b]) { g[1] = '\0'; }
-  void operator()() {
+  a() : b(2), g(new char[b])
+  {
+    g[1] = '\0';
+  }
+  void operator()()
+  {
     if (nondet_bool())
       g[0] = 'x';
     else
       g[0] = '\0';
   }
 };
-int main() {
+
+int main()
+{
   a f;
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < 2; i++)
+  {
     f();
-    strcpy(new char[2], f.g);
+    char *dst = new char[2];
+    strcpy(dst, f.g);
+    /* Reads back through the converted cast: an arm that dropped the source
+     * would still avoid the abort, but would fail here. */
+    assert(dst[0] == f.g[0]);
   }
 }

--- a/regression/esbmc-cpp/cpp/github_7544/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7544/main.cpp
@@ -1,0 +1,28 @@
+/* A heap array whose size expression references a data member is given a
+ * symbolic array type; storing into it and casting the result reaches the
+ * array-to-array arm of convert_typecast. Without that arm ESBMC aborts with
+ * "Typecast for unexpected type" (esbmc/esbmc#7544, fixed by #7618 without a
+ * test). The shape is load-bearing -- the loop, the conditional write through
+ * an undefined extern, and the strcpy all contribute; simplifying any of them
+ * can stop reaching the arm while the test still passes. */
+#include <cstring>
+extern bool nondet_bool();
+class a {
+  int b;
+public:
+  char *g;
+  a() : b(2), g(new char[b]) { g[1] = '\0'; }
+  void operator()() {
+    if (nondet_bool())
+      g[0] = 'x';
+    else
+      g[0] = '\0';
+  }
+};
+int main() {
+  a f;
+  for (int i = 0; i < 2; i++) {
+    f();
+    strcpy(new char[2], f.g);
+  }
+}

--- a/regression/esbmc-cpp/cpp/github_7544/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7544/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 4
+^\*\* 0 of 22 properties failed, 22 passed$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7544/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7544/test.desc
@@ -1,5 +1,6 @@
 CORE
 main.cpp
 --unwind 4
-^\*\* 0 of 22 properties failed, 22 passed$
+^\s*PASSED\s+\[main\.assertion\.1\]\s+line \d+\s+assertion dst\[0\] == f\.g\[0\]$
+^\*\* 0 of [0-9]+ properties failed, [0-9]+ passed$
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7544_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7544_fail/main.cpp
@@ -1,0 +1,26 @@
+/* A heap array whose size expression references a data member is given a
+ * symbolic array type; storing into it and casting the result reaches the
+ * array-to-array arm of convert_typecast. Without that arm ESBMC aborts with
+ * "Typecast for unexpected type" (esbmc/esbmc#7544, fixed by #7618 without a
+ * test). The shape is load-bearing -- the loop, the conditional write through
+ * an undefined extern, and the strcpy all contribute; simplifying any of them
+ * can stop reaching the arm while the test still passes. */
+#include <cstring>
+extern bool nondet_bool();
+class a {
+  int b;
+public:
+  char *g;
+  a() : b(2), g(new char[b]) {}
+  void operator()() {
+    if (nondet_bool())
+      g[0] = 'x';
+  }
+};
+int main() {
+  a f;
+  for (int i = 0; i < 2; i++) {
+    f();
+    strcpy(new char[1], f.g);
+  }
+}

--- a/regression/esbmc-cpp/cpp/github_7544_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7544_fail/test.desc
@@ -1,5 +1,5 @@
 CORE
 main.cpp
 --unwind 4
-^\s*FAILED\s+\[strcpy\.heap-array-bounds-violated\.1\]\s+line\s+36\s+dereference failure: array bounds violated: heap object$
+^\s*FAILED\s+\[strcpy\.heap-array-bounds-violated\.1\]\s+line \d+\s+dereference failure: array bounds violated: heap object$
 ^VERIFICATION FAILED$

--- a/regression/esbmc-cpp/cpp/github_7544_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7544_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--unwind 4
+^\s*FAILED\s+\[strcpy\.heap-array-bounds-violated\.1\]\s+line\s+36\s+dereference failure: array bounds violated: heap object$
+^VERIFICATION FAILED$


### PR DESCRIPTION
PR #7618 removed the `Typecast for unexpected type` abort but shipped without a
test — the issue's reproducer reaches the arm only at `--unwind 2` and then does
not terminate. Bounding both of its loops gives a pair that reaches the arm in
under a second.

Deleting the arm makes both tests abort (rc=134) rather than change verdict, and
the passing test reads the copy back so an arm returning the wrong AST is caught
too.

Fixes #7544
