### PR TITLE
[python] Dispatch random.choice/sample on the sequence type

### DIFF
--- a/regression/python/harness_random_choice_float/main.py
+++ b/regression/python/harness_random_choice_float/main.py
@@ -1,0 +1,11 @@
+# Model: src/python-frontend/models/random.py (choice_float).
+# ENSURES: E1 - choice over a list of floats returns one of its elements.
+import random
+
+
+def main() -> None:
+    c = random.choice([1.5, 2.5])
+    assert c == 1.5 or c == 2.5  # E1
+
+
+main()

--- a/regression/python/harness_random_choice_float/test.desc
+++ b/regression/python/harness_random_choice_float/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_random_choice_float_fail/main.py
+++ b/regression/python/harness_random_choice_float_fail/main.py
@@ -1,0 +1,14 @@
+# The failing half of harness_random_choice_float. The first assertion is the
+# true one: on an unfixed binary the result is mistyped and *it* is the claim
+# that fails, so pinning the second violation is what makes this test bite.
+# The false value is outside the list so CPython rejects it deterministically.
+import random
+
+
+def main() -> None:
+    c = random.choice([1.5, 2.5])
+    assert c == 1.5 or c == 2.5
+    assert c == 9.5
+
+
+main()

--- a/regression/python/harness_random_choice_float_fail/test.desc
+++ b/regression/python/harness_random_choice_float_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--unwind 6 --multi-property
+^\s+PASSED\s+\[main\.assertion\.[0-9]+\]\s+line\s+10\s+assertion
+^\s+FAILED\s+\[main\.assertion\.[0-9]+\]\s+line\s+11\s+assertion
+^VERIFICATION FAILED$

--- a/regression/python/harness_random_choice_liststr/main.py
+++ b/regression/python/harness_random_choice_liststr/main.py
@@ -1,0 +1,11 @@
+# Model: src/python-frontend/models/random.py (choice_str).
+# ENSURES: E1 - choice over a list of strings returns one of its elements.
+import random
+
+
+def main() -> None:
+    c = random.choice(["ab", "cd"])
+    assert c == "ab" or c == "cd"  # E1
+
+
+main()

--- a/regression/python/harness_random_choice_liststr/test.desc
+++ b/regression/python/harness_random_choice_liststr/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_random_choice_liststr_fail/main.py
+++ b/regression/python/harness_random_choice_liststr_fail/main.py
@@ -1,0 +1,11 @@
+# The failing half of harness_random_choice_liststr; see the float twin.
+import random
+
+
+def main() -> None:
+    c = random.choice(["ab", "cd"])
+    assert c == "ab" or c == "cd"
+    assert c == "zz"
+
+
+main()

--- a/regression/python/harness_random_choice_liststr_fail/test.desc
+++ b/regression/python/harness_random_choice_liststr_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--unwind 6 --multi-property
+^\s+PASSED\s+\[main\.assertion\.[0-9]+\]\s+line\s+7\s+assertion
+^\s+FAILED\s+\[main\.assertion\.[0-9]+\]\s+line\s+8\s+assertion
+^VERIFICATION FAILED$

--- a/regression/python/harness_random_choice_str/main.py
+++ b/regression/python/harness_random_choice_str/main.py
@@ -1,0 +1,12 @@
+# Model: src/python-frontend/models/random.py (choice_chars).
+# REQUIRES: nothing.
+# ENSURES: E1 - random.choice(s) over a str returns one of its characters.
+import random
+
+
+def main() -> None:
+    c = random.choice("abc")
+    assert c == "a" or c == "b" or c == "c"  # E1
+
+
+main()

--- a/regression/python/harness_random_choice_str/test.desc
+++ b/regression/python/harness_random_choice_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_random_choice_str_fail/main.py
+++ b/regression/python/harness_random_choice_str_fail/main.py
@@ -1,0 +1,13 @@
+# The failing half of harness_random_choice_str. The first assertion is the
+# true one: on an unfixed binary the result is mistyped and *it* is the claim
+# that fails, so pinning the second violation is what makes this test bite.
+import random
+
+
+def main() -> None:
+    c = random.choice("abc")
+    assert c == "a" or c == "b" or c == "c"
+    assert c == "z"
+
+
+main()

