### PR TITLE
Verify a few lines of C in process, end to end

### DIFF
--- a/src/esbmc/CMakeLists.txt
+++ b/src/esbmc/CMakeLists.txt
@@ -49,7 +49,11 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c
   VERBATIM
 )
 
-add_executable(esbmc main.cpp
+# Everything the driver does -- option handling, GOTO preparation, the BMC
+# strategies, reporting -- lives in a library so unit tests can reach it. The
+# executable keeps the entry point and the two definitions that only make sense
+# for a real binary: the build ID stamped into it, and the language mode table.
+add_library(esbmc-driver
     parseoptions/bmc_strategy.cpp
     parseoptions/command_line_options.cpp
     parseoptions/driver.cpp
@@ -58,18 +62,22 @@ add_executable(esbmc main.cpp
     parseoptions/k_induction.cpp
     parseoptions/process_goto_program.cpp
     parseoptions/property_monitors.cpp
-    bmc.cpp property_report.cpp ranking_synthesis.cpp non_termination.cpp globals.cpp show_vcc.cpp options.cpp ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c)
-target_include_directories(esbmc
-    PRIVATE ${CMAKE_BINARY_DIR}/src
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-    PRIVATE ${Boost_INCLUDE_DIRS}
+    bmc.cpp property_report.cpp ranking_synthesis.cpp non_termination.cpp show_vcc.cpp options.cpp)
+target_include_directories(esbmc-driver
+    PUBLIC ${CMAKE_BINARY_DIR}/src
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    PUBLIC ${Boost_INCLUDE_DIRS}
 )
-target_link_libraries(esbmc ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} ${PYTHON_FRONTEND_TARGETS}
+target_link_libraries(esbmc-driver PUBLIC
+                            ${OLD_FRONTEND_TARGETS} ${SOLIDITY_FRONTEND_TARGETS} ${PYTHON_FRONTEND_TARGETS}
                             ${LD_FRONTEND_TARGETS}
                             ${GOTO_CONTRACTOR_TARGETS} ${JIMPLE_FRONTEND_TARGETS}
                             clangcfrontend clangcppfrontend symex langapi
                             solvers clibs gotoalgorithms cache ${Boost_LIBRARIES} goto2c ${OS_INCLUDE_LIBS}
                             nlohmann_json::nlohmann_json)
+
+add_executable(esbmc main.cpp globals.cpp ${CMAKE_CURRENT_BINARY_DIR}/buildidobj.c)
+target_link_libraries(esbmc esbmc-driver)
 if(MSVC)
   # Windows counterpart of the large stack main.cpp asks for elsewhere: its
   # default is 1MB, so deeply nested expressions overflow sooner still. The

--- a/unit/CMakeLists.txt
+++ b/unit/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(goto-programs)
 add_subdirectory(goto-symex)
 add_subdirectory(big-int)
 add_subdirectory(clang-c-frontend)
+add_subdirectory(esbmc)
 
 if(ENABLE_JIMPLE_FRONTEND)
  add_subdirectory(jimple-frontend)

--- a/unit/esbmc/CMakeLists.txt
+++ b/unit/esbmc/CMakeLists.txt
@@ -1,0 +1,1 @@
+new_unit_test(property-report-test "property_report.test.cpp" "esbmc-driver;mode_table_obj")

--- a/unit/esbmc/CMakeLists.txt
+++ b/unit/esbmc/CMakeLists.txt
@@ -1,1 +1,2 @@
 new_unit_test(property-report-test "property_report.test.cpp" "esbmc-driver;mode_table_obj")
+new_unit_test(bmc-run-test "bmc_run.test.cpp" "esbmc-driver;test_goto_factory;clangcppfrontend;clibs;filesystem;langapi;build_id_obj;gotoprograms;$<LINK_LIBRARY:WHOLE_ARCHIVE,gotoalgorithms>")

--- a/unit/esbmc/bmc_run.test.cpp
+++ b/unit/esbmc/bmc_run.test.cpp
@@ -1,0 +1,117 @@
+/*******************************************************************
+ Module: bmct end-to-end run unit tests
+
+ One in-process verification of a few lines of C: parse, goto convert,
+ symex, encode, solve and report. Milliseconds, and the only way to reach
+ the run/solve path -- everything below multi_property_check needs a live
+ reachability tree and a real solver.
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/bmc.h>
+#include <solvers/smt/smt_result.h>
+#include <util/message/message.h>
+
+#include <cstdio>
+#include <initializer_list>
+#include <string>
+
+#include "../testing-utils/goto_factory.h"
+
+namespace
+{
+struct runt
+{
+  smt_resultt result;
+  std::string output;
+};
+
+/// Verifies \p src and returns the verdict together with everything the run
+/// logged, captured from the message system's own output stream.
+runt verify(
+  const std::string &src,
+  std::initializer_list<const char *> set = {})
+{
+  std::string source = src;
+  program prog = goto_factory::get_goto_functions(
+    source, goto_factory::Architecture::BIT_64);
+  optionst options =
+    goto_factory::get_default_options(goto_factory::get_default_cmdline("t.c"));
+  for (const char *flag : set)
+    options.set_option(flag, true);
+
+  bmct bmc(prog.functions, options, prog.context);
+
+  FILE *captured = tmpfile();
+  REQUIRE(captured != nullptr);
+  FILE *previous = messaget::state.out;
+  messaget::state.out = captured;
+  const smt_resultt result = bmc.start_bmc();
+  messaget::state.out = previous;
+
+  std::string logged;
+  char buffer[8192];
+  rewind(captured);
+  for (size_t n; (n = fread(buffer, 1, sizeof(buffer), captured)) > 0;)
+    logged.append(buffer, n);
+  fclose(captured);
+  return {result, logged};
+}
+} // namespace
+
+TEST_CASE("an assertion that holds verifies", "[bmc][run]")
+{
+  const runt run = verify("int main() { int x = 1; assert(x == 1); }");
+  CHECK(run.result == P_UNSATISFIABLE);
+  CHECK_THAT(run.output, Catch::Matchers::Contains("VERIFICATION SUCCESSFUL"));
+  CHECK_THAT(run.output, Catch::Matchers::Contains("PASSED"));
+}
+
+TEST_CASE("an assertion that fails is refuted", "[bmc][run]")
+{
+  const runt run = verify("int main() { int x = 1; assert(x == 2); }");
+  CHECK(run.result == P_SATISFIABLE);
+  CHECK_THAT(run.output, Catch::Matchers::Contains("VERIFICATION FAILED"));
+  CHECK_THAT(run.output, Catch::Matchers::Contains("[Counterexample]"));
+}
+
+TEST_CASE("a nondet input is refuted with a witness", "[bmc][run]")
+{
+  const runt run = verify(
+    "int nondet_int();\n"
+    "int main() { int x = nondet_int(); assert(x != 42); }");
+  CHECK(run.result == P_SATISFIABLE);
+  CHECK_THAT(run.output, Catch::Matchers::Contains("VERIFICATION FAILED"));
+}
+
+TEST_CASE("a built-in check is proved alongside the assertion", "[bmc][run]")
+{
+  // The property report names the division check, not just the assertion.
+  const runt run = verify(
+    "int nondet_int();\n"
+    "int main() { int d = nondet_int(); if (d != 0) { int q = 7 / d; "
+    "assert(q * d <= 7); } }");
+  CHECK_THAT(run.output, Catch::Matchers::Contains("division by zero"));
+}
+
+TEST_CASE("every property gets its own verdict", "[bmc][run]")
+{
+  const runt run = verify(
+    "int nondet_int();\n"
+    "int main() { int x = nondet_int(); assert(x == x); assert(x != x); }",
+    {"multi-property"});
+  CHECK_THAT(run.output, Catch::Matchers::Contains("PASSED"));
+  CHECK_THAT(run.output, Catch::Matchers::Contains("FAILED"));
+}
+
+TEST_CASE("a coverage run measures instead of verifying", "[bmc][run]")
+{
+  // The instrumentation replaced the program's assertions with reachability
+  // probes, so the run reports goals rather than a verdict.
+  const runt run = verify(
+    "int main() { int x = 1; assert(x == 1); }",
+    {"assertion-coverage", "coverage-measurement"});
+  CHECK_THAT(run.output, Catch::Matchers::Contains("Coverage goals:"));
+  CHECK_THAT(run.output, !Catch::Matchers::Contains("VERIFICATION SUCCESSFUL"));
+}

--- a/unit/esbmc/property_report.test.cpp
+++ b/unit/esbmc/property_report.test.cpp
@@ -1,0 +1,211 @@
+/*******************************************************************
+ Module: Property report unit tests
+ \*******************************************************************/
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include <esbmc/property_report.h>
+#include <goto-programs/goto_functions.h>
+#include <irep2/irep2_utils.h>
+
+namespace
+{
+property_resultt result(
+  property_verdictt verdict,
+  std::string file,
+  std::string function,
+  unsigned line,
+  std::string description,
+  unsigned column = 0)
+{
+  property_resultt r;
+  r.verdict = verdict;
+  r.loc.file = std::move(file);
+  r.loc.function = std::move(function);
+  r.loc.description = std::move(description);
+  r.loc.line = line;
+  r.loc.column = column;
+  return r;
+}
+
+std::vector<std::string> ids(const std::vector<property_rowt> &rows)
+{
+  std::vector<std::string> out;
+  for (const auto &row : rows)
+    out.push_back(row.id);
+  return out;
+}
+
+/// A function whose body holds one assert at \p file, hidden or not.
+goto_functiont asserting_function(const std::string &file, bool hide)
+{
+  goto_functiont fn;
+  fn.body.hide = hide;
+  auto it = fn.body.add_instruction();
+  it->make_assertion(gen_true_expr());
+  it->location.set_file(file);
+  return fn;
+}
+} // namespace
+
+TEST_CASE("verdict_label names every verdict", "[property-report]")
+{
+  CHECK(
+    std::string(verdict_label(property_verdictt::NotChecked)) == "NOT CHECKED");
+  CHECK(std::string(verdict_label(property_verdictt::Passed)) == "PASSED");
+  CHECK(std::string(verdict_label(property_verdictt::Unknown)) == "UNKNOWN");
+  CHECK(std::string(verdict_label(property_verdictt::Failed)) == "FAILED");
+}
+
+TEST_CASE("count_properties tallies each verdict", "[property-report]")
+{
+  std::vector<property_rowt> rows(5);
+  rows[0].verdict = property_verdictt::Passed;
+  rows[1].verdict = property_verdictt::Passed;
+  rows[2].verdict = property_verdictt::Failed;
+  rows[3].verdict = property_verdictt::Unknown;
+  rows[4].verdict = property_verdictt::NotChecked;
+
+  const property_countst counts = count_properties(rows);
+  CHECK(counts.passed == 2);
+  CHECK(counts.failed == 1);
+  CHECK(counts.unknown == 1);
+  CHECK(counts.not_checked == 1);
+  CHECK(counts.anything_decided());
+}
+
+TEST_CASE("count_properties of nothing decides nothing", "[property-report]")
+{
+  const property_countst counts = count_properties({});
+  CHECK(counts.passed == 0);
+  CHECK(counts.id_width == 0);
+  CHECK(counts.line_width == 0);
+  CHECK_FALSE(counts.anything_decided());
+}
+
+TEST_CASE(
+  "a table of only unchecked properties has decided nothing",
+  "[property-report]")
+{
+  std::vector<property_rowt> rows(2);
+  CHECK(count_properties(rows).not_checked == 2);
+  CHECK_FALSE(count_properties(rows).anything_decided());
+}
+
+TEST_CASE("column widths span the widest row", "[property-report]")
+{
+  std::vector<property_rowt> rows(2);
+  rows[0].id = "main.assertion.1";
+  rows[0].line = 7;
+  rows[1].id = "f.division-by-zero.10";
+  rows[1].line = 1234;
+
+  const property_countst counts = count_properties(rows);
+  // Two wider than the id itself: the report prints it in brackets.
+  CHECK(counts.id_width == rows[1].id.size() + 2);
+  CHECK(counts.line_width == 4);
+}
+
+TEST_CASE("rows sort by source position", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"c", result(property_verdictt::Passed, "a.c", "main", 20, "third")},
+    {"a", result(property_verdictt::Passed, "a.c", "main", 10, "first")},
+    {"b", result(property_verdictt::Passed, "a.c", "main", 10, "second", 4)},
+    {"d", result(property_verdictt::Passed, "b.c", "main", 1, "fourth")}};
+
+  const std::vector<property_rowt> rows = build_property_rows(verdicts, {});
+  REQUIRE(rows.size() == 4);
+  CHECK(rows[0].description == "first");
+  CHECK(rows[1].description == "second");
+  CHECK(rows[2].description == "third");
+  CHECK(rows[3].description == "fourth");
+}
+
+TEST_CASE("library rows sort last whatever their path", "[property-report]")
+{
+  // An absolute path would otherwise sort ahead of the user's relative one.
+  const std::map<std::string, property_resultt> verdicts{
+    {"lib", result(property_verdictt::Passed, "/opt/om/stdlib.c", "f", 1, "l")},
+    {"user", result(property_verdictt::Failed, "user.c", "main", 9, "u")}};
+
+  const std::vector<property_rowt> rows =
+    build_property_rows(verdicts, {"/opt/om/stdlib.c"});
+  REQUIRE(rows.size() == 2);
+  CHECK(rows[0].description == "u");
+  CHECK_FALSE(rows[0].library);
+  CHECK(rows[1].description == "l");
+  CHECK(rows[1].library);
+}
+
+TEST_CASE(
+  "ids are numbered per function and property class",
+  "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Failed, "a.c", "main", 1, "an assertion")},
+    {"b",
+     result(property_verdictt::Failed, "a.c", "main", 2, "division by zero")},
+    {"c", result(property_verdictt::Failed, "a.c", "main", 3, "another one")},
+    {"d",
+     result(property_verdictt::Failed, "a.c", "helper", 4, "yet another")}};
+
+  // Rows sort by function before line, so helper's row leads.
+  const std::vector<std::string> expected{
+    "helper.assertion.1",
+    "main.assertion.1",
+    "main.division-by-zero.1",
+    "main.assertion.2"};
+  CHECK(ids(build_property_rows(verdicts, {})) == expected);
+}
+
+TEST_CASE("a property in no function is called global", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Unknown, "a.c", "", 1, "an assertion")}};
+
+  CHECK(build_property_rows(verdicts, {})[0].id == "global.assertion.1");
+}
+
+TEST_CASE("a row with no location falls back to its key", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"unnamed claim", result(property_verdictt::NotChecked, "", "", 0, "")}};
+
+  CHECK(build_property_rows(verdicts, {})[0].description == "unnamed claim");
+}
+
+TEST_CASE("surrounding whitespace is trimmed off", "[property-report]")
+{
+  const std::map<std::string, property_resultt> verdicts{
+    {"a", result(property_verdictt::Passed, "a.c", "main", 1, "  spaced \n")},
+    {"b", result(property_verdictt::Passed, "a.c", "main", 2, " \t\n")}};
+
+  const std::vector<property_rowt> rows = build_property_rows(verdicts, {});
+  CHECK(rows[0].description == "spaced");
+  CHECK(rows[1].description.empty());
+}
+
+TEST_CASE("only hidden functions contribute library files", "[property-report]")
+{
+  goto_functionst goto_functions;
+  goto_functions.function_map["om"] = asserting_function("stdlib.c", true);
+  goto_functions.function_map["user"] = asserting_function("user.c", false);
+
+  const std::set<std::string> files =
+    collect_library_assertion_files(goto_functions);
+  CHECK(files == std::set<std::string>{"stdlib.c"});
+}
+
+TEST_CASE(
+  "a hidden function with no assert contributes nothing",
+  "[property-report]")
+{
+  goto_functionst goto_functions;
+  goto_functiont fn;
+  fn.body.hide = true;
+  fn.body.add_instruction()->make_skip();
+  goto_functions.function_map["om"] = std::move(fn);
+
+  CHECK(collect_library_assertion_files(goto_functions).empty());
+}

