### PR TITLE
Cover bmct's verdict, coverage and multi-witness reporting

### DIFF
--- a/src/esbmc/CMakeLists.txt
+++ b/src/esbmc/CMakeLists.txt
@@ -49,7 +49,11 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c
   VERBATIM
 )
 
-add_executable(esbmc main.cpp
+# Everything the driver does -- option handling, GOTO preparation, the BMC
+# strategies, reporting -- lives in a library so unit tests can reach it. The
+# executable keeps the entry point and the two definitions that only make sense
+# for a real binary: the build ID stamped into it, and the language mode table.
+add_library(esbmc-driver
     parseoptions/bmc_strategy.cpp
     parseoptions/command_line_options.cpp
     parseoptions/driver.cpp
@@ -58,18 +62,22 @@ add_executable(esbmc main.cpp
     parseoptions/k_induction.cpp
     parseoptions/process_goto_program.cpp
     parseoptions/property_monitors.cpp
-    bmc.cpp property_report.cpp ranking_synthesis.cpp non_termination.cpp globals.cpp show_vcc.cpp options.cpp ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c)
-target_include_directories(esbmc
-    PRIVATE ${CMAKE_BINARY_DIR}/src
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-    PRIVATE ${Boost_INCLUDE_DIRS}
+    bmc.cpp property_report.cpp ranking_synthesis.cpp non_termination.cpp show_vcc.cpp options.cpp)
+target_include_directories(esbmc-driver
+    PUBLIC ${CMAKE_BINARY_DIR}/src
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC ${Boost_INCLUDE_DIRS}
 )
-target_link_libraries(esbmc ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} ${PYTHON_FRONTEND_TARGETS}
+target_link_libraries(esbmc-driver PUBLIC
+                            ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} ${PYTHON_FRONTEND_TARGETS}
                             ${LD_FRONTEND_TARGETS}
                             ${GOTO_CONTRACTOR_TARGETS} ${JIMPLE_FRONTEND_TARGETS}
                             clangcfrontend clangcppfrontend symex langapi
                             solvers clibs gotoalgorithms cache ${Boost_LIBRARIES} goto2c ${OS_INCLUDE_LIBS}
                             nlohmann_json::nlohmann_json)
+
+add_executable(esbmc main.cpp globals.cpp ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c)
+target_link_libraries(esbmc esbmc-driver)
 if(MSVC)
   # Windows counterpart of the large stack main.cpp asks for elsewhere: its
   # default is 1MB, so deeply nested expressions overflow sooner still. The

--- a/src/goto-programs/goto_coverage.h
+++ b/src/goto-programs/goto_coverage.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <goto-programs/goto_functions.h>
 #include <goto-programs/goto_convert_class.h>
 #include <goto-programs/loop_unroll.h>

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(goto-programs)
 add_subdirectory(goto-symex)
 add_subdirectory(big-int)
 add_subdirectory(clang-c-frontend)
+add_subdirectory(esbmc)
 
 if(ENABLE_JIMPLE_FRONTEND)
  add_subdirectory(jimple-frontend)

--- a/unit/esbmc/CMakeLists.txt
+++ b/unit/esbmc/CMakeLists.txt
@@ -1,0 +1,1 @@
+new_unit_test(property-report-test "property_report.test.cpp" "esbmc-driver;mode_table_obj")

--- a/unit/esbmc/CMakeLists.txt
+++ b/unit/esbmc/CMakeLists.txt
@@ -1,1 +1,5 @@
 new_unit_test(property-report-test "property_report.test.cpp" "esbmc-driver;mode_table_obj")
+new_unit_test(report-result-test "report_result.test.cpp" "esbmc-driver;mode_table_obj;build_id_obj;$<LINK_LIBRARY:WHOLE_ARCHIVE,gotoalgorithms>")
+new_unit_test(report-coverage-test "report_coverage.test.cpp" "esbmc-driver;mode_table_obj;build_id_obj;$<LINK_LIBRARY:WHOLE_ARCHIVE,gotoalgorithms>")
+new_unit_test(report-multi-property-trace-test "report_multi_property_trace.test.cpp" "esbmc-driver;build_id_obj;$<LINK_LIBRARY:WHOLE_ARCHIVE,gotoalgorithms>")
+new_unit_test(report-coverage-completeness-test "report_coverage_completeness.test.cpp" "esbmc-driver;mode_table_obj;build_id_obj;$<LINK_LIBRARY:WHOLE_ARCHIVE,gotoalgorithms>")

--- a/unit/esbmc/property_report.test.cpp
+++ b/unit/esbmc/property_report.test.cpp
@@ -1,0 +1,211 @@
+/*******************************************************************
+ Module: Property report unit tests
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/property_report.h>
+#include <goto-programs/goto_functions.h>
+#include <irep2/irep2_utils.h>
+
+namespace
+{
+property_resultt result(
+  property_verdictt verdict,
+  std::string file,
+  std::string function,
+  unsigned line,
+  std::string description,
+  unsigned column = 0)
+{
+  property_resultt r;
+  r.verdict = verdict;
+  r.loc.file = std::move(file);
+  r.loc.function = std::move(function);
+  r.loc.description = std::move(description);
+  r.loc.line = line;
+  r.loc.column = column;
+  return r;
+}
+
+std::vector<std::string> ids(const std::vector<property_rowt> &rows)
+{
+  std::vector<std::string> out;
+  for (const auto &row : rows)
+    out.push_back(row.id);
+  return out;
+}
+
+/// A function whose body holds one assert at \p file, hidden or not.
+goto_functiont asserting_function(const std::string &file, bool hide)
+{
+  goto_functiont fn;
+  fn.body.hide = hide;
+  auto it = fn.body.add_instruction();
+  it->make_assertion(gen_true_expr());
+  it->location.set_file(file);
+  return fn;
+}
+} // namespace
+
+TEST_CASE("verdict_label names every verdict", "[property-report]")
+{
+  CHECK(
+    std::string(verdict_label(property_verdictt::NotChecked)) == "NOT CHECKED");
+  CHECK(std::string(verdict_label(property_verdictt::Passed)) == "PASSED");
+  CHECK(std::string(verdict_label(property_verdictt::Unknown)) == "UNKNOWN");
+  CHECK(std::string(verdict_label(property_verdictt::Failed)) == "FAILED");
+}
+
+TEST_CASE("count_properties tallies each verdict", "[property-report]")
+{
+  std::vector<property_rowt> rows(5);
+  rows[0].verdict = property_verdictt::Passed;
+  rows[1].verdict = property_verdictt::Passed;
+  rows[2].verdict = property_verdictt::Failed;
+  rows[3].verdict = property_verdictt::Unknown;
+  rows[4].verdict = property_verdictt::NotChecked;
+
+  const property_countst counts = count_properties(rows);
+  CHECK(counts.passed == 2);
+  CHECK(counts.failed == 1);
+  CHECK(counts.unknown == 1);
+  CHECK(counts.not_checked == 1);
+  CHECK(counts.anything_decided());
+}
+
+TEST_CASE("count_properties of nothing decides nothing", "[property-report]")
+{
+  const property_countst counts = count_properties({});
+  CHECK(counts.passed == 0);
+  CHECK(counts.id_width == 0);
+  CHECK(counts.line_width == 0);
+  CHECK_FALSE(counts.anything_decided());
+}
+
+TEST_CASE(
+  "a table of only unchecked properties has decided nothing",
+  "[property-report]")
+{
+  std::vector<property_rowt> rows(2);
+  CHECK(count_properties(rows).not_checked == 2);
+  CHECK_FALSE(count_properties(rows).anything_decided());
+}
+
+TEST_CASE("column widths span the widest row", "[property-report]")
+{
+  std::vector<property_rowt> rows(2);
+  rows[0].id = "main.assertion.1";
+  rows[0].line = 7;
+  rows[1].id = "f.division-by-zero.10";
+  rows[1].line = 1234;
+
+  const property_countst counts = count_properties(rows);
+  // Two wider than the id itself: the report prints it in brackets.
+  CHECK(counts.id_width == rows[1].id.size() + 2);
+  CHECK(counts.line_width == 4);
+}
+
+TEST_CASE("rows sort by source position", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"c", result(property_verdictt::Passed, "a.c", "main", 20, "third")},
+    {"a", result(property_verdictt::Passed, "a.c", "main", 10, "first")},
+    {"b", result(property_verdictt::Passed, "a.c", "main", 10, "second", 4)},
+    {"d", result(property_verdictt::Passed, "b.c", "main", 1, "fourth")}};
+
+  const std::vector<property_rowt> rows = build_property_rows(verdicts, {});
+  REQUIRE(rows.size() == 4);
+  CHECK(rows[0].description == "first");
+  CHECK(rows[1].description == "second");
+  CHECK(rows[2].description == "third");
+  CHECK(rows[3].description == "fourth");
+}
+
+TEST_CASE("library rows sort last whatever their path", "[property-report]")
+{
+  // An absolute path would otherwise sort ahead of the user's relative one.
+  const std::map<std::string, property_resultt> verdicts{
+    {"lib", result(property_verdictt::Passed, "/opt/om/stdlib.c", "f", 1, "l")},
+    {"user", result(property_verdictt::Failed, "user.c", "main", 9, "u")}};
+
+  const std::vector<property_rowt> rows =
+    build_property_rows(verdicts, {"/opt/om/stdlib.c"});
+  REQUIRE(rows.size() == 2);
+  CHECK(rows[0].description == "u");
+  CHECK_FALSE(rows[0].library);
+  CHECK(rows[1].description == "l");
+  CHECK(rows[1].library);
+}
+
+TEST_CASE(
+  "ids are numbered per function and property class",
+  "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Failed, "a.c", "main", 1, "an assertion")},
+    {"b",
+     result(property_verdictt::Failed, "a.c", "main", 2, "division by zero")},
+    {"c", result(property_verdictt::Failed, "a.c", "main", 3, "another one")},
+    {"d",
+     result(property_verdictt::Failed, "a.c", "helper", 4, "yet another")}};
+
+  // Rows sort by function before line, so helper's row leads.
+  const std::vector<std::string> expected{
+    "helper.assertion.1",
+    "main.assertion.1",
+    "main.division-by-zero.1",
+    "main.assertion.2"};
+  CHECK(ids(build_property_rows(verdicts, {})) == expected);
+}
+
+TEST_CASE("a property in no function is called global", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Unknown, "a.c", "", 1, "an assertion")}};
+
+  CHECK(build_property_rows(verdicts, {})[0].id == "global.assertion.1");
+}
+
+TEST_CASE("a row with no location falls back to its key", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"unnamed claim", result(property_verdictt::NotChecked, "", "", 0, "")}};
+
+  CHECK(build_property_rows(verdicts, {})[0].description == "unnamed claim");
+}
+
+TEST_CASE("surrounding whitespace is trimmed off", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Passed, "a.c", "main", 1, "  spaced \n")},
+    {"b", result(property_verdictt::Passed, "a.c", "main", 2, " \t\n")}};
+
+  const std::vector<property_rowt> rows = build_property_rows(verdicts, {});
+  CHECK(rows[0].description == "spaced");
+  CHECK(rows[1].description.empty());
+}
+
+TEST_CASE("only hidden functions contribute library files", "[property-report]")
+{
+  goto_functionst goto_functions;
+  goto_functions.function_map["om"] = asserting_function("stdlib.c", true);
+  goto_functions.function_map["user"] = asserting_function("user.c", false);
+
+  const std::set<std::string> files =
+    collect_library_assertion_files(goto_functions);
+  CHECK(files == std::set<std::string>{"stdlib.c"});
+}
+
+TEST_CASE(
+  "a hidden function with no assert contributes nothing",
+  "[property-report]")
+{
+  goto_functionst goto_functions;
+  goto_functiont fn;
+  fn.body.hide = true;
+  fn.body.add_instruction()->make_skip();
+  goto_functions.function_map["om"] = std::move(fn);
+
+  CHECK(collect_library_assertion_files(goto_functions).empty());
+}

--- a/unit/esbmc/report_coverage.test.cpp
+++ b/unit/esbmc/report_coverage.test.cpp
@@ -1,0 +1,204 @@
+/*******************************************************************
+ Module: report_coverage unit tests
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/bmc.h>
+#include <goto-programs/goto_coverage.h>
+#include <util/message/message.h>
+
+#include <cstdio>
+#include <initializer_list>
+#include <set>
+#include <string>
+
+#include <unordered_set>
+
+namespace
+{
+using claimt = std::pair<std::string, std::string>;
+
+std::string signature(const claimt &claim)
+{
+  return claim.first + "\t" + claim.second;
+}
+
+/// The counters report_coverage reads are process-wide, so every case states
+/// all of them rather than inheriting whatever ran before it.
+void reset_totals()
+{
+  goto_coveraget::total_assert = 0;
+  goto_coveraget::total_assert_ins = 0;
+  goto_coveraget::total_branch = 0;
+  goto_coveraget::total_func_branch = 0;
+  goto_coveraget::total_cond.clear();
+  goto_coveraget::all_claims.clear();
+}
+
+optionst flags(std::initializer_list<const char *> set)
+{
+  optionst options;
+  for (const char *flag : set)
+    options.set_option(flag, true);
+  return options;
+}
+
+/// Everything report_coverage logs, captured from the message system's own
+/// output stream.
+std::string coverage_report(
+  const optionst &options,
+  std::unordered_set<std::string> reached,
+  const std::unordered_multiset<std::string> &reached_instances = {})
+{
+  pytest_generator pytest_gen;
+  ctest_generator ctest_gen;
+
+  FILE *captured = tmpfile();
+  REQUIRE(captured != nullptr);
+  FILE *previous = messaget::state.out;
+  messaget::state.out = captured;
+  report_coverage(options, reached, reached_instances, pytest_gen, ctest_gen);
+  messaget::state.out = previous;
+
+  std::string logged;
+  char buffer[4096];
+  rewind(captured);
+  for (size_t n; (n = fread(buffer, 1, sizeof(buffer), captured)) > 0;)
+    logged.append(buffer, n);
+  fclose(captured);
+  return logged;
+}
+} // namespace
+
+TEST_CASE("dead-code analysis reports no coverage block", "[coverage]")
+{
+  // It borrows the coverage instrumentation but reports CWE-561 advisories
+  // from start_bmc instead, once exploration has finished. Coverage is asked
+  // for as well, so silence here is the guard rather than an idle run.
+  const claimt claim{"assertion failed", "t.c:5"};
+  reset_totals();
+  goto_coveraget::all_claims = {claim};
+  goto_coveraget::total_assert = 1;
+  goto_coveraget::total_assert_ins = 1;
+
+  CHECK(coverage_report(flags({"dead-code-check", "assertion-coverage"}), {})
+          .empty());
+}
+
+TEST_CASE("assertion coverage counts claims and instances", "[coverage]")
+{
+  const claimt reached{"assertion failed", "t.c:5"};
+  const claimt missed{"division by zero", "t.c:9"};
+  reset_totals();
+  goto_coveraget::all_claims = {reached, missed};
+  goto_coveraget::total_assert = 2;
+  goto_coveraget::total_assert_ins = 4;
+
+  const std::string logged =
+    coverage_report(flags({"assertion-coverage"}), {}, {signature(reached)});
+
+  CHECK_THAT(logged, Catch::Matchers::Contains("[Coverage]"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Total Asserts: 2"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Unreached Asserts: 1"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Total Assertion Instances: 4"));
+  CHECK_THAT(
+    logged, Catch::Matchers::Contains("Reached Assertion Instances: 1"));
+  CHECK_THAT(
+    logged, Catch::Matchers::Contains("Assertion Instances Coverage: 25"));
+}
+
+TEST_CASE("assertion coverage can list every claim", "[coverage]")
+{
+  const claimt reached{"assertion failed", "t.c:5"};
+  const claimt missed{"division by zero", "t.c:9"};
+  reset_totals();
+  goto_coveraget::all_claims = {reached, missed};
+  goto_coveraget::total_assert = 2;
+  goto_coveraget::total_assert_ins = 2;
+
+  const std::string logged = coverage_report(
+    flags({"assertion-coverage-claims"}), {}, {signature(reached)});
+
+  CHECK_THAT(logged, Catch::Matchers::Contains("assertion failed"));
+  CHECK_THAT(logged, Catch::Matchers::Contains(": REACHED"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("division by zero"));
+  CHECK_THAT(logged, Catch::Matchers::Contains(": UNREACHED"));
+}
+
+TEST_CASE(
+  "more instances reached than counted is not a percentage",
+  "[coverage]")
+{
+  // A loop too large or too non-deterministic to goto-unwind leaves the
+  // instance total below what symex actually reached.
+  const claimt first{"assertion failed", "t.c:5"};
+  const claimt second{"assertion failed", "t.c:6"};
+  reset_totals();
+  goto_coveraget::all_claims = {first, second};
+  goto_coveraget::total_assert = 2;
+  goto_coveraget::total_assert_ins = 1;
+
+  const std::string logged = coverage_report(
+    flags({"assertion-coverage"}), {}, {signature(first), signature(second)});
+
+  CHECK_THAT(
+    logged,
+    Catch::Matchers::Contains(
+      "Total Assertion Instances: unknown / non-deterministic"));
+  CHECK_THAT(
+    logged, Catch::Matchers::Contains("Assertion Instances Coverage Unknown"));
+}
+
+TEST_CASE("a program with no assertion instances covers none", "[coverage]")
+{
+  reset_totals();
+  goto_coveraget::total_assert = 0;
+  goto_coveraget::total_assert_ins = 0;
+
+  CHECK_THAT(
+    coverage_report(flags({"assertion-coverage"}), {}),
+    Catch::Matchers::Contains("Assertion Instances Coverage: 0%"));
+}
+
+TEST_CASE("an unreached negation is an unsatisfied condition", "[coverage]")
+{
+  // Each condition is instrumented as a pair: the claim and its negation.
+  // Reaching only one half satisfies one and leaves the other unsatisfied.
+  const claimt condition{"a == 1", "t.c:3"};
+  reset_totals();
+  goto_coveraget::total_cond = {condition};
+
+  const std::string logged =
+    coverage_report(flags({"condition-coverage"}), {signature(condition)});
+
+  CHECK_THAT(logged, Catch::Matchers::Contains("Reached Conditions:  2"));
+  CHECK_THAT(
+    logged, Catch::Matchers::Contains("Condition Properties - SATISFIED:  1"));
+  CHECK_THAT(
+    logged,
+    Catch::Matchers::Contains("Condition Properties - UNSATISFIED:  1"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Condition Coverage: 100%"));
+}
+
+TEST_CASE("a condition never reached was short circuited", "[coverage]")
+{
+  const claimt condition{"a == 1", "t.c:3"};
+  reset_totals();
+  goto_coveraget::total_cond = {condition};
+
+  const std::string logged = coverage_report(flags({"condition-coverage"}), {});
+
+  CHECK_THAT(logged, Catch::Matchers::Contains("Reached Conditions:  0"));
+  CHECK_THAT(
+    logged, Catch::Matchers::Contains("Short Circuited Conditions:  1"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Condition Coverage: 0%"));
+}
+
+TEST_CASE("a program with no conditions covers none", "[coverage]")
+{
+  reset_totals();
+  CHECK_THAT(
+    coverage_report(flags({"condition-coverage"}), {}),
+    Catch::Matchers::Contains("Condition Coverage: 0%"));
+}

--- a/unit/esbmc/report_coverage.test.cpp
+++ b/unit/esbmc/report_coverage.test.cpp
@@ -32,8 +32,11 @@ void reset_totals()
   goto_coveraget::total_assert_ins = 0;
   goto_coveraget::total_branch = 0;
   goto_coveraget::total_func_branch = 0;
+  goto_coveraget::total_kpath = 0;
+  goto_coveraget::total_kpath_spanning = 0;
   goto_coveraget::total_cond.clear();
   goto_coveraget::all_claims.clear();
+  goto_coveraget::k_path_spanning_redundant.clear();
 }
 
 optionst flags(std::initializer_list<const char *> set)
@@ -201,4 +204,102 @@ TEST_CASE("a program with no conditions covers none", "[coverage]")
   CHECK_THAT(
     coverage_report(flags({"condition-coverage"}), {}),
     Catch::Matchers::Contains("Condition Coverage: 0%"));
+}
+
+TEST_CASE("branch coverage counts the goals reached", "[coverage]")
+{
+  const claimt taken{"branch taken", "t.c:4"};
+  const claimt missed{"branch not taken", "t.c:4"};
+  reset_totals();
+  goto_coveraget::all_claims = {taken, missed};
+  goto_coveraget::total_branch = 4;
+
+  const std::string logged =
+    coverage_report(flags({"branch-coverage"}), {signature(taken)});
+
+  CHECK_THAT(logged, Catch::Matchers::Contains("Branches : 4"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Reached : 1"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Branch Coverage: 25%"));
+}
+
+TEST_CASE("branch coverage can list what was reached", "[coverage]")
+{
+  const claimt taken{"branch taken", "t.c:4"};
+  reset_totals();
+  goto_coveraget::all_claims = {taken};
+  goto_coveraget::total_branch = 1;
+
+  CHECK_THAT(
+    coverage_report(flags({"branch-coverage-claims"}), {signature(taken)}),
+    Catch::Matchers::Contains("branch taken"));
+}
+
+TEST_CASE("a program with no branches has no percentage", "[coverage]")
+{
+  reset_totals();
+  goto_coveraget::total_func_branch = 0;
+
+  CHECK_THAT(
+    coverage_report(flags({"branch-function-coverage"}), {}),
+    Catch::Matchers::Contains("Branch Coverage: N/A (no branches)"));
+}
+
+TEST_CASE("function branch coverage counts entry points too", "[coverage]")
+{
+  const claimt entry{"function main entered", "t.c:1"};
+  reset_totals();
+  goto_coveraget::all_claims = {entry};
+  goto_coveraget::total_func_branch = 2;
+
+  const std::string logged =
+    coverage_report(flags({"branch-function-coverage"}), {signature(entry)});
+
+  CHECK_THAT(
+    logged, Catch::Matchers::Contains("Function Entry Points & Branches : 2"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Branch Coverage: 50%"));
+}
+
+TEST_CASE("k-path coverage measures against the spanning set", "[coverage]")
+{
+  const claimt maximal{"k-path witness", "t.c:7"};
+  reset_totals();
+  goto_coveraget::total_kpath = 5;
+  goto_coveraget::total_kpath_spanning = 2;
+
+  const std::string logged =
+    coverage_report(flags({"k-path-coverage-enabled"}), {signature(maximal)});
+
+  CHECK_THAT(logged, Catch::Matchers::Contains("k-Path Witnesses : 5"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Spanning Set : 2"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Reached : 1"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("k-Path Coverage: 50%"));
+}
+
+TEST_CASE("a subsumed k-path goal does not inflate coverage", "[coverage]")
+{
+  // Numerator and denominator must both restrict to maximal goals, or a
+  // reached-but-subsumed goal counts against a maximal-only total.
+  const claimt maximal{"k-path witness", "t.c:7"};
+  const claimt subsumed{"k-path witness", "t.c:8"};
+  reset_totals();
+  goto_coveraget::total_kpath = 5;
+  goto_coveraget::total_kpath_spanning = 2;
+  goto_coveraget::k_path_spanning_redundant = {subsumed};
+
+  CHECK_THAT(
+    coverage_report(
+      flags({"k-path-coverage-enabled"}),
+      {signature(maximal), signature(subsumed)}),
+    Catch::Matchers::Contains("Reached : 1"));
+}
+
+TEST_CASE("no k-path goals means no percentage", "[coverage]")
+{
+  reset_totals();
+  goto_coveraget::total_kpath = 3;
+  goto_coveraget::total_kpath_spanning = 0;
+
+  CHECK_THAT(
+    coverage_report(flags({"k-path-coverage-enabled"}), {}),
+    Catch::Matchers::Contains("k-Path Coverage: N/A (no k-path goals)"));
 }

--- a/unit/esbmc/report_coverage_completeness.test.cpp
+++ b/unit/esbmc/report_coverage_completeness.test.cpp
@@ -1,0 +1,106 @@
+/*******************************************************************
+ Module: report_coverage_completeness unit tests
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/bmc.h>
+#include <goto-programs/goto_coverage.h>
+#include <util/message/message.h>
+
+#include <cstdio>
+#include <string>
+
+namespace
+{
+using claimt = std::pair<std::string, std::string>;
+
+/// Runs a coverage measurement and then its completeness qualifier, returning
+/// everything the pair logged.
+///
+/// The qualifier reads file-static state that only a measurement sets, and
+/// that nothing outside multi_property_check clears, so each case runs its own
+/// measurement rather than inheriting one. ctest gives every case its own
+/// process; run the binary directly and they share one, in declaration order.
+std::string measure_then_qualify(size_t total_instances, size_t reached)
+{
+  const claimt claim{"assertion failed", "t.c:5"};
+  goto_coveraget::all_claims = {claim};
+  goto_coveraget::total_assert = 1;
+  goto_coveraget::total_assert_ins = total_instances;
+
+  optionst options;
+  options.set_option("assertion-coverage", true);
+  std::unordered_set<std::string> reached_claims;
+  std::unordered_multiset<std::string> instances;
+  for (size_t i = 0; i < reached; ++i)
+    instances.insert(claim.first + "\t" + claim.second);
+
+  pytest_generator pytest_gen;
+  ctest_generator ctest_gen;
+
+  FILE *captured = tmpfile();
+  REQUIRE(captured != nullptr);
+  FILE *previous = messaget::state.out;
+  messaget::state.out = captured;
+  report_coverage(options, reached_claims, instances, pytest_gen, ctest_gen);
+  report_coverage_completeness();
+  messaget::state.out = previous;
+
+  std::string logged;
+  char buffer[4096];
+  rewind(captured);
+  for (size_t n; (n = fread(buffer, 1, sizeof(buffer), captured)) > 0;)
+    logged.append(buffer, n);
+  fclose(captured);
+  return logged;
+}
+/// Everything report_coverage_completeness logs on its own.
+std::string qualify_only()
+{
+  FILE *captured = tmpfile();
+  REQUIRE(captured != nullptr);
+  FILE *previous = messaget::state.out;
+  messaget::state.out = captured;
+  report_coverage_completeness();
+  messaget::state.out = previous;
+
+  std::string logged;
+  char buffer[1024];
+  rewind(captured);
+  for (size_t n; (n = fread(buffer, 1, sizeof(buffer), captured)) > 0;)
+    logged.append(buffer, n);
+  fclose(captured);
+  return logged;
+}
+} // namespace
+
+// Declared first: nothing measured is the state the process starts in, and no
+// measurement this binary runs is ever undone.
+TEST_CASE("nothing measured qualifies nothing", "[coverage]")
+{
+  CHECK(qualify_only().empty());
+}
+
+TEST_CASE("a measurement that added up is complete", "[coverage]")
+{
+  CHECK_THAT(
+    measure_then_qualify(2, 1),
+    Catch::Matchers::Contains("COVERAGE ANALYSIS COMPLETE"));
+}
+
+TEST_CASE("an unknown instance total makes it incomplete", "[coverage]")
+{
+  // The percentages are lower bounds once a total could not be determined,
+  // and the reason is named so the reader can act on it.
+  const std::string logged = measure_then_qualify(1, 2);
+  CHECK_THAT(
+    logged,
+    Catch::Matchers::Contains(
+      "COVERAGE ANALYSIS INCOMPLETE: the percentages above are lower bounds"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("reason:"));
+  CHECK_THAT(
+    logged,
+    Catch::Matchers::Contains(
+      "the total number of assertion instances could not be determined"));
+}

--- a/unit/esbmc/report_multi_property_trace.test.cpp
+++ b/unit/esbmc/report_multi_property_trace.test.cpp
@@ -1,0 +1,249 @@
+/*******************************************************************
+ Module: bmct::report_multi_property_trace unit tests
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/bmc.h>
+#include <irep2/irep2_utils.h>
+#include <langapi/mode.h>
+#include <solvers/smt/smt_result.h>
+#include <util/lang/c_types.h>
+#include <util/message/message.h>
+
+#include <cstdio>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+// Rendering a witness input goes through from_expr, which falls back to C for
+// an unqualified identifier and dereferences whatever new_language() returns.
+const mode_table_et mode_table[] = {LANGAPI_MODE_CLANG_C, LANGAPI_MODE_END};
+
+namespace
+{
+struct reportert : bmct
+{
+  reportert(goto_functionst &funcs, optionst &opts, contextt &context)
+    : bmct(funcs, opts, context)
+  {
+  }
+  using bmct::enumeration_stop_reasont;
+  using bmct::report_multi_property_trace;
+  using bmct::witness_recordt;
+};
+
+using stop_reasont = reportert::enumeration_stop_reasont;
+
+optionst flags(std::initializer_list<const char *> set)
+{
+  optionst options;
+  options.set_option("no-cache-asserts", true);
+  for (const char *flag : set)
+    options.set_option(flag, true);
+  return options;
+}
+
+/// A witness carrying \p inputs concrete integer inputs and an empty trace.
+reportert::witness_recordt witness(std::initializer_list<int> inputs)
+{
+  reportert::witness_recordt record;
+  record.ce_index = 0;
+  for (int value : inputs)
+  {
+    collected_nondet_value nondet;
+    nondet.symbol_name = "nondet$symex::nondet0";
+    nondet.type = int_type2();
+    nondet.value_expr = constant_int2tc(int_type2(), BigInt(value));
+    record.nondet_inputs.push_back(nondet);
+  }
+  return record;
+}
+
+/// Everything report_multi_property_trace logs, captured from the message
+/// system's own output stream.
+std::string report(
+  optionst &options,
+  smt_resultt result,
+  const std::vector<reportert::witness_recordt> &witnesses,
+  stop_reasont stop_reason,
+  bool reachability_trace = false)
+{
+  goto_functionst goto_functions;
+  contextt context;
+  reportert bmc(goto_functions, options, context);
+
+  FILE *captured = tmpfile();
+  REQUIRE(captured != nullptr);
+  FILE *previous = messaget::state.out;
+  messaget::state.out = captured;
+  bmc.report_multi_property_trace(
+    result, witnesses, stop_reason, "claim.assertion.1", reachability_trace);
+  messaget::state.out = previous;
+
+  std::string logged;
+  char buffer[8192];
+  rewind(captured);
+  for (size_t n; (n = fread(buffer, 1, sizeof(buffer), captured)) > 0;)
+    logged.append(buffer, n);
+  fclose(captured);
+  return logged;
+}
+
+std::string report(
+  optionst &&options,
+  smt_resultt result,
+  const std::vector<reportert::witness_recordt> &witnesses,
+  stop_reasont stop_reason,
+  bool reachability_trace = false)
+{
+  return report(options, result, witnesses, stop_reason, reachability_trace);
+}
+} // namespace
+
+TEST_CASE("result-only mode prints no trace at all", "[bmc][witness]")
+{
+  CHECK(report(
+          flags({"result-only"}),
+          P_SATISFIABLE,
+          {witness({1})},
+          stop_reasont::Disabled)
+          .empty());
+}
+
+TEST_CASE("an undischarged claim holds only up to k", "[bmc][witness]")
+{
+  const std::string logged =
+    report(flags({}), P_UNSATISFIABLE, {}, stop_reasont::Disabled);
+  CHECK_THAT(
+    logged,
+    Catch::Matchers::Contains(
+      "Claim 'claim.assertion.1' holds up to the current K"));
+}
+
+TEST_CASE("a claim the solver could not decide says so", "[bmc][witness]")
+{
+  CHECK_THAT(
+    report(flags({}), P_ERROR, {}, stop_reasont::Disabled),
+    Catch::Matchers::Contains("Claim 'claim.assertion.1' could not be solved"));
+}
+
+TEST_CASE("a single witness keeps the counterexample form", "[bmc][witness]")
+{
+  const std::string logged =
+    report(flags({}), P_SATISFIABLE, {witness({1})}, stop_reasont::Disabled);
+  CHECK_THAT(logged, Catch::Matchers::Contains("[Counterexample]"));
+  CHECK_THAT(logged, !Catch::Matchers::Contains("Summary:"));
+}
+
+TEST_CASE("a reachability run is not a violation", "[bmc][witness]")
+{
+  const std::string logged = report(
+    flags({}), P_SATISFIABLE, {witness({1})}, stop_reasont::Disabled, true);
+  CHECK_THAT(logged, Catch::Matchers::Contains("[Reachability trace]"));
+  CHECK_THAT(logged, !Catch::Matchers::Contains("[Counterexample]"));
+}
+
+TEST_CASE("several witnesses are boxed and summarised", "[bmc][witness]")
+{
+  const std::string logged = report(
+    flags({}),
+    P_SATISFIABLE,
+    {witness({1}), witness({2})},
+    stop_reasont::Unsat);
+
+  CHECK_THAT(logged, Catch::Matchers::Contains("[Counterexamples - 2 witness"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Witness 1 of 2"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("Witness 2 of 2"));
+  CHECK_THAT(
+    logged,
+    Catch::Matchers::Contains(
+      "Summary: 2 distinct input tuples violate this property"));
+  CHECK_THAT(logged, Catch::Matchers::Contains("UNSAT after 2 witnesses"));
+}
+
+TEST_CASE("a truncated enumeration says so up front", "[bmc][witness]")
+{
+  // The same fact reaches the footer, but that sits after every witness
+  // block, which on a real program is tens of kilobytes further down.
+  const std::string logged = report(
+    flags({}),
+    P_SATISFIABLE,
+    {witness({1}), witness({2})},
+    stop_reasont::CapHit);
+
+  CHECK_THAT(
+    logged,
+    Catch::Matchers::Contains(
+      "NOTE: --max-witnesses cap reached; more witnesses may exist."));
+  CHECK_THAT(logged, Catch::Matchers::Contains("--max-witnesses cap reached)"));
+}
+
+TEST_CASE("an exhausted enumeration is distinguished", "[bmc][witness]")
+{
+  CHECK_THAT(
+    report(
+      flags({}),
+      P_SATISFIABLE,
+      {witness({1}), witness({2})},
+      stop_reasont::NoInputs),
+    Catch::Matchers::Contains("no enumerable nondet inputs"));
+  CHECK_THAT(
+    report(
+      flags({}),
+      P_SATISFIABLE,
+      {witness({1}), witness({2})},
+      stop_reasont::Error),
+    Catch::Matchers::Contains("solver returned error/unknown"));
+}
+
+TEST_CASE("inputs are collected ahead of the traces", "[bmc][witness]")
+{
+  const std::string logged = report(
+    flags({}),
+    P_SATISFIABLE,
+    {witness({7}), witness({8})},
+    stop_reasont::Unsat);
+
+  const size_t inputs = logged.find("Inputs by witness:");
+  CHECK(inputs != std::string::npos);
+  // Ahead of the first witness box, which is the whole point of collecting
+  // them: they are what differs between witnesses.
+  CHECK(inputs < logged.find("Witness 1 of 2"));
+}
+
+TEST_CASE("a witness with no inputs says none", "[bmc][witness]")
+{
+  const std::string logged = report(
+    flags({}), P_SATISFIABLE, {witness({}), witness({})}, stop_reasont::Unsat);
+  CHECK_THAT(logged, Catch::Matchers::Contains("Inputs : (none)"));
+  CHECK_THAT(logged, !Catch::Matchers::Contains("Inputs by witness:"));
+}
+
+TEST_CASE("an incremental run names the unwinding", "[bmc][witness]")
+{
+  // Without it a reader cannot tell which k produced a block, or that two
+  // blocks are different unwindings rather than a repeat.
+  optionst options = flags({"incremental-bmc"});
+  options.set_option("unwind", "3");
+  CHECK_THAT(
+    report(
+      options,
+      P_SATISFIABLE,
+      {witness({1}), witness({2})},
+      stop_reasont::Unsat),
+    Catch::Matchers::Contains("at k = 3"));
+}
+
+TEST_CASE("reachability traces reach rather than violate", "[bmc][witness]")
+{
+  CHECK_THAT(
+    report(
+      flags({}),
+      P_SATISFIABLE,
+      {witness({1}), witness({2})},
+      stop_reasont::Unsat,
+      true),
+    Catch::Matchers::Contains(
+      "Summary: 2 distinct input tuples reach this goal"));
+}

--- a/unit/esbmc/report_result.test.cpp
+++ b/unit/esbmc/report_result.test.cpp
@@ -1,0 +1,168 @@
+/*******************************************************************
+ Module: bmct::report_result unit tests
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/bmc.h>
+#include <solvers/smt/smt_result.h>
+#include <util/message/message.h>
+
+#include <cstdio>
+#include <initializer_list>
+#include <string>
+
+namespace
+{
+struct reportert : bmct
+{
+  reportert(goto_functionst &funcs, optionst &opts, contextt &context)
+    : bmct(funcs, opts, context)
+  {
+  }
+  using bmct::report_result;
+};
+
+optionst flags(std::initializer_list<const char *> set)
+{
+  optionst options;
+  // Keeps the constructor off the on-disk SSA cache.
+  options.set_option("no-cache-asserts", true);
+  for (const char *flag : set)
+    options.set_option(flag, true);
+  return options;
+}
+
+/// Everything report_result logs for this combination, captured from the
+/// message system's own output stream.
+std::string verdict(optionst &options, smt_resultt result)
+{
+  goto_functionst goto_functions;
+  contextt context;
+  reportert bmc(goto_functions, options, context);
+
+  FILE *captured = tmpfile();
+  REQUIRE(captured != nullptr);
+  FILE *previous = messaget::state.out;
+  messaget::state.out = captured;
+  bmc.report_result(result);
+  messaget::state.out = previous;
+
+  std::string logged;
+  char buffer[4096];
+  rewind(captured);
+  for (size_t n; (n = fread(buffer, 1, sizeof(buffer), captured)) > 0;)
+    logged.append(buffer, n);
+  fclose(captured);
+  return logged;
+}
+
+std::string verdict(optionst &&options, smt_resultt result)
+{
+  return verdict(options, result);
+}
+} // namespace
+
+TEST_CASE("an unsatisfiable run reports success", "[bmc][report]")
+{
+  CHECK_THAT(
+    verdict(flags({}), P_UNSATISFIABLE),
+    Catch::Matchers::Contains("VERIFICATION SUCCESSFUL"));
+}
+
+TEST_CASE("a satisfiable run reports failure", "[bmc][report]")
+{
+  CHECK_THAT(
+    verdict(flags({}), P_SATISFIABLE),
+    Catch::Matchers::Contains("VERIFICATION FAILED"));
+}
+
+TEST_CASE("a solver error is not a verdict", "[bmc][report]")
+{
+  const std::string logged = verdict(flags({}), P_ERROR);
+  CHECK_THAT(logged, Catch::Matchers::Contains("SMT solver failed"));
+  CHECK_THAT(logged, !Catch::Matchers::Contains("VERIFICATION"));
+}
+
+TEST_CASE("emitting a formula decides nothing", "[bmc][report]")
+{
+  CHECK(verdict(flags({}), P_SMTLIB).empty());
+}
+
+TEST_CASE("runs that report their own verdict stay quiet", "[bmc][report]")
+{
+  CHECK(verdict(flags({"k-induction-parallel"}), P_SATISFIABLE).empty());
+  CHECK(verdict(flags({"diagnose-unknown-properties"}), P_SATISFIABLE).empty());
+  CHECK(verdict(flags({"coverage-measurement"}), P_SATISFIABLE).empty());
+}
+
+TEST_CASE("a completed dead-code analysis is a successful run", "[bmc][report]")
+{
+  // Its probes are violated for every live branch, which must not become a
+  // FAILED verdict.
+  CHECK_THAT(
+    verdict(flags({"dead-code-check"}), P_SATISFIABLE),
+    Catch::Matchers::Contains("VERIFICATION SUCCESSFUL"));
+  CHECK_THAT(
+    verdict(flags({"dead-code-check"}), P_ERROR),
+    Catch::Matchers::Contains("SMT solver failed"));
+  CHECK(verdict(flags({"dead-code-check"}), P_SMTLIB).empty());
+}
+
+TEST_CASE("a proved termination property is a failure", "[bmc][report]")
+{
+  CHECK_THAT(
+    verdict(flags({"inductive-step", "termination"}), P_UNSATISFIABLE),
+    Catch::Matchers::Contains("VERIFICATION FAILED"));
+}
+
+TEST_CASE("a clean base case proves nothing on its own", "[bmc][report]")
+{
+  const std::string logged = verdict(flags({"base-case"}), P_UNSATISFIABLE);
+  CHECK_THAT(
+    logged,
+    Catch::Matchers::Contains("No bug has been found in the base case"));
+  CHECK_THAT(logged, !Catch::Matchers::Contains("VERIFICATION SUCCESSFUL"));
+}
+
+TEST_CASE("multi-property reports success from the base case", "[bmc][report]")
+{
+  CHECK_THAT(
+    verdict(flags({"base-case", "multi-property"}), P_UNSATISFIABLE),
+    Catch::Matchers::Contains("VERIFICATION SUCCESSFUL"));
+}
+
+TEST_CASE("an earlier k-step violation suppresses success", "[bmc][report]")
+{
+  CHECK(verdict(flags({"kind-violation-found"}), P_UNSATISFIABLE).empty());
+}
+
+TEST_CASE("an incomplete inductive step proves nothing", "[bmc][report]")
+{
+  CHECK(verdict(
+          flags({"inductive-step", "disable-inductive-step"}), P_UNSATISFIABLE)
+          .empty());
+}
+
+TEST_CASE("a bounded round withholds the verdict", "[bmc][report]")
+{
+  const std::string logged =
+    verdict(flags({"suppress-bounded-success"}), P_UNSATISFIABLE);
+  CHECK_THAT(
+    logged,
+    Catch::Matchers::Contains(
+      "No violation found within the current context bound"));
+  CHECK_THAT(logged, !Catch::Matchers::Contains("VERIFICATION SUCCESSFUL"));
+}
+
+TEST_CASE("neither half of k-induction claims a violation", "[bmc][report]")
+{
+  CHECK_THAT(
+    verdict(flags({"forward-condition"}), P_SATISFIABLE),
+    Catch::Matchers::Contains(
+      "The forward condition is unable to prove the property"));
+  CHECK_THAT(
+    verdict(flags({"inductive-step"}), P_SATISFIABLE),
+    Catch::Matchers::Contains(
+      "The inductive step is unable to prove the property"));
+}

--- a/unit/testing-utils/CMakeLists.txt
+++ b/unit/testing-utils/CMakeLists.txt
@@ -7,6 +7,11 @@ target_link_libraries(test_util_irep PUBLIC util_esbmc)
 add_library(mode_table_obj OBJECT mode_table.cpp)
 target_link_libraries(mode_table_obj PRIVATE langapi)
 
+# Companion to mode_table for tests that link esbmc-driver: the driver reports
+# the build id, which only a linked executable actually has.
+add_library(build_id_obj OBJECT esbmc_build_id.cpp)
+target_link_libraries(build_id_obj PRIVATE util_esbmc)
+
 add_library(test_goto_factory goto_factory.cpp)
 target_link_libraries(test_goto_factory PUBLIC irep2 clangcfrontend clangcppfrontend clibs)
 target_include_directories(test_goto_factory

--- a/unit/testing-utils/esbmc_build_id.cpp
+++ b/unit/testing-utils/esbmc_build_id.cpp
@@ -1,0 +1,11 @@
+#include <esbmc/globals.h>
+
+// The real definition reads buildidstring_buf out of the object flail.py
+// generates for the executable at link time (src/esbmc/CMakeLists.txt), so it
+// exists only in a real esbmc binary. Tests that link esbmc-driver pull in
+// objects that report the build id; none of them depend on its value.
+// Use as an OBJECT library, like mode_table, so the .o is always in the link.
+std::string esbmc_build_id()
+{
+  return "unit-test build";
+}


### PR DESCRIPTION
Depends on #7661. Four commits, all new unit binaries covering `bmct`'s reporting layer.

## `bmct::report_result`

Maps a solver result plus the option flags onto the line ESBMC prints; nothing is verified to exercise it, since `smt_resultt` is an input the cases pass directly (`P_UNSATISFIABLE`, `P_SATISFIABLE`, `P_ERROR`, `P_SMTLIB`) over an empty program. Covers the run kinds that must stay quiet, a formula-only run deciding nothing, dead-code analysis counting as successful because its probes are violated on every live branch, a proved termination property as failure, a clean base case proving nothing alone but succeeding under `--multi-property`, an earlier k-step violation and an incomplete inductive step both suppressing success, a bounded round withholding the verdict, and neither half of k-induction claiming a violation. 13 cases, 39 assertions, 100 lines reachable only from regression, 73 in `bmc.cpp`.

## `report_coverage` and `report_coverage_completeness`

Renders the `[Coverage]` block from `goto_coveraget`'s public static counters -- assertion, condition, branch, function-branch and k-path modes -- and the completeness qualifier that follows it. Covers per-mode totals and percentages, the REACHED/UNREACHED and SATISFIED/UNSATISFIED listings, a loop too non-deterministic to unwind leaving more instances reached than counted, a subsumed k-path goal filtered out of the numerator so it cannot inflate coverage against a maximal-only denominator, and (for completeness) nothing measured qualifying nothing, a measurement that added up reported complete, and an undetermined total making it incomplete with the reason named. 18 cases, 58 assertions, 203 lines reachable only from regression.

`goto_coverage.h` had no include guard -- the only header in `goto-programs` without one. It survived because nothing included it twice in one translation unit until this test did.

## `bmct::report_multi_property_trace`

Renders a failing claim's witnesses; reads nothing from symex and never solves, so cases build witnesses in memory. Covers `--result-only` suppressing the trace, a claim holding up to k, one the solver could not decide, the single-witness form preserved for existing tests, a reachability run vs. a violation, several witnesses boxed and summarised, the cap notice printed up front rather than only in the footer tens of kilobytes below, each stop reason, inputs collected ahead of the traces, and an incremental run naming its unwinding. 12 cases, 35 assertions, 348 lines reachable only from regression (139 in `bmc.cpp`, 141 in `c_expr2string.cpp` via the witness-input renderer).

## Verification

Every decision-table branch above was mutation-checked: the fix reverted, test re-run, verdict confirmed to flip, fix restored. Full unit suite green (851 tests; the one failure is the pre-existing, unrelated `irep2test` stack-depth SEGFAULT).