--- a/regression/python/harness_random_choice_str_fail/test.desc
+++ b/regression/python/harness_random_choice_str_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--unwind 6 --multi-property
+^\s+PASSED\s+\[main\.assertion\.[0-9]+\]\s+line\s+9\s+assertion
+^\s+FAILED\s+\[main\.assertion\.[0-9]+\]\s+line\s+10\s+assertion
+^VERIFICATION FAILED$

--- a/regression/python/harness_random_choice_tuple/main.py
+++ b/regression/python/harness_random_choice_tuple/main.py
@@ -1,0 +1,17 @@
+# A tuple has no model variant: its arity and member types vary per call site,
+# so function_call_expr::fold_random_choice_over_tuple selects an element
+# inline. The members must still share one type -- see random_choice_none_tuple
+# for the case that does not.
+# ENSURES: E1 - an int tuple yields one of its members.
+#          E2 - a float tuple yields one of its members.
+import random
+
+
+def main() -> None:
+    a = random.choice((10, 20, 30))
+    assert a == 10 or a == 20 or a == 30  # E1
+    b = random.choice((1.5, 2.5))
+    assert b == 1.5 or b == 2.5  # E2
+
+
+main()

--- a/regression/python/harness_random_choice_tuple/test.desc
+++ b/regression/python/harness_random_choice_tuple/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_random_choice_tuple_fail/main.py
+++ b/regression/python/harness_random_choice_tuple_fail/main.py
@@ -1,0 +1,11 @@
+# The failing half of harness_random_choice_tuple; see the float twin.
+import random
+
+
+def main() -> None:
+    a = random.choice((10, 20, 30))
+    assert a == 10 or a == 20 or a == 30
+    assert a == 99
+
+
+main()

--- a/regression/python/harness_random_choice_tuple_fail/test.desc
+++ b/regression/python/harness_random_choice_tuple_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--unwind 6 --multi-property
+^\s+PASSED\s+\[main\.assertion\.[0-9]+\]\s+line\s+7\s+assertion
+^\s+FAILED\s+\[main\.assertion\.[0-9]+\]\s+line\s+8\s+assertion
+^VERIFICATION FAILED$

--- a/regression/python/harness_random_sample_float/main.py
+++ b/regression/python/harness_random_sample_float/main.py
@@ -1,0 +1,13 @@
+# Model: src/python-frontend/models/random.py (sample_float).
+# ENSURES: E1 - sample over a list of floats keeps the element type, so every
+#          sampled value is one of the population's.
+import random
+
+
+def main() -> None:
+    r = random.sample([1.5, 2.5, 3.5], 2)
+    assert len(r) == 2
+    assert r[0] == 1.5 or r[0] == 2.5 or r[0] == 3.5  # E1
+
+
+main()

--- a/regression/python/harness_random_sample_float/test.desc
+++ b/regression/python/harness_random_sample_float/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_random_sample_float_fail/main.py
+++ b/regression/python/harness_random_sample_float_fail/main.py
@@ -1,0 +1,11 @@
+# The failing half of harness_random_sample_float; see the choice twin.
+import random
+
+
+def main() -> None:
+    r = random.sample([1.5, 2.5, 3.5], 2)
+    assert r[0] == 1.5 or r[0] == 2.5 or r[0] == 3.5
+    assert r[0] == 9.5
+
+
+main()

--- a/regression/python/harness_random_sample_float_fail/test.desc
+++ b/regression/python/harness_random_sample_float_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--unwind 8 --multi-property
+^\s+PASSED\s+\[main\.assertion\.[0-9]+\]\s+line\s+7\s+assertion
+^\s+FAILED\s+\[main\.assertion\.[0-9]+\]\s+line\s+8\s+assertion
+^VERIFICATION FAILED$

