### PR TITLE
Cover the driver's option parsing and command-line mapping

### DIFF
--- a/src/esbmc/CMakeLists.txt
+++ b/src/esbmc/CMakeLists.txt
@@ -49,7 +49,11 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c
   VERBATIM
 )
 
-add_executable(esbmc main.cpp
+# Everything the driver does -- option handling, GOTO preparation, the BMC
+# strategies, reporting -- lives in a library so unit tests can reach it. The
+# executable keeps the entry point and the two definitions that only make sense
+# for a real binary: the build ID stamped into it, and the language mode table.
+add_library(esbmc-driver
     parseoptions/bmc_strategy.cpp
     parseoptions/command_line_options.cpp
     parseoptions/driver.cpp
@@ -58,18 +62,22 @@ add_executable(esbmc main.cpp
     parseoptions/k_induction.cpp
     parseoptions/process_goto_program.cpp
     parseoptions/property_monitors.cpp
-    bmc.cpp property_report.cpp ranking_synthesis.cpp non_termination.cpp globals.cpp show_vcc.cpp options.cpp ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c)
-target_include_directories(esbmc
-    PRIVATE ${CMAKE_BINARY_DIR}/src
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-    PRIVATE ${Boost_INCLUDE_DIRS}
+    bmc.cpp property_report.cpp ranking_synthesis.cpp non_termination.cpp show_vcc.cpp options.cpp)
+target_include_directories(esbmc-driver
+    PUBLIC ${CMAKE_BINARY_DIR}/src
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC ${Boost_INCLUDE_DIRS}
 )
-target_link_libraries(esbmc ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} ${PYTHON_FRONTEND_TARGETS}
+target_link_libraries(esbmc-driver PUBLIC
+                            ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} ${PYTHON_FRONTEND_TARGETS}
                             ${LD_FRONTEND_TARGETS}
                             ${GOTO_CONTRACTOR_TARGETS} ${JIMPLE_FRONTEND_TARGETS}
                             clangcfrontend clangcppfrontend symex langapi
                             solvers clibs gotoalgorithms cache ${Boost_LIBRARIES} goto2c ${OS_INCLUDE_LIBS}
                             nlohmann_json::nlohmann_json)
+
+add_executable(esbmc main.cpp globals.cpp ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c)
+target_link_libraries(esbmc esbmc-driver)
 if(MSVC)
   # Windows counterpart of the large stack main.cpp asks for elsewhere: its
   # default is 1MB, so deeply nested expressions overflow sooner still. The

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(goto-programs)
 add_subdirectory(goto-symex)
 add_subdirectory(big-int)
 add_subdirectory(clang-c-frontend)
+add_subdirectory(esbmc)
 
 if(ENABLE_JIMPLE_FRONTEND)
  add_subdirectory(jimple-frontend)

--- a/unit/esbmc/CMakeLists.txt
+++ b/unit/esbmc/CMakeLists.txt
@@ -1,0 +1,1 @@
+new_unit_test(property-report-test "property_report.test.cpp" "esbmc-driver;mode_table_obj")

--- a/unit/esbmc/CMakeLists.txt
+++ b/unit/esbmc/CMakeLists.txt
@@ -1,1 +1,3 @@
 new_unit_test(property-report-test "property_report.test.cpp" "esbmc-driver;mode_table_obj")
+new_unit_test(command-line-options-test "command_line_options.test.cpp" "esbmc-driver;mode_table_obj;build_id_obj")
+new_unit_test(get-command-line-options-test "get_command_line_options.test.cpp" "esbmc-driver;mode_table_obj;build_id_obj")

--- a/unit/esbmc/command_line_options.test.cpp
+++ b/unit/esbmc/command_line_options.test.cpp
@@ -1,0 +1,77 @@
+/*******************************************************************
+ Module: Command-line spec parser unit tests
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/esbmc_parseoptions.h>
+
+namespace
+{
+/// read_time_spec and read_mem_spec are protected members that use no state.
+/// Deriving reaches them without changing their access in the driver.
+struct spec_readert : esbmc_parseoptionst
+{
+  static const char *argv0;
+  spec_readert() : esbmc_parseoptionst(1, &argv0)
+  {
+  }
+  using esbmc_parseoptionst::read_mem_spec;
+  using esbmc_parseoptionst::read_time_spec;
+};
+const char *spec_readert::argv0 = "esbmc";
+
+/// One per process: constructing esbmc_parseoptionst parses all_cmd_options,
+/// and a table is parsed exactly once. esbmc constructs one too.
+spec_readert &reader()
+{
+  static spec_readert r;
+  return r;
+}
+
+constexpr uint64_t kib = 1024;
+constexpr uint64_t mib = 1024 * kib;
+constexpr uint64_t gib = 1024 * mib;
+} // namespace
+
+TEST_CASE("a timeout with no suffix is seconds", "[command-line-options]")
+{
+  CHECK(reader().read_time_spec("0") == 0);
+  CHECK(reader().read_time_spec("42") == 42);
+}
+
+TEST_CASE("every timeout suffix scales to seconds", "[command-line-options]")
+{
+  CHECK(reader().read_time_spec("90s") == 90);
+  CHECK(reader().read_time_spec("2m") == 120);
+  CHECK(reader().read_time_spec("3h") == 10800);
+  CHECK(reader().read_time_spec("1d") == 86400);
+}
+
+TEST_CASE(
+  "a memory limit with no suffix is megabytes",
+  "[command-line-options]")
+{
+  CHECK(reader().read_mem_spec("1") == mib);
+  CHECK(reader().read_mem_spec("512") == 512 * mib);
+}
+
+TEST_CASE("every memory suffix scales to bytes", "[command-line-options]")
+{
+  CHECK(reader().read_mem_spec("4096b") == 4096);
+  CHECK(reader().read_mem_spec("64k") == 64 * kib);
+  CHECK(reader().read_mem_spec("8m") == 8 * mib);
+  CHECK(reader().read_mem_spec("2g") == 2 * gib);
+}
+
+TEST_CASE("a memory limit does not overflow 32 bits", "[command-line-options]")
+{
+  // 8g exceeds UINT32_MAX once scaled; the arithmetic is 64-bit throughout.
+  CHECK(reader().read_mem_spec("8g") == 8ULL * gib);
+  CHECK(reader().read_mem_spec("8g") > UINT32_MAX);
+}
+
+TEST_CASE("a timeout of days does not overflow", "[command-line-options]")
+{
+  CHECK(reader().read_time_spec("1000d") == 1000ULL * 86400);
+}

--- a/unit/esbmc/get_command_line_options.test.cpp
+++ b/unit/esbmc/get_command_line_options.test.cpp
@@ -1,0 +1,92 @@
+/*******************************************************************
+ Module: get_command_line_options unit tests
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/esbmc_parseoptions.h>
+
+namespace
+{
+struct option_readert : esbmc_parseoptionst
+{
+  option_readert(int argc, const char **argv) : esbmc_parseoptionst(argc, argv)
+  {
+  }
+  using esbmc_parseoptionst::get_command_line_options;
+};
+
+const char *driver_argv[] = {
+  "esbmc",
+  "--context-bound",
+  "3",
+  "--max-context-bound",
+  "7",
+  "--deadlock-check",
+  "--compact-trace",
+  "--base-case",
+  "--fixedbv",
+  "--smt-symex-guard",
+  "main.c"};
+
+/// esbmc_parseoptionst parses all_cmd_options on construction, and a table is
+/// parsed once per process, so the whole binary shares one command line.
+const optionst &driver_options()
+{
+  static const optionst options = [] {
+    option_readert reader(
+      static_cast<int>(std::size(driver_argv)), driver_argv);
+    optionst built;
+    reader.get_command_line_options(built);
+    return built;
+  }();
+  return options;
+}
+} // namespace
+
+TEST_CASE("a bound given on the command line reaches options", "[driver]")
+{
+  CHECK(driver_options().get_option("context-bound") == "3");
+  CHECK(driver_options().get_option("max-context-bound") == "7");
+}
+
+TEST_CASE("an unset bound falls back to its default", "[driver]")
+{
+  // --incremental-context-bound was not given, so it stays off rather than
+  // inheriting the bound above.
+  CHECK_FALSE(driver_options().get_bool_option("incremental-context-bound"));
+}
+
+TEST_CASE("deadlock checking turns atomicity checking off", "[driver]")
+{
+  CHECK(driver_options().get_bool_option("deadlock-check"));
+  CHECK_FALSE(driver_options().get_bool_option("atomicity-check"));
+}
+
+TEST_CASE("a compact trace keeps the slicer away from it", "[driver]")
+{
+  CHECK(driver_options().get_bool_option("no-slice"));
+}
+
+TEST_CASE("fixed-point encoding displaces floating point", "[driver]")
+{
+  CHECK(driver_options().get_bool_option("fixedbv"));
+  CHECK_FALSE(driver_options().get_bool_option("floatbv"));
+}
+
+TEST_CASE("the base case runs without unwinding assertions", "[driver]")
+{
+  CHECK(driver_options().get_bool_option("base-case"));
+  CHECK(driver_options().get_bool_option("no-unwinding-assertions"));
+  CHECK_FALSE(driver_options().get_bool_option("partial-loops"));
+}
+
+TEST_CASE("an SMT symex guard pulls in SMT during symex", "[driver]")
+{
+  CHECK(driver_options().get_bool_option("smt-during-symex"));
+}
+
+TEST_CASE("integer encoding is left off without --ir", "[driver]")
+{
+  CHECK_FALSE(driver_options().get_bool_option("int-encoding"));
+}

--- a/unit/esbmc/property_report.test.cpp
+++ b/unit/esbmc/property_report.test.cpp
@@ -1,0 +1,211 @@
+/*******************************************************************
+ Module: Property report unit tests
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/property_report.h>
+#include <goto-programs/goto_functions.h>
+#include <irep2/irep2_utils.h>
+
+namespace
+{
+property_resultt result(
+  property_verdictt verdict,
+  std::string file,
+  std::string function,
+  unsigned line,
+  std::string description,
+  unsigned column = 0)
+{
+  property_resultt r;
+  r.verdict = verdict;
+  r.loc.file = std::move(file);
+  r.loc.function = std::move(function);
+  r.loc.description = std::move(description);
+  r.loc.line = line;
+  r.loc.column = column;
+  return r;
+}
+
+std::vector<std::string> ids(const std::vector<property_rowt> &rows)
+{
+  std::vector<std::string> out;
+  for (const auto &row : rows)
+    out.push_back(row.id);
+  return out;
+}
+
+/// A function whose body holds one assert at \p file, hidden or not.
+goto_functiont asserting_function(const std::string &file, bool hide)
+{
+  goto_functiont fn;
+  fn.body.hide = hide;
+  auto it = fn.body.add_instruction();
+  it->make_assertion(gen_true_expr());
+  it->location.set_file(file);
+  return fn;
+}
+} // namespace
+
+TEST_CASE("verdict_label names every verdict", "[property-report]")
+{
+  CHECK(
+    std::string(verdict_label(property_verdictt::NotChecked)) == "NOT CHECKED");
+  CHECK(std::string(verdict_label(property_verdictt::Passed)) == "PASSED");
+  CHECK(std::string(verdict_label(property_verdictt::Unknown)) == "UNKNOWN");
+  CHECK(std::string(verdict_label(property_verdictt::Failed)) == "FAILED");
+}
+
+TEST_CASE("count_properties tallies each verdict", "[property-report]")
+{
+  std::vector<property_rowt> rows(5);
+  rows[0].verdict = property_verdictt::Passed;
+  rows[1].verdict = property_verdictt::Passed;
+  rows[2].verdict = property_verdictt::Failed;
+  rows[3].verdict = property_verdictt::Unknown;
+  rows[4].verdict = property_verdictt::NotChecked;
+
+  const property_countst counts = count_properties(rows);
+  CHECK(counts.passed == 2);
+  CHECK(counts.failed == 1);
+  CHECK(counts.unknown == 1);
+  CHECK(counts.not_checked == 1);
+  CHECK(counts.anything_decided());
+}
+
+TEST_CASE("count_properties of nothing decides nothing", "[property-report]")
+{
+  const property_countst counts = count_properties({});
+  CHECK(counts.passed == 0);
+  CHECK(counts.id_width == 0);
+  CHECK(counts.line_width == 0);
+  CHECK_FALSE(counts.anything_decided());
+}
+
+TEST_CASE(
+  "a table of only unchecked properties has decided nothing",
+  "[property-report]")
+{
+  std::vector<property_rowt> rows(2);
+  CHECK(count_properties(rows).not_checked == 2);
+  CHECK_FALSE(count_properties(rows).anything_decided());
+}
+
+TEST_CASE("column widths span the widest row", "[property-report]")
+{
+  std::vector<property_rowt> rows(2);
+  rows[0].id = "main.assertion.1";
+  rows[0].line = 7;
+  rows[1].id = "f.division-by-zero.10";
+  rows[1].line = 1234;
+
+  const property_countst counts = count_properties(rows);
+  // Two wider than the id itself: the report prints it in brackets.
+  CHECK(counts.id_width == rows[1].id.size() + 2);
+  CHECK(counts.line_width == 4);
+}
+
+TEST_CASE("rows sort by source position", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"c", result(property_verdictt::Passed, "a.c", "main", 20, "third")},
+    {"a", result(property_verdictt::Passed, "a.c", "main", 10, "first")},
+    {"b", result(property_verdictt::Passed, "a.c", "main", 10, "second", 4)},
+    {"d", result(property_verdictt::Passed, "b.c", "main", 1, "fourth")}};
+
+  const std::vector<property_rowt> rows = build_property_rows(verdicts, {});
+  REQUIRE(rows.size() == 4);
+  CHECK(rows[0].description == "first");
+  CHECK(rows[1].description == "second");
+  CHECK(rows[2].description == "third");
+  CHECK(rows[3].description == "fourth");
+}
+
+TEST_CASE("library rows sort last whatever their path", "[property-report]")
+{
+  // An absolute path would otherwise sort ahead of the user's relative one.
+  const std::map<std::string, property_resultt> verdicts{
+    {"lib", result(property_verdictt::Passed, "/opt/om/stdlib.c", "f", 1, "l")},
+    {"user", result(property_verdictt::Failed, "user.c", "main", 9, "u")}};
+
+  const std::vector<property_rowt> rows =
+    build_property_rows(verdicts, {"/opt/om/stdlib.c"});
+  REQUIRE(rows.size() == 2);
+  CHECK(rows[0].description == "u");
+  CHECK_FALSE(rows[0].library);
+  CHECK(rows[1].description == "l");
+  CHECK(rows[1].library);
+}
+
+TEST_CASE(
+  "ids are numbered per function and property class",
+  "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Failed, "a.c", "main", 1, "an assertion")},
+    {"b",
+     result(property_verdictt::Failed, "a.c", "main", 2, "division by zero")},
+    {"c", result(property_verdictt::Failed, "a.c", "main", 3, "another one")},
+    {"d",
+     result(property_verdictt::Failed, "a.c", "helper", 4, "yet another")}};
+
+  // Rows sort by function before line, so helper's row leads.
+  const std::vector<std::string> expected{
+    "helper.assertion.1",
+    "main.assertion.1",
+    "main.division-by-zero.1",
+    "main.assertion.2"};
+  CHECK(ids(build_property_rows(verdicts, {})) == expected);
+}
+
+TEST_CASE("a property in no function is called global", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Unknown, "a.c", "", 1, "an assertion")}};
+
+  CHECK(build_property_rows(verdicts, {})[0].id == "global.assertion.1");
+}
+
+TEST_CASE("a row with no location falls back to its key", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"unnamed claim", result(property_verdictt::NotChecked, "", "", 0, "")}};
+
+  CHECK(build_property_rows(verdicts, {})[0].description == "unnamed claim");
+}
+
+TEST_CASE("surrounding whitespace is trimmed off", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Passed, "a.c", "main", 1, "  spaced \n")},
+    {"b", result(property_verdictt::Passed, "a.c", "main", 2, " \t\n")}};
+
+  const std::vector<property_rowt> rows = build_property_rows(verdicts, {});
+  CHECK(rows[0].description == "spaced");
+  CHECK(rows[1].description.empty());
+}
+
+TEST_CASE("only hidden functions contribute library files", "[property-report]")
+{
+  goto_functionst goto_functions;
+  goto_functions.function_map["om"] = asserting_function("stdlib.c", true);
+  goto_functions.function_map["user"] = asserting_function("user.c", false);
+
+  const std::set<std::string> files =
+    collect_library_assertion_files(goto_functions);
+  CHECK(files == std::set<std::string>{"stdlib.c"});
+}
+
+TEST_CASE(
+  "a hidden function with no assert contributes nothing",
+  "[property-report]")
+{
+  goto_functionst goto_functions;
+  goto_functiont fn;
+  fn.body.hide = true;
+  fn.body.add_instruction()->make_skip();
+  goto_functions.function_map["om"] = std::move(fn);
+
+  CHECK(collect_library_assertion_files(goto_functions).empty());
+}

--- a/unit/testing-utils/CMakeLists.txt
+++ b/unit/testing-utils/CMakeLists.txt
@@ -7,6 +7,11 @@ target_link_libraries(test_util_irep PUBLIC util_esbmc)
 add_library(mode_table_obj OBJECT mode_table.cpp)
 target_link_libraries(mode_table_obj PRIVATE langapi)
 
+# Companion to mode_table for tests that link esbmc-driver: the driver reports
+# the build id, which only a linked executable actually has.
+add_library(build_id_obj OBJECT esbmc_build_id.cpp)
+target_link_libraries(build_id_obj PRIVATE util_esbmc)
+
 add_library(test_goto_factory goto_factory.cpp)
 target_link_libraries(test_goto_factory PUBLIC irep2 clangcfrontend clangcppfrontend clibs)
 target_include_directories(test_goto_factory

--- a/unit/testing-utils/esbmc_build_id.cpp
+++ b/unit/testing-utils/esbmc_build_id.cpp
@@ -1,0 +1,11 @@
+#include <esbmc/globals.h>
+
+// The real definition reads buildidstring_buf out of the object flail.py
+// generates for the executable at link time (src/esbmc/CMakeLists.txt), so it
+// exists only in a real esbmc binary. Tests that link esbmc-driver pull in
+// objects that report the build id; none of them depend on its value.
+// Use as an OBJECT library, like mode_table, so the .o is always in the link.
+std::string esbmc_build_id()
+{
+  return "unit-test build";
+}


### PR DESCRIPTION
Depends on #7661 (extracts the `esbmc-driver` library this stacks on). Two commits, both new unit binaries.

## Timeout and memlimit spec parsers

`read_time_spec`/`read_mem_spec` turn `--timeout`/`--memlimit` strings into seconds and bytes. The regression suite never reaches either: it applies its own limits through `testing_tool.py` rather than the flags, so these lines were covered by nothing at all -- not regression, not unit. 6 cases, 15 assertions, every suffix and the 32-bit overflow boundary included, 20 ms.

## The command-line to options mapping

`get_command_line_options` turns the parsed command line into the `optionst` the rest of the run reads, and every regression test reaches it while no unit test could. It is a long chain of `isset -> set_option`, so one command line exercises many branches at once: a bound copied through, a default left in place, deadlock checking displacing atomicity checking, a compact trace suppressing the slicer, fixed-point encoding displacing floating point, the base case dropping unwinding assertions, an SMT symex guard pulling in SMT during symex. 8 cases, 13 assertions.

130 of the lines this covers were reachable only from the regression suite, 57 in `command_line_options.cpp` itself. Six mutations tried against the decision logic (atomicity left enabled, `no-slice` flipped, the fixedbv/floatbv branches swapped, base-case unwinding assertions flipped, `smt-during-symex` flipped, `max-context-bound` forced to default) -- all six killed by the tests.

Each gets its own binary: a command-line table is parsed at most once per process (see #7458), and constructing `esbmc_parseoptionst` parses one.

## Verification

Full unit suite green (822 tests; the one failure is the pre-existing, unrelated `irep2test` stack-depth SEGFAULT).
