### PR TITLE
[python] Give a bare `Callable` an Any return, not void

### DIFF
--- a/regression/python/github_7672_callable_param/main.py
+++ b/regression/python/github_7672_callable_param/main.py
@@ -1,0 +1,20 @@
+# A parameter annotated with an unsubscripted `Callable` must not lose the
+# value of the call made through it. An unsubscripted `Callable` is
+# `Callable[..., Any]` (PEP 484); typing its return void made `apply` look
+# like it returned None and folded the comparison to False (#7672).
+from typing import Callable
+
+
+def apply(g: Callable):
+    return g()
+
+
+def five() -> int:
+    return 5
+
+
+def main() -> None:
+    assert apply(five) == 5
+
+
+main()

--- a/regression/python/github_7672_callable_param/test.desc
+++ b/regression/python/github_7672_callable_param/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7672_callable_param_fail/main.py
+++ b/regression/python/github_7672_callable_param_fail/main.py
@@ -1,0 +1,19 @@
+# `five` returns 5, so the call through the `Callable`-annotated parameter must
+# not prove 6. Guards the return value actually reaching the caller rather than
+# staying nondet (#7672).
+from typing import Callable
+
+
+def apply(g: Callable):
+    return g()
+
+
+def five() -> int:
+    return 5
+
+
+def main() -> None:
+    assert apply(five) == 6
+
+
+main()

--- a/regression/python/github_7672_callable_param_fail/test.desc
+++ b/regression/python/github_7672_callable_param_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION FAILED$
+^\s*FAILED\s+\[main\.assertion\.1\].*assertion .* == .*6$

--- a/regression/python/github_7672_callable_param_nondet/main.py
+++ b/regression/python/github_7672_callable_param_nondet/main.py
@@ -1,0 +1,25 @@
+# The SV-COMP shape from #7672: a nondet source passed through a
+# `Callable`-annotated parameter. The assumption constrains the value the
+# callee returns, so it can only hold at the caller if the call through the
+# parameter carries that value back.
+from typing import Callable
+
+
+def nondet_int() -> int: ...
+
+
+def source() -> int:
+    v: int = nondet_int()
+    __ESBMC_assume(v >= 10)
+    return v
+
+
+def call(g: Callable):
+    return g()
+
+
+def main() -> None:
+    assert call(source) >= 10
+
+
+main()

--- a/regression/python/github_7672_callable_param_nondet/test.desc
+++ b/regression/python/github_7672_callable_param_nondet/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7672_callable_param_nondet_fail/main.py
+++ b/regression/python/github_7672_callable_param_nondet_fail/main.py
@@ -1,0 +1,24 @@
+# `source` is only assumed >= 10, so a stronger bound must stay refutable: the
+# counterpart guards against the call through the parameter being folded to a
+# constant instead of carrying the nondet value (#7672).
+from typing import Callable
+
+
+def nondet_int() -> int: ...
+
+
+def source() -> int:
+    v: int = nondet_int()
+    __ESBMC_assume(v >= 10)
+    return v
+
+
+def call(g: Callable):
+    return g()
+
+
+def main() -> None:
+    assert call(source) >= 11
+
+
+main()

--- a/regression/python/github_7672_callable_param_nondet_fail/test.desc
+++ b/regression/python/github_7672_callable_param_nondet_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION FAILED$
+^\s*FAILED\s+\[main\.assertion\.1\].*assertion .* >= 11$

--- a/regression/python/github_7672_callable_param_typed/main.py
+++ b/regression/python/github_7672_callable_param_typed/main.py
@@ -1,0 +1,19 @@
+# Same shape with a return annotation on the caller: the void return of the
+# unsubscripted `Callable` reached the solver as `Unexpected type in int/ptr
+# typecast` instead of a verdict (#7672).
+from typing import Callable
+
+
+def apply(g: Callable) -> int:
+    return g()
+
+
+def five() -> int:
+    return 5
+
+
+def main() -> None:
+    assert apply(five) == 5
+
+
+main()

--- a/regression/python/github_7672_callable_param_typed/test.desc
+++ b/regression/python/github_7672_callable_param_typed/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7672_callable_param_typed_fail/main.py
+++ b/regression/python/github_7672_callable_param_typed_fail/main.py
@@ -1,0 +1,18 @@
+# The `-> int` counterpart of github_7672_callable_param_fail: `five` returns
+# 5, so 6 must not be provable (#7672).
+from typing import Callable
+
+
+def apply(g: Callable) -> int:
+    return g()
+
+
+def five() -> int:
+    return 5
+
+
+def main() -> None:
+    assert apply(five) == 6
+
+
+main()

--- a/regression/python/github_7672_callable_param_typed_fail/test.desc
+++ b/regression/python/github_7672_callable_param_typed_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 1
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -1152,9 +1152,8 @@ python_converter::extract_type_info(const nlohmann::json &var_node)
     // A spelled `Callable[[A], R]` keeps its signature, so a call through the
     // variable recovers R. A bare one -- what the annotation pass infers for a
     // variable bound to a function value -- resolves to a pointer whose code