--- a/regression/python/harness_random_sample_str/main.py
+++ b/regression/python/harness_random_sample_str/main.py
@@ -1,0 +1,15 @@
+# Model: src/python-frontend/models/random.py (sample_chars, sample_str).
+# ENSURES: E1 - sample over a str yields k one-character strings.
+#          E2 - sample over a list of strings yields k of its elements.
+import random
+
+
+def main() -> None:
+    a = random.sample("abc", 2)
+    assert len(a) == 2
+    assert a[0] == "a" or a[0] == "b" or a[0] == "c"  # E1
+    b = random.sample(["ab", "cd", "ef"], 2)
+    assert len(b) == 2  # E2
+
+
+main()

--- a/regression/python/harness_random_sample_str/test.desc
+++ b/regression/python/harness_random_sample_str/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 8
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/harness_random_sample_str_fail/main.py
+++ b/regression/python/harness_random_sample_str_fail/main.py
@@ -1,0 +1,11 @@
+# The failing half of harness_random_sample_str; see the choice twin.
+import random
+
+
+def main() -> None:
+    a = random.sample("abc", 2)
+    assert a[0] == "a" or a[0] == "b" or a[0] == "c"
+    assert a[0] == "z"
+
+
+main()

--- a/regression/python/harness_random_sample_str_fail/test.desc
+++ b/regression/python/harness_random_sample_str_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--unwind 8 --multi-property
+^\s+PASSED\s+\[main\.assertion\.[0-9]+\]\s+line\s+7\s+assertion
+^\s+FAILED\s+\[main\.assertion\.[0-9]+\]\s+line\s+8\s+assertion
+^VERIFICATION FAILED$

--- a/regression/python/random_choice_call_argument/main.py
+++ b/regression/python/random_choice_call_argument/main.py
@@ -1,0 +1,16 @@
+# The sequence argument is not always a symbol: a call result has no element
+# type recorded for it. That must keep the base model it had before the
+# dispatch existed rather than become an error (#7673).
+import random
+
+
+def make() -> list[int]:
+    return [1, 2]
+
+
+def main() -> None:
+    c = random.choice(make())
+    assert c == 1 or c == 2
+
+
+main()

--- a/regression/python/random_choice_call_argument/test.desc
+++ b/regression/python/random_choice_call_argument/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/random_choice_empty_tuple_fail/main.py
+++ b/regression/python/random_choice_empty_tuple_fail/main.py
@@ -1,0 +1,11 @@
+# An empty tuple has no member to select, so the inline fold reports it rather
+# than emitting a claim. CPython raises IndexError here.
+import random
+
+
+def main() -> None:
+    v = random.choice(())
+    assert v is not None
+
+
+main()

--- a/regression/python/random_choice_empty_tuple_fail/test.desc
+++ b/regression/python/random_choice_empty_tuple_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^ERROR: random\.choice\(\): empty tuple$

--- a/regression/python/random_choice_mixed_tuple/main.py
+++ b/regression/python/random_choice_mixed_tuple/main.py
@@ -1,0 +1,14 @@
+# The inline tuple fold builds one conditional, which carries one type, so a
+# tuple whose members differ in type would coerce every result to the first
+# member's type and silently mis-answer later comparisons. Report it instead of
+# emitting a claim. CPython accepts this call, so a verdict here would be a
+# false one either way (#7673).
+import random
+
+
+def main() -> None:
+    c = random.choice((1, "two"))
+    assert c == 1 or c == "two"
+
+
+main()

--- a/regression/python/random_choice_mixed_tuple/test.desc
+++ b/regression/python/random_choice_mixed_tuple/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^ERROR: random\.choice\(\): unsupported mixed-type tuple$

--- a/regression/python/random_choice_module_alias/main.py
+++ b/regression/python/random_choice_module_alias/main.py
@@ -1,0 +1,11 @@
+# The dispatch keys on the call's receiver, so an aliased import must still
+# reach the str variant rather than the int-list model.
+import random as rnd
+
+
+def main() -> None:
+    c = rnd.choice("abc")
+    assert c == "a" or c == "b" or c == "c"
+
+
+main()

