### PR TITLE
Extract an esbmc-driver library so the driver is unit-testable

### DIFF
--- a/src/esbmc/CMakeLists.txt
+++ b/src/esbmc/CMakeLists.txt
@@ -49,7 +49,11 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c
   VERBATIM
 )
 
-add_executable(esbmc main.cpp
+# Everything the driver does -- option handling, GOTO preparation, the BMC
+# strategies, reporting -- lives in a library so unit tests can reach it. The
+# executable keeps the entry point and the two definitions that only make sense
+# for a real binary: the build ID stamped into it, and the language mode table.
+add_library(esbmc-driver
     parseoptions/bmc_strategy.cpp
     parseoptions/command_line_options.cpp
     parseoptions/driver.cpp
@@ -58,18 +62,22 @@ add_executable(esbmc main.cpp
     parseoptions/k_induction.cpp
     parseoptions/process_goto_program.cpp
     parseoptions/property_monitors.cpp
-    bmc.cpp property_report.cpp ranking_synthesis.cpp non_termination.cpp globals.cpp show_vcc.cpp options.cpp ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c)
-target_include_directories(esbmc
-    PRIVATE ${CMAKE_BINARY_DIR}/src
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-    PRIVATE ${Boost_INCLUDE_DIRS}
+    bmc.cpp property_report.cpp ranking_synthesis.cpp non_termination.cpp show_vcc.cpp options.cpp)
+target_include_directories(esbmc-driver
+    PUBLIC ${CMAKE_BINARY_DIR}/src
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC ${Boost_INCLUDE_DIRS}
 )
-target_link_libraries(esbmc ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} ${PYTHON_FRONTEND_TARGETS}
+target_link_libraries(esbmc-driver PUBLIC
+                            ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} ${PYTHON_FRONTEND_TARGETS}
                             ${LD_FRONTEND_TARGETS}
                             ${GOTO_CONTRACTOR_TARGETS} ${JIMPLE_FRONTEND_TARGETS}
                             clangcfrontend clangcppfrontend symex langapi
                             solvers clibs gotoalgorithms cache ${Boost_LIBRARIES} goto2c ${OS_INCLUDE_LIBS}
                             nlohmann_json::nlohmann_json)
+
+add_executable(esbmc main.cpp globals.cpp ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c)
+target_link_libraries(esbmc esbmc-driver)
 if(MSVC)
   # Windows counterpart of the large stack main.cpp asks for elsewhere: its
   # default is 1MB, so deeply nested expressions overflow sooner still. The

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(goto-programs)
 add_subdirectory(goto-symex)
 add_subdirectory(big-int)
 add_subdirectory(clang-c-frontend)
+add_subdirectory(esbmc)
 
 if(ENABLE_JIMPLE_FRONTEND)
  add_subdirectory(jimple-frontend)

--- a/unit/esbmc/CMakeLists.txt
+++ b/unit/esbmc/CMakeLists.txt
@@ -1,0 +1,1 @@
+new_unit_test(property-report-test "property_report.test.cpp" "esbmc-driver;mode_table_obj")

--- a/unit/esbmc/property_report.test.cpp
+++ b/unit/esbmc/property_report.test.cpp
@@ -1,0 +1,211 @@
+/*******************************************************************
+ Module: Property report unit tests
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/property_report.h>
+#include <goto-programs/goto_functions.h>
+#include <irep2/irep2_utils.h>
+
+namespace
+{
+property_resultt result(
+  property_verdictt verdict,
+  std::string file,
+  std::string function,
+  unsigned line,
+  std::string description,
+  unsigned column = 0)
+{
+  property_resultt r;
+  r.verdict = verdict;
+  r.loc.file = std::move(file);
+  r.loc.function = std::move(function);
+  r.loc.description = std::move(description);
+  r.loc.line = line;
+  r.loc.column = column;
+  return r;
+}
+
+std::vector<std::string> ids(const std::vector<property_rowt> &rows)
+{
+  std::vector<std::string> out;
+  for (const auto &row : rows)
+    out.push_back(row.id);
+  return out;
+}
+
+/// A function whose body holds one assert at \p file, hidden or not.
+goto_functiont asserting_function(const std::string &file, bool hide)
+{
+  goto_functiont fn;
+  fn.body.hide = hide;
+  auto it = fn.body.add_instruction();
+  it->make_assertion(gen_true_expr());
+  it->location.set_file(file);
+  return fn;
+}
+} // namespace
+
+TEST_CASE("verdict_label names every verdict", "[property-report]")
+{
+  CHECK(
+    std::string(verdict_label(property_verdictt::NotChecked)) == "NOT CHECKED");
+  CHECK(std::string(verdict_label(property_verdictt::Passed)) == "PASSED");
+  CHECK(std::string(verdict_label(property_verdictt::Unknown)) == "UNKNOWN");
+  CHECK(std::string(verdict_label(property_verdictt::Failed)) == "FAILED");
+}
+
+TEST_CASE("count_properties tallies each verdict", "[property-report]")
+{
+  std::vector<property_rowt> rows(5);
+  rows[0].verdict = property_verdictt::Passed;
+  rows[1].verdict = property_verdictt::Passed;
+  rows[2].verdict = property_verdictt::Failed;
+  rows[3].verdict = property_verdictt::Unknown;
+  rows[4].verdict = property_verdictt::NotChecked;
+
+  const property_countst counts = count_properties(rows);
+  CHECK(counts.passed == 2);
+  CHECK(counts.failed == 1);
+  CHECK(counts.unknown == 1);
+  CHECK(counts.not_checked == 1);
+  CHECK(counts.anything_decided());
+}
+
+TEST_CASE("count_properties of nothing decides nothing", "[property-report]")
+{
+  const property_countst counts = count_properties({});
+  CHECK(counts.passed == 0);
+  CHECK(counts.id_width == 0);
+  CHECK(counts.line_width == 0);
+  CHECK_FALSE(counts.anything_decided());
+}
+
+TEST_CASE(
+  "a table of only unchecked properties has decided nothing",
+  "[property-report]")
+{
+  std::vector<property_rowt> rows(2);
+  CHECK(count_properties(rows).not_checked == 2);
+  CHECK_FALSE(count_properties(rows).anything_decided());
+}
+
+TEST_CASE("column widths span the widest row", "[property-report]")
+{
+  std::vector<property_rowt> rows(2);
+  rows[0].id = "main.assertion.1";
+  rows[0].line = 7;
+  rows[1].id = "f.division-by-zero.10";
+  rows[1].line = 1234;
+
+  const property_countst counts = count_properties(rows);
+  // Two wider than the id itself: the report prints it in brackets.
+  CHECK(counts.id_width == rows[1].id.size() + 2);
+  CHECK(counts.line_width == 4);
+}
+
+TEST_CASE("rows sort by source position", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"c", result(property_verdictt::Passed, "a.c", "main", 20, "third")},
+    {"a", result(property_verdictt::Passed, "a.c", "main", 10, "first")},
+    {"b", result(property_verdictt::Passed, "a.c", "main", 10, "second", 4)},
+    {"d", result(property_verdictt::Passed, "b.c", "main", 1, "fourth")}};
+
+  const std::vector<property_rowt> rows = build_property_rows(verdicts, {});
+  REQUIRE(rows.size() == 4);
+  CHECK(rows[0].description == "first");
+  CHECK(rows[1].description == "second");
+  CHECK(rows[2].description == "third");
+  CHECK(rows[3].description == "fourth");
+}
+
+TEST_CASE("library rows sort last whatever their path", "[property-report]")
+{
+  // An absolute path would otherwise sort ahead of the user's relative one.
+  const std::map<std::string, property_resultt> verdicts{
+    {"lib", result(property_verdictt::Passed, "/opt/om/stdlib.c", "f", 1, "l")},
+    {"user", result(property_verdictt::Failed, "user.c", "main", 9, "u")}};
+
+  const std::vector<property_rowt> rows =
+    build_property_rows(verdicts, {"/opt/om/stdlib.c"});
+  REQUIRE(rows.size() == 2);
+  CHECK(rows[0].description == "u");
+  CHECK_FALSE(rows[0].library);
+  CHECK(rows[1].description == "l");
+  CHECK(rows[1].library);
+}
+
+TEST_CASE(
+  "ids are numbered per function and property class",
+  "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Failed, "a.c", "main", 1, "an assertion")},
+    {"b",
+     result(property_verdictt::Failed, "a.c", "main", 2, "division by zero")},
+    {"c", result(property_verdictt::Failed, "a.c", "main", 3, "another one")},
+    {"d",
+     result(property_verdictt::Failed, "a.c", "helper", 4, "yet another")}};
+
+  // Rows sort by function before line, so helper's row leads.
+  const std::vector<std::string> expected{
+    "helper.assertion.1",
+    "main.assertion.1",
+    "main.division-by-zero.1",
+    "main.assertion.2"};
+  CHECK(ids(build_property_rows(verdicts, {})) == expected);
+}
+
+TEST_CASE("a property in no function is called global", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Unknown, "a.c", "", 1, "an assertion")}};
+
+  CHECK(build_property_rows(verdicts, {})[0].id == "global.assertion.1");
+}
+
+TEST_CASE("a row with no location falls back to its key", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"unnamed claim", result(property_verdictt::NotChecked, "", "", 0, "")}};
+
+  CHECK(build_property_rows(verdicts, {})[0].description == "unnamed claim");
+}
+
+TEST_CASE("surrounding whitespace is trimmed off", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Passed, "a.c", "main", 1, "  spaced \n")},
+    {"b", result(property_verdictt::Passed, "a.c", "main", 2, " \t\n")}};
+
+  const std::vector<property_rowt> rows = build_property_rows(verdicts, {});
+  CHECK(rows[0].description == "spaced");
+  CHECK(rows[1].description.empty());
+}
+
+TEST_CASE("only hidden functions contribute library files", "[property-report]")
+{
+  goto_functionst goto_functions;
+  goto_functions.function_map["om"] = asserting_function("stdlib.c", true);
+  goto_functions.function_map["user"] = asserting_function("user.c", false);
+
+  const std::set<std::string> files =
+    collect_library_assertion_files(goto_functions);
+  CHECK(files == std::set<std::string>{"stdlib.c"});
+}
+
+TEST_CASE(
+  "a hidden function with no assert contributes nothing",
+  "[property-report]")
+{
+  goto_functionst goto_functions;
+  goto_functiont fn;
+  fn.body.hide = true;
+  fn.body.add_instruction()->make_skip();
+  goto_functions.function_map["om"] = std::move(fn);
+
+  CHECK(collect_library_assertion_files(goto_functions).empty());
+}

--- a/unit/testing-utils/CMakeLists.txt
+++ b/unit/testing-utils/CMakeLists.txt
@@ -7,6 +7,11 @@ target_link_libraries(test_util_irep PUBLIC util_esbmc)
 add_library(mode_table_obj OBJECT mode_table.cpp)
 target_link_libraries(mode_table_obj PRIVATE langapi)
 
+# Companion to mode_table for tests that link esbmc-driver: the driver reports
+# the build id, which only a linked executable actually has.
+add_library(build_id_obj OBJECT esbmc_build_id.cpp)
+target_link_libraries(build_id_obj PRIVATE util_esbmc)
+
 add_library(test_goto_factory goto_factory.cpp)
 target_link_libraries(test_goto_factory PUBLIC irep2 clangcfrontend clangcppfrontend clibs)
 target_include_directories(test_goto_factory

--- a/unit/testing-utils/esbmc_build_id.cpp
+++ b/unit/testing-utils/esbmc_build_id.cpp
@@ -1,0 +1,11 @@
+#include <esbmc/globals.h>
+
+// The real definition reads buildidstring_buf out of the object flail.py
+// generates for the executable at link time (src/esbmc/CMakeLists.txt), so it
+// exists only in a real esbmc binary. Tests that link esbmc-driver pull in
+// objects that report the build id; none of them depend on its value.
+// Use as an OBJECT library, like mode_table, so the .o is always in the link.
+std::string esbmc_build_id()
+{
+  return "unit-test build";
+}


### PR DESCRIPTION
The driver -- option handling, GOTO preparation, the BMC strategies, reporting -- was compiled straight into the executable, so no unit test could link it. In the per-test coverage attribution run behind the coverage-migration plan, not one line under `src/esbmc/` was reached by any of the 80 unit binaries; every line of it was regression-only by construction.

## The change

Everything but the entry point moves to a static `esbmc-driver` library. `main.cpp`, `globals.cpp` and the generated `buildidobj.c` stay in the executable: `mode_table` and `buildidstring_buf` are whole-binary definitions, and leaving them out keeps a test that links `esbmc-driver` free to supply its own. No source file changes, so the binary is the same code behind the same link line.

`unit/testing-utils` gains `esbmc_build_id.cpp` beside its existing `mode_table` stub, for the same reason: the driver reports a build id that only a linked executable has, and no test depends on its value. Not named `build_id.cpp` -- `.gitignore`'s `build*` rule would silently swallow it (which is exactly what happened during development; it was never committed until renamed).

## First test on it

`property_report.cpp` end to end -- verdict labels, tallies and column widths, row ordering with library files last, per-function/class id numbering, description fallback and trimming, and the hidden-body filter -- from plain in-memory structs, no parsing and no verification run. 13 cases, 34 assertions, 15 ms, 100% line and region coverage of the file.

## Verification

Full unit suite green (808 tests; the one failure is a pre-existing, unrelated `irep2test` stack-depth SEGFAULT). Two disjoint regression samples, 100% each. `--help` output byte-identical before and after (840 lines).

This is the base commit for three follow-up PRs that add tests on top of the newly-linkable driver: #TBD-B (option handling), #TBD-C (bmc reporting), #TBD-D (end-to-end).