--- a/unit/testing-utils/CMakeLists.txt
+++ b/unit/testing-utils/CMakeLists.txt
@@ -7,6 +7,11 @@ target_link_libraries(test_util_irep PUBLIC util_esbmc)
 add_library(mode_table_obj OBJECT mode_table.cpp)
 target_link_libraries(mode_table_obj PRIVATE langapi)
 
+# Companion to mode_table for tests that link esbmc-driver: the driver reports
+# the build id, which only a linked executable actually has.
+add_library(build_id_obj OBJECT esbmc_build_id.cpp)
+target_link_libraries(build_id_obj PRIVATE util_esbmc)
+
 add_library(test_goto_factory goto_factory.cpp)
 target_link_libraries(test_goto_factory PUBLIC irep2 clangcfrontend clangcppfrontend clibs)
 target_include_directories(test_goto_factory

--- a/unit/testing-utils/esbmc_build_id.cpp
+++ b/unit/testing-utils/esbmc_build_id.cpp
@@ -1,0 +1,11 @@
+#include <esbmc/globals.h>
+
+// The real definition reads buildidstring_buf out of the object flail.py
+// generates for the executable at link time (src/esbmc/CMakeLists.txt), so it
+// exists only in a real esbmc binary. Tests that link esbmc-driver pull in
+// objects that report the build id; none of them depend on its value.
+// Use as an OBJECT library, like mode_table, so the .o is always in the link.
+std::string esbmc_build_id()
+{
+  return "unit-test build";
+}


### PR DESCRIPTION
Depends on #7661.

Everything below `multi_property_check` needs a live reachability tree and a real solver, so none of it was reachable from the reporting tests in #7663. The `bmct` constructor already builds the tree, and `goto_factory` already turns a C string into goto functions, so a whole run -- parse, goto convert, symex, encode, solve, report -- costs milliseconds: 0.003s of BMC time for the cases here.

## Covered

An assertion that holds, one that fails with its counterexample, a nondet input refuted with a witness, a built-in division check named in the property report alongside the user's assertion, per-property verdicts under `--multi-property`, and a coverage run reporting goals instead of a verdict. 6 cases, 19 assertions.

1,844 of the lines these reach were reachable only from the regression suite, across 61 files: the run and solve path in `bmc.cpp`, the trace builder, the SMT layer, and the frontend and goto conversion the snippets pass through on the way.

## Note on what these are

These are integration tests, and their coverage per assertion is far lower than the decision-table tests in #7662/#7663 -- one check can drag in code it does not pin. They exist for the paths nothing else reaches (parse through solve, in one process), not as a model for covering logic that can be reached directly; that logic gets a tighter unit test where one exists.

## Verification

Full unit suite green (814 tests; the one failure is the pre-existing, unrelated `irep2test` stack-depth SEGFAULT). Verified individually under `ctest` isolation as well as run directly.