--- a/regression/python/random_choice_module_alias/test.desc
+++ b/regression/python/random_choice_module_alias/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/random_choice_none_tuple/main.py
+++ b/regression/python/random_choice_none_tuple/main.py
@@ -1,0 +1,12 @@
+# int and None share an element-type class but not a type, and folding them
+# together let ESBMC prove `c is not None` on a tuple that holds None. The
+# members' types must agree exactly, so this is reported (#7673).
+import random
+
+
+def main() -> None:
+    c = random.choice((1, None))
+    assert c == 1 or c is None
+
+
+main()

--- a/regression/python/random_choice_none_tuple/test.desc
+++ b/regression/python/random_choice_none_tuple/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^ERROR: random\.choice\(\): unsupported mixed-type tuple$

--- a/regression/python/random_choice_user_shadow/main.py
+++ b/regression/python/random_choice_user_shadow/main.py
@@ -1,0 +1,16 @@
+# A module-level function of the same name cannot be the callee of
+# `random.choice(...)` -- the receiver already names the module -- so the
+# dispatch must still fire and pick the str variant.
+import random
+
+
+def choice(x: int) -> int:
+    return x
+
+
+def main() -> None:
+    c = random.choice("abc")
+    assert c == "a" or c == "b" or c == "c"
+
+
+main()

--- a/regression/python/random_choice_user_shadow/test.desc
+++ b/regression/python/random_choice_user_shadow/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 6
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/random_sample_tuple_unsupported/main.py
+++ b/regression/python/random_sample_tuple_unsupported/main.py
@@ -1,0 +1,12 @@
+# sample() has no tuple variant -- a model parameter cannot name one arity and
+# one member type. The sequence type is reported instead of running the
+# int-list model, which used to raise a spurious memory-safety claim (#7673).
+import random
+
+
+def main() -> None:
+    r = random.sample((10, 20, 30), 2)
+    assert len(r) == 2
+
+
+main()

--- a/regression/python/random_sample_tuple_unsupported/test.desc
+++ b/regression/python/random_sample_tuple_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 4
+^ERROR: random\.sample\(\): unsupported sequence type .tuple.$

--- a/src/python-frontend/function_call/expr.cpp
+++ b/src/python-frontend/function_call/expr.cpp
@@ -5123,6 +5123,175 @@ static void reject_unfoldable_key(
         "the key function cannot be applied and would be ignored");
 }
 