-    // type returns void, leaving that call nondet: worse than no annotation at
-    // all, since an unannotated binding takes the callee's own return type. So
-    // defer to the RHS instead (#6640).
+    // type returns Any, so deferring to the RHS keeps the callee's own return
+    // type instead (#6640).
     if (var_type_str == "Callable")
       return {
         var_type_str,

--- a/src/python-frontend/type/type_handler.cpp
+++ b/src/python-frontend/type/type_handler.cpp
@@ -508,12 +508,14 @@ typet type_handler::get_typet(const std::string &ast_type, size_t type_size)
   // Return a pointer to a generic no-argument code type (function pointer),
   // built IREP2-internal and lowered at the seam (Phase 4.3, Part IV §5). Empty
   // argument/name vectors satisfy code_type2t's args.size()==argument_names
-  // .size() invariant (irep2_type.h).
+  // .size() invariant (irep2_type.h). An unsubscripted `Callable` is
+  // `Callable[..., Any]` (PEP 484), so the return type is Any, not void: a
+  // void return makes the call through it drop the callee's value (#7672).
   if (ast_type == "Callable")
   {
     const type2tc code_t = code_type2tc(
       std::vector<type2tc>{},
-      get_empty_type(),
+      pointer_type2tc(get_empty_type()),
       std::vector<irep_idt>{},
       /*ellipsis=*/false);
     return lower_to_seam(pointer_type2tc(code_t));


### PR DESCRIPTION
A parameter annotated `typing.Callable` breaks the call made through it, and
the same code with the annotation removed verifies.

```python
from typing import Callable

def apply(g: Callable):
    return g()

def five() -> int:
    return 5

def main() -> None:
    assert apply(five) == 5

main()
```

```
$ esbmc main.py
  FAILED       [main.assertion.1]  line 10  assertion 0
VERIFICATION FAILED
```

`assertion 0`: the comparison was constant-folded, so `apply(five)` never
carried `five`'s return value. Under CPython the program exits 0.

`type_handler::get_typet` built the type for an unsubscripted `Callable` as a
function pointer whose code type returns `get_empty_type()`, i.e. void. In
`converter_funcall.cpp`, an indirect call through a variable takes its type
from that code type's return type, so the call produced nothing, `apply` was
inferred to return None, and the comparison folded to false. The `void*`
an *unannotated* parameter gets takes the other branch of the same function
(`call.type() = any_type()`), which is why dropping the annotation verifies.

An unsubscripted `Callable` is `Callable[..., Any]` (PEP 484 "Callable",
"the return type must be a single type"; a bare `Callable` leaves both
unspecified). It does not say the function returns nothing.

### The change

One line: the generic code type returns Any rather than void.

```diff
-      get_empty_type(),
+      pointer_type2tc(get_empty_type()),
```

A bare `Callable` parameter now behaves as the unannotated one already did.
The second hunk refreshes a comment in `converter_stmt.cpp` that explained a
`Callable` variable's deferral to the RHS by the void return this removes;
the deferral itself is unchanged and still wanted, since the RHS carries the
concrete signature and Any does not.

The `Callable[[A], R]` path is untouched: `get_callable_type` only falls back
to this type when the signature is not spelled.

### Tests

Three pairs under `regression/python/`, over the annotated shapes in the
issue:

| | expects |
|---|---|
| `github_7672_callable_param` / `_fail` | the issue's program, no return annotation on the caller |
| `github_7672_callable_param_typed` / `_fail` | the `-> int` variant, which aborted rather than answering |
| `github_7672_callable_param_nondet` / `_fail` | a nondet source called through the parameter, so no cell can be constant-folded |

Mutation-checked by reverting the one-line change and rebuilding. All six
change verdict:

```
$ ctest -R github_7672                     # with the fix
100% tests passed, 0 tests failed out of 6

$ ctest -R github_7672                     # one-line change reverted
0% tests passed, 6 tests failed out of 6
```

Two of the three `_fail` cases needed more than `^VERIFICATION FAILED$` to
bite: before the fix *everything* fails, so the expectation held for the
wrong reason. Their `test.desc` also pins the violated property, which the
unfixed build does not produce:

| test | unfixed output | with the fix |
|---|---|---|
| `..._param_fail` | `assertion 0` | `assertion return_value$_apply$1 == (void *)6` |
| `..._param_nondet_fail` | `uncaught exception: TypeError` | `assertion (signed long int)return_value$_call$1 >= 11` |

### Checks

- `ctest -R github_7672` — 6/6, and 0/6 with the change reverted.
- Every Python regression whose source mentions `Callable` (36 tests,
  including `callable1..7`, `callable_member_*`, `github_6640_*`,
  `sv_verifier_nondet_list`, `sv_verifier_nondet_stub`) — 36/36.
- `ctest -R '^regression/python/'` — 5016/5016, measured on this branch's
  first base, `e11670ac5b`. Rebased since onto `892c1ad24a`; both runs
  above were repeated on the new base, and a full re-run is under way.
- clang-format clean.

### One residual, pre-existing

`Any` is `void*`, which cannot carry a double, so a callable returning a
float still reports a false failure:

```python
def apply(g: Callable): return g()
def half() -> float: return 0.5
assert apply(half) == 0.5      # VERIFICATION FAILED
```

That is unchanged by this PR: the same program with `def apply(g):` fails
identically on master. It is a gap in the Any representation, not in the
annotation, and wants its own issue.

Fixes #7672.