+// A Python tuple is lowered to a struct tagged "tag-tuple...".
+static bool is_tuple_struct(const typet &type)
+{
+  return type.is_struct() &&
+         to_struct_type(type).tag().as_string().starts_with("tag-tuple");
+}
+
+// Suffix naming the models/random.py variant for an element type, matching the
+// min/max/sorted convention in models/builtins.py: integers keep the base name.
+static std::string random_element_suffix(const typet &elem_type)
+{
+  if (elem_type.is_floatbv())
+    return "_float";
+  if (type_utils::is_string_type(elem_type))
+    return "_str";
+  return "";
+}
+
+std::optional<exprt>
+function_call_expr::fold_random_choice_over_tuple(const exprt &seq)
+{
+  const typet &seq_type = converter_.ns.follow(seq.type());
+  if (!is_tuple_struct(seq_type))
+    return std::nullopt;
+
+  tuple_handler &tuples = converter_.get_tuple_handler();
+
+  const struct_typet &tuple_type = to_struct_type(seq_type);
+  const struct_typet::componentst &members = tuple_type.components();
+  if (members.empty())
+    throw std::runtime_error("random.choice(): empty tuple");
+
+  // The conditional below carries one type, so members of differing types
+  // would be coerced to the first one's and every later comparison against the
+  // result would silently answer against the wrong type. Compare the types
+  // themselves: an int and a None both map to the same element-type suffix,
+  // and folding those together proved `c is not None` on a tuple holding None.
+  const typet &first = converter_.ns.follow(members.front().type());
+  for (const auto &member : members)
+    if (converter_.ns.follow(member.type()) != first)
+      throw std::runtime_error("random.choice(): unsupported mixed-type tuple");
+
+  exprt result = tuples.get_tuple_element(seq, tuple_type, members.size() - 1);
+  if (members.size() == 1)
+    return result;
+
+  // The index is only compared, never used to address memory, so it needs no
+  // range assumption: the final else arm makes every out-of-range value pick
+  // the last member, leaving the result's value set exactly the tuple's
+  // members -- which is what choice() promises.
+  locationt loc = converter_.get_location_from_decl(call_);
+  exprt idx = build_symbol(
+    converter_.create_tmp_symbol(call_, "$choice_idx$", int_type(), exprt()));
+  code_declt decl(idx);
+  decl.location() = loc;
+  converter_.add_instruction(decl);
+  code_assignt assign(idx, side_effect_expr_nondett(int_type()));
+  assign.location() = loc;
+  converter_.add_instruction(assign);
+
+  for (size_t i = members.size() - 1; i-- > 0;)
+    result = if_exprt(
+      equality_exprt(idx, from_integer(BigInt(i), idx.type())),
+      tuples.get_tuple_element(seq, tuple_type, i),
+      result);
+  return result;
+}
+
+std::string function_call_expr::random_sequence_suffix(
+  const exprt &seq,
+  const std::string &func_name)
+{
+  // A str is a sequence of one-character strings, not a list, so it has its
+  // own variant rather than an element-type suffix.
+  if (type_utils::is_string_type(seq.type()))
+    return "_chars";
+
+  // homogeneous_element_type throws, naming func_name, when the elements mix
+  // incompatibly -- which is the diagnostic an unmodelled list should get.
+  if (seq.is_symbol())
+    return random_element_suffix(
+      converter_.get_element_type_registry().homogeneous_element_type(
+        seq.identifier().as_string(), func_name));
+
+  // A tuple reaching here is a sample() call: no model parameter can name one
+  // arity and one member type, and the list model would raise a spurious
+  // memory-safety claim on it, so report it.
+  if (is_tuple_struct(converter_.ns.follow(seq.type())))
+    throw std::runtime_error(
+      "random." + func_name + "(): unsupported sequence type 'tuple'");
+
+  // Anything else -- a call result, say -- keeps the base model it had before
+  // this dispatch existed. Erroring here would turn a verdict into no verdict
+  // on programs that already verified.
+  return "";
+}
+
+// Whether every tuple member is numeric, setting @p any_float when at least
+// one is a float. Non-numeric members (nested tuples, strings -- a TypeError in
+// CPython anyway) leave the tuple unfoldable.
+static bool tuple_members_are_numeric(
+  const struct_typet::componentst &members,
+  const namespacet &ns,
+  bool &any_float)
+{
+  any_float = false;
+  for (const auto &member : members)
+  {
+    const typet &type = ns.follow(member.type());
+    if (type.is_floatbv() || type.is_fixedbv())
+      any_float = true;
+    else if (!type.is_signedbv() && !type.is_unsignedbv() && !type.is_bool())
+      return false;
+  }
+  return true;
+}
+
+// sum() over a tuple: the sum/sum_float models iterate a *list* representation
+// that a tuple struct does not have, so they return garbage
+// (e.g. sum((1, 2, 3)) != 6). Fold the tuple's members directly with '+',
+// promoting to double when any member is float so mixed int/float tuples keep
+// Python semantics (sum((1, 2.5, 3)) == 6.5).
+std::optional<exprt> function_call_expr::fold_sum_over_tuple(
+  bool is_user_imported,
+  bool is_numpy_model_call)
+{
+  const std::string &func_name = function_id_.get_function();
+  const size_t n_args = call_["args"].size();
+  if (
+    func_name != "sum" || is_user_imported || is_numpy_model_call ||
+    (n_args != 1 && n_args != 2) ||
+    !try_find_function(converter_.ast()["body"], func_name).empty())
+    return std::nullopt;
+
+  exprt arg = converter_.get_expr(call_["args"][0]);
+  const typet &arg_type = converter_.ns.follow(arg.type());
+  if (!is_tuple_struct(arg_type))
+    return std::nullopt;
+
+  const struct_typet::componentst &members =
+    to_struct_type(arg_type).components();
+  bool any_float = false;
+  if (!tuple_members_are_numeric(members, converter_.ns, any_float))
+    return std::nullopt;
+
+  const type2tc sum_type =
+    migrate_type(any_float ? double_type() : long_long_int_type());
+
+  expr2tc acc;
+  if (n_args == 2)
+  {
+    migrate_expr(converter_.get_expr(call_["args"][1]), acc);
+    if (acc->type != sum_type)
+      acc = typecast2tc(sum_type, acc);
+  }
+  else
+    acc = gen_zero(sum_type);
+
+  for (const auto &member : members)
+  {
+    expr2tc value;
+    migrate_expr(build_member(arg, member.get_name(), member.type()), value);
+    if (value->type != sum_type)
+      value = typecast2tc(sum_type, value);
+    acc = add2tc(sum_type, acc, value);
+  }
+  return migrate_expr_back(acc);
+}
+
 std::optional<exprt> function_call_expr::apply_builtin_dispatch(
   std::string &actual_func_name,
   bool is_user_imported,
@@ -5134,61 +5303,24 @@ std::optional<exprt> function_call_expr::apply_builtin_dispatch(
   // consistently. The other builtins below remain 1-arg only.
   const size_t n_args = call_["args"].size();
 
-  // sum() over a tuple: the sum/sum_float models iterate a *list*
-  // representation that a tuple struct does not have, so they return
-  // garbage (e.g. sum((1, 2, 3)) != 6). Fold the tuple's members directly
-  // with '+', promoting to double when any element is float so mixed
-  // int/float tuples keep Python semantics (sum((1, 2.5, 3)) == 6.5).
   if (
-    func_name == "sum" && !is_user_imported && !is_numpy_model_call &&
-    (n_args == 1 || n_args == 2) &&
-    try_find_function(converter_.ast()["body"], func_name).empty())
+    std::optional<exprt> summed =
+      fold_sum_over_tuple(is_user_imported, is_numpy_model_call))
+    return *summed;
+
+  // random.choice / random.sample dispatch to the models/random.py variant
+  // matching the argument's sequence type; without it every non-int-list
+  // sequence runs the int-list model and raises a spurious memory-safety
+  // claim (issue #7673).
+  if (
+    (func_name == "choice" || func_name == "sample") && !is_user_imported &&
+    !is_numpy_model_call && n_args >= 1 && get_object_name() == "random")
   {
-    exprt arg = converter_.get_expr(call_["args"][0]);
-    const typet &at = converter_.ns.follow(arg.type());
-    if (
-      at.is_struct() &&
-      to_struct_type(at).tag().as_string().starts_with("tag-tuple"))
-    {
-      const struct_typet::componentst &comps = to_struct_type(at).components();
-      // Only fold numeric tuples; leave non-numeric ones (nested tuples,
-      // strings — a TypeError in CPython anyway) to the existing path so
-      // this change is scoped to the case it fixes.
-      bool any_float = false, all_numeric = true;
-      for (const auto &c : comps)
-      {
-        const typet &ct = converter_.ns.follow(c.type());
-        if (ct.is_floatbv() || ct.is_fixedbv())
-          any_float = true;
-        else if (!ct.is_signedbv() && !ct.is_unsignedbv() && !ct.is_bool())
-          all_numeric = false;
-      }
-      if (all_numeric)
-      {
-        const type2tc rt2 =
-          migrate_type(any_float ? double_type() : long_long_int_type());
-
-        expr2tc acc;
-        if (n_args == 2)
-        {
-          migrate_expr(converter_.get_expr(call_["args"][1]), acc);
-          if (acc->type != rt2)
-            acc = typecast2tc(rt2, acc);
-        }
-        else
-          acc = gen_zero(rt2);
-
-        for (const auto &c : comps)
-        {
-          expr2tc m2;
-          migrate_expr(build_member(arg, c.get_name(), c.type()), m2);
-          if (m2->type != rt2)
-            m2 = typecast2tc(rt2, m2);
-          acc = add2tc(rt2, acc, m2);
-        }
-        return migrate_expr_back(acc);
-      }
-    }
+    const exprt seq = converter_.get_expr(call_["args"][0]);
+    if (func_name == "choice")
+      if (std::optional<exprt> element = fold_random_choice_over_tuple(seq))
+        return element;
+    actual_func_name += random_sequence_suffix(seq, func_name);
   }
 
   const bool is_sorted_min_max = func_name == "min" || func_name == "max" ||

--- a/src/python-frontend/function_call/expr.h
+++ b/src/python-frontend/function_call/expr.h
@@ -719,6 +719,53 @@ private:
    */
   std::optional<exprt> try_fold_identity_array_return();
 
+  /**
+   * Suffix selecting the models/random.py variant that matches a sequence
+   * argument's type: "_float" or "_str" for a list of those, "_chars" for a
+   * str, and "" for a list of ints and for any argument this cannot type,
+   * which keeps the base model it had before the dispatch existed.
+   *
+   * @param seq  the converted sequence argument.
+   * @param func_name  "choice" or "sample", used in the diagnostic.
+   * @return the suffix to append to the model function name.
+   * @throws std::runtime_error naming func_name for a tuple, which no model
+   *         parameter can take and on which the list model would raise a
+   *         spurious memory-safety claim; and from
+   *         element_type_registry::homogeneous_element_type for a list whose
+   *         elements mix incompatibly.
+   */
+  std::string
+  random_sequence_suffix(const exprt &seq, const std::string &func_name);
+
+  /**
+   * Selects an element of a tuple for random.choice(), inline.
+   *
+   * A model function cannot take a tuple, whose arity and member types vary
+   * per call site, so the choice is folded into a nested conditional over a
+   * nondet index instead.
+   *
+   * @param seq  the converted sequence argument.
+   * @return the selected element, or nullopt when @p seq is not a tuple.
+   * @throws std::runtime_error on an empty tuple, which has no element to
+   *         select, and on a tuple whose members differ in type, which one
+   *         conditional cannot carry.
+   */
+  std::optional<exprt> fold_random_choice_over_tuple(const exprt &seq);
+
+  /**
+   * Folds sum() over a numeric tuple into a chain of additions.
+   *
+   * The sum/sum_float models iterate a list representation a tuple struct does
+   * not have, so they would return garbage.
+   *
+   * @param is_user_imported  whether a user import shadows the builtin.
+   * @param is_numpy_model_call  whether the call is inside models/numpy.py.
+   * @return the folded sum, or nullopt when the call is not sum() over a
+   *         numeric tuple.
+   */
+  std::optional<exprt>
+  fold_sum_over_tuple(bool is_user_imported, bool is_numpy_model_call);
+
   /*
    * Typed-builtin dispatch for min/max/sum/sorted/reversed: appends the
    * _float/_str/_default suffix to actual_func_name based on element type, and

--- a/src/python-frontend/models/random.py
+++ b/src/python-frontend/models/random.py
@@ -71,6 +71,46 @@ def choice(seq: list[int]) -> int:
     return seq[i]
 
 
+# `choice` and `sample` accept any sequence, but the frontend is monomorphic:
+# one body carries one type, and an unannotated one mixing a str and an int list
+# fails to encode at all. So each sequence type gets its own body and
+# function_call_expr::random_sequence_suffix picks between them at the call
+# site, exactly as builtins.py spells min/min_float/min_str (issue #7673).
+# The bodies below are deliberate copies; only the annotations differ. A tuple
+# gets no variant: its arity and member types vary per call site, so
+# function_call_expr::fold_random_choice_over_tuple selects an element inline.
+
+
+def choice_float(seq: list[float]) -> float:
+    """`choice` over a list of floats."""
+    n: int = len(seq)
+    if n <= 0:
+        raise IndexError("Cannot choose from an empty sequence")
+    i: int = nondet_int()
+    __ESBMC_assume(i >= 0 and i < n)
+    return seq[i]
+
+
+def choice_str(seq: list[str]) -> str:
+    """`choice` over a list of strings."""
+    n: int = len(seq)
+    if n <= 0:
+        raise IndexError("Cannot choose from an empty sequence")
+    i: int = nondet_int()
+    __ESBMC_assume(i >= 0 and i < n)
+    return seq[i]
+
+
+def choice_chars(seq: str) -> str:
+    """`choice` over a string, which is a sequence of one-character strings."""
+    n: int = len(seq)
+    if n <= 0:
+        raise IndexError("Cannot choose from an empty sequence")
+    i: int = nondet_int()
+    __ESBMC_assume(i >= 0 and i < n)
+    return seq[i]
+
+
 def shuffle(lst: list[int]) -> None:
     """random.shuffle(lst) — permutes `lst` in place.
 
@@ -91,6 +131,45 @@ def sample(population: list[int], k: int) -> list[int]:
     if k < 0 or k > n:
         raise ValueError("Sample larger than population or is negative")
     result: list[int] = []
+    i: int = 0
+    while i < k:
+        result.append(population[i])
+        i = i + 1
+    return result
+
+
+def sample_float(population: list[float], k: int) -> list[float]:
+    """`sample` over a list of floats."""
+    n: int = len(population)
+    if k < 0 or k > n:
+        raise ValueError("Sample larger than population or is negative")
+    result: list[float] = []
+    i: int = 0
+    while i < k:
+        result.append(population[i])
+        i = i + 1
+    return result
+
+
+def sample_str(population: list[str], k: int) -> list[str]:
+    """`sample` over a list of strings."""
+    n: int = len(population)
+    if k < 0 or k > n:
+        raise ValueError("Sample larger than population or is negative")
+    result: list[str] = []
+    i: int = 0
+    while i < k:
+        result.append(population[i])
+        i = i + 1
+    return result
+
+
+def sample_chars(population: str, k: int) -> list[str]:
+    """`sample` over a string, yielding a list of one-character strings."""
+    n: int = len(population)
+    if k < 0 or k > n:
+        raise ValueError("Sample larger than population or is negative")
+    result: list[str] = []
     i: int = 0
     while i < k:
         result.append(population[i])

--- a/src/python-frontend/python_annotation/annotation_conversion.inl
+++ b/src/python-frontend/python_annotation/annotation_conversion.inl
@@ -1936,6 +1936,23 @@ std::string python_annotation<Json>::get_type_from_method(const Json &call)
 {
   std::string type("");
 
+  // random.choice / random.sample resolve to the models/random.py variant
+  // matching the argument's element type, so the base model's `-> int` is not
+  // this call's return type. Defer to the argument, as min/max/sum do by being
+  // "Any" in builtin_functions() (issue #7673).
+  if (
+    call["func"].contains("value") && call["func"]["value"].is_object() &&
+    call["func"]["value"].value("_type", std::string()) == "Name" &&
+    call["func"]["value"].value("id", std::string()) == "random" &&
+    call["func"].contains("attr"))
+  {
+    const std::string &method = call["func"]["attr"];
+    if (method == "choice")
+      return "Any";
+    if (method == "sample")
+      return "list";
+  }
+
   // Handle method calls on constant literals
   // When Python code has " ".join(l), the func["value"] is a Constant node
   // We need to map string method names to their return types directly


### PR DESCRIPTION
`random.choice`/`random.sample` were annotated `list[int]` in
`models/random.py`, so a str, a tuple, or a list of floats or strings ran the
int-list model and reported a dereference failure — a false
`VERIFICATION FAILED` on a correct program. The frontend is monomorphic, so
each sequence type gets its own model variant and the call site picks one, as
`min`/`max`/`sorted` already do; a tuple is folded inline because no model
parameter can name one arity.

Fixes #7673. Still open: `from random import choice` (the callee is not yet
resolved to the model where the dispatch runs), keyword-argument calls, and
`sample` over a tuple — all of which now report an unsupported sequence or
keep their previous verdict rather than emitting a bogus claim.
