### PR TITLE
[python] Model sys and stop unmodelled imports aborting

### DIFF
--- a/regression/python/github_5898_itertools/test.desc
+++ b/regression/python/github_5898_itertools/test.desc
@@ -1,4 +1,6 @@
 CORE
 main.py
 --function first_n --no-bounds-check
-^ERROR: Cannot open file:.*itertools\.json$
+^WARNING: no operational model for module 'itertools'; its names will be unresolved$
+^ERROR: Could not resolve type of receiver in member call '\.itertools\.islice\(\)'\.
+\A(?![\s\S]*Cannot open the AST)[\s\S]*\Z

--- a/regression/python/github_7674/main.py
+++ b/regression/python/github_7674/main.py
@@ -2,9 +2,11 @@ import sys
 
 
 def main() -> None:
-    assert sys.float_info.max > 0.0
-    assert sys.float_info.epsilon > 0.0
+    assert sys.float_info.max == 1.7976931348623157e+308
+    assert sys.float_info.min == 2.2250738585072014e-308
+    assert sys.float_info.epsilon == 2.220446049250313e-16
     assert sys.float_info.mant_dig == 53
+    assert sys.float_info.radix == 2
 
 
 main()

--- a/regression/python/github_7674/main.py
+++ b/regression/python/github_7674/main.py
@@ -1,0 +1,10 @@
+import sys
+
+
+def main() -> None:
+    assert sys.float_info.max > 0.0
+    assert sys.float_info.epsilon > 0.0
+    assert sys.float_info.mant_dig == 53
+
+
+main()

--- a/regression/python/github_7674/test.desc
+++ b/regression/python/github_7674/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$
+\A(?![\s\S]*module-file-not-found)[\s\S]*\Z

--- a/regression/python/github_7674_fail/main.py
+++ b/regression/python/github_7674_fail/main.py
@@ -1,0 +1,8 @@
+import sys
+
+
+def main() -> None:
+    assert sys.float_info.max < 0.0
+
+
+main()

--- a/regression/python/github_7674_fail/test.desc
+++ b/regression/python/github_7674_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^\s*FAILED\s+\[main\.assertion\.1\].*assertion float_info->max < 0\.000000$
+^VERIFICATION FAILED$

--- a/regression/python/github_7674_local_import/main.py
+++ b/regression/python/github_7674_local_import/main.py
@@ -1,0 +1,10 @@
+def bounded() -> float:
+    import sys
+    return sys.float_info.max
+
+
+def main() -> None:
+    assert bounded() > 0.0
+
+
+main()

--- a/regression/python/github_7674_local_import/test.desc
+++ b/regression/python/github_7674_local_import/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7674_local_import_fail/main.py
+++ b/regression/python/github_7674_local_import_fail/main.py
@@ -1,0 +1,10 @@
+def bounded() -> float:
+    import sys
+    return sys.float_info.max
+
+
+def main() -> None:
+    assert bounded() < 0.0
+
+
+main()

--- a/regression/python/github_7674_local_import_fail/test.desc
+++ b/regression/python/github_7674_local_import_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^\s*FAILED\s+\[main\.assertion\.1\].*assertion return_value\$_bounded\$1 < 0\.000000$
+^VERIFICATION FAILED$

--- a/regression/python/github_7674_maxsize/main.py
+++ b/regression/python/github_7674_maxsize/main.py
@@ -1,0 +1,9 @@
+import sys
+
+
+def main() -> None:
+    assert sys.maxsize == 9223372036854775807
+    assert sys.byteorder == "little"
+
+
+main()

--- a/regression/python/github_7674_maxsize/test.desc
+++ b/regression/python/github_7674_maxsize/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7674_maxsize_fail/main.py
+++ b/regression/python/github_7674_maxsize_fail/main.py
@@ -1,0 +1,8 @@
+import sys
+
+
+def main() -> None:
+    assert sys.maxsize < 0
+
+
+main()

--- a/regression/python/github_7674_maxsize_fail/test.desc
+++ b/regression/python/github_7674_maxsize_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^\s*FAILED\s+\[main\.assertion\.1\].*assertion maxsize < 0$
+^VERIFICATION FAILED$

--- a/regression/python/github_7674_multi_name/main.py
+++ b/regression/python/github_7674_multi_name/main.py
@@ -1,0 +1,8 @@
+import math, json
+
+
+def main() -> None:
+    assert math.pi > 3.0
+
+
+main()

--- a/regression/python/github_7674_multi_name/test.desc
+++ b/regression/python/github_7674_multi_name/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^WARNING: no operational model for module 'json'; its names will be unresolved$
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7674_multi_name_fail/main.py
+++ b/regression/python/github_7674_multi_name_fail/main.py
@@ -1,0 +1,8 @@
+import math, json
+
+
+def main() -> None:
+    assert math.pi < 3.0
+
+
+main()

--- a/regression/python/github_7674_multi_name_fail/test.desc
+++ b/regression/python/github_7674_multi_name_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^\s*FAILED\s+\[main\.assertion\.1\].*assertion pi < 3\.000000$
+^VERIFICATION FAILED$

--- a/regression/python/github_7674_try_import/main.py
+++ b/regression/python/github_7674_try_import/main.py
@@ -1,0 +1,11 @@
+def main() -> None:
+    taken: int = 0
+    try:
+        import json
+        taken = 1
+    except ImportError:
+        taken = 2
+    assert taken == 1
+
+
+main()

--- a/regression/python/github_7674_try_import/test.desc
+++ b/regression/python/github_7674_try_import/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^WARNING: no operational model for module 'json'; its names will be unresolved$
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7674_try_import_fail/main.py
+++ b/regression/python/github_7674_try_import_fail/main.py
@@ -1,0 +1,11 @@
+def main() -> None:
+    taken: int = 0
+    try:
+        import json
+        taken = 1
+    except ImportError:
+        taken = 2
+    assert taken == 2
+
+
+main()

--- a/regression/python/github_7674_try_import_fail/test.desc
+++ b/regression/python/github_7674_try_import_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^\s*FAILED\s+\[main\.assertion\.1\].*assertion taken == 2$
+^VERIFICATION FAILED$

--- a/regression/python/github_7674_unmodelled/main.py
+++ b/regression/python/github_7674_unmodelled/main.py
@@ -1,0 +1,9 @@
+import json
+
+
+def main() -> None:
+    data: str = json.dumps([1, 2])
+    assert len(data) > 0
+
+
+main()

--- a/regression/python/github_7674_unmodelled/test.desc
+++ b/regression/python/github_7674_unmodelled/test.desc
@@ -2,4 +2,5 @@ CORE
 main.py
 
 ^WARNING: no operational model for module 'json'; its names will be unresolved$
+^ERROR: Could not resolve type of receiver in member call '\.json\.dumps\(\)'\.
 \A(?![\s\S]*Cannot open the AST)[\s\S]*\Z

--- a/regression/python/github_7674_unmodelled/test.desc
+++ b/regression/python/github_7674_unmodelled/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^WARNING: no operational model for module 'json'; its names will be unresolved$
+\A(?![\s\S]*Cannot open the AST)[\s\S]*\Z

--- a/regression/python/github_7674_unmodelled_local/main.py
+++ b/regression/python/github_7674_unmodelled_local/main.py
@@ -1,0 +1,10 @@
+def encode() -> str:
+    import json
+    return json.dumps([1, 2])
+
+
+def main() -> None:
+    assert len(encode()) > 0
+
+
+main()

--- a/regression/python/github_7674_unmodelled_local/test.desc
+++ b/regression/python/github_7674_unmodelled_local/test.desc
@@ -2,4 +2,5 @@ CORE
 main.py
 
 ^WARNING: no operational model for module 'json'; its names will be unresolved$
+^ERROR: Could not resolve type of receiver in member call '\.json\.dumps\(\)'\.
 \A(?![\s\S]*Cannot open the AST)[\s\S]*\Z

--- a/regression/python/github_7674_unmodelled_local/test.desc
+++ b/regression/python/github_7674_unmodelled_local/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.py
+
+^WARNING: no operational model for module 'json'; its names will be unresolved$
+\A(?![\s\S]*Cannot open the AST)[\s\S]*\Z

--- a/regression/python/github_7674_unresolved_local_import_fail/main.py
+++ b/regression/python/github_7674_unresolved_local_import_fail/main.py
@@ -1,0 +1,10 @@
+def helper() -> int:
+    import totally_missing_module
+    return 1
+
+
+def main() -> None:
+    assert helper() == 1
+
+
+main()

--- a/regression/python/github_7674_unresolved_local_import_fail/test.desc
+++ b/regression/python/github_7674_unresolved_local_import_fail/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/models/sys.py
+++ b/src/python-frontend/models/sys.py
@@ -1,0 +1,54 @@
+"""Operational model for the sys module.
+
+Data only: the interpreter-state attributes a verification harness reads. The
+standard streams (stdout/stderr/stdin), sys.exit and the frame/trace
+introspection API are not modelled.
+
+Values describe the 64-bit little-endian target ESBMC's C models assume and
+the IEEE-754 binary64 float the frontend maps `float` onto; they match CPython
+on that target. `platform` and `version_info` cannot be derived that way and
+name the target the models assume, not the host interpreter.
+"""
+# The attribute names are the stdlib's API, not names this module chooses.
+# pylint: disable=invalid-name,too-few-public-methods,too-many-instance-attributes
+
+
+class _FloatInfo:
+    """sys.float_info — IEEE-754 binary64 limits."""
+
+    def __init__(self) -> None:
+        self.max: float = 1.7976931348623157e+308
+        self.max_exp: int = 1024
+        self.max_10_exp: int = 308
+        self.min: float = 2.2250738585072014e-308
+        self.min_exp: int = -1021
+        self.min_10_exp: int = -307
+        self.dig: int = 15
+        self.mant_dig: int = 53
+        self.epsilon: float = 2.220446049250313e-16
+        self.radix: int = 2
+        self.rounds: int = 1
+
+
+class _VersionInfo:
+    """sys.version_info — the Python level the frontend accepts."""
+
+    def __init__(self) -> None:
+        self.major: int = 3
+        self.minor: int = 12
+        self.micro: int = 0
+        self.releaselevel: str = "final"
+        self.serial: int = 0
+
+
+float_info: _FloatInfo = _FloatInfo()
+version_info: _VersionInfo = _VersionInfo()
+
+maxsize: int = 9223372036854775807
+maxunicode: int = 1114111
+byteorder: str = "little"
+platform: str = "linux"
+
+# No command line reaches the program under verification, so argv holds the
+# script name alone, as `python3 main.py` does.
+argv: list[str] = [""]

--- a/src/python-frontend/models/sys.py
+++ b/src/python-frontend/models/sys.py
@@ -6,8 +6,13 @@ introspection API are not modelled.
 
 Values describe the 64-bit little-endian target ESBMC's C models assume and
 the IEEE-754 binary64 float the frontend maps `float` onto; they match CPython
-on that target. `platform` and `version_info` cannot be derived that way and
-name the target the models assume, not the host interpreter.
+on that target. `platform` names the target the models assume, not the host
+interpreter.
+
+`version_info` is deliberately absent: the frontend does not dispatch
+`__getitem__`, so the usual `sys.version_info[0]` would report a spurious
+IndexError. An attribute-only stand-in that turns the common form into a false
+alarm is worse than no attribute at all.
 """
 # The attribute names are the stdlib's API, not names this module chooses.
 # pylint: disable=invalid-name,too-few-public-methods,too-many-instance-attributes
@@ -30,19 +35,7 @@ class _FloatInfo:
         self.rounds: int = 1
 
 
-class _VersionInfo:
-    """sys.version_info — the Python level the frontend accepts."""
-
-    def __init__(self) -> None:
-        self.major: int = 3
-        self.minor: int = 12
-        self.micro: int = 0
-        self.releaselevel: str = "final"
-        self.serial: int = 0
-
-
 float_info: _FloatInfo = _FloatInfo()
-version_info: _VersionInfo = _VersionInfo()
 
 maxsize: int = 9223372036854775807
 maxunicode: int = 1114111

--- a/src/python-frontend/parser/import_resolver.py
+++ b/src/python-frontend/parser/import_resolver.py
@@ -282,6 +282,11 @@ def process_imports(node: ast.Import | ast.ImportFrom, output_dir: str) -> None:
     if not module_names:
         return
 
+    # `import_module_name` in python_converter.cpp resolves an `import a, b`
+    # node to its first name alone, so only that name decides whether the node
+    # is convertible; flagging it for `b` would drop `a` too.
+    converter_target = module_names[0]
+
     for module_name in module_names:
         if module_name not in module_imports:
             module_imports[module_name] = {'import_all': False, 'specific_names': set()}
@@ -299,17 +304,14 @@ def process_imports(node: ast.Import | ast.ImportFrom, output_dir: str) -> None:
             continue
         filename = _module_filename(module)
         if filename is None:
-            # The module imports under CPython but has no AST to emit: a
-            # builtin (`sys`), or a stdlib file `_is_standard_library_file`
-            # filters out (`json`). Without a model to stand in for it, the
-            # converter must skip the import rather than look for an AST that
-            # was never written (#7674). This is deliberately *not*
-            # `module_not_found`: that flag makes `except ImportError` the
-            # statically-selected branch, which would be wrong for a module
-            # CPython imports fine.
+            # The module imports under CPython but has no AST to emit, and no
+            # model stands in for it, so there is nothing to convert (#7674).
+            # Not `module_not_found`: that flag statically selects an
+            # `except ImportError` branch, wrong for an importable module.
             if not _has_model_file(module_name, output_dir):
-                node.module_unmodelled = True
                 _warn_unmodelled_module(module_name)
+                if module_name == converter_target:
+                    node.module_unmodelled = True
             continue
         _mark_import_resolution(node, ok=True, full_path=filename)
 

--- a/src/python-frontend/parser/import_resolver.py
+++ b/src/python-frontend/parser/import_resolver.py
@@ -116,7 +116,7 @@ def _warn_unmodelled_module(module_name: str) -> None:
 
 
 def _warn_module_file_not_found(module_name: str) -> None:
-    """Report a module with no emit-able AST, unless already reported."""
+    """Warn unless `_warn_unmodelled_module` already named this module."""
     if module_name in _reported_unmodelled:
         return
     _resolver_warning(f"{module_name} module-file-not-found")
@@ -310,10 +310,9 @@ def process_imports(node: ast.Import | ast.ImportFrom, output_dir: str) -> None:
             continue
         filename = _module_filename(module)
         if filename is None:
-            # The module imports under CPython but has no AST to emit, and no
-            # model stands in for it, so there is nothing to convert (#7674).
-            # Not `module_not_found`: that flag statically selects an
-            # `except ImportError` branch, wrong for an importable module.
+            # Importable under CPython, no AST to emit, no model standing in
+            # for it: nothing to convert (#7674). Not `module_not_found` --
+            # that flag statically selects an `except ImportError` branch.
             if not _has_model_file(module_name, output_dir):
                 _warn_unmodelled_module(module_name)
                 if module_name == converter_target:

--- a/src/python-frontend/parser/import_resolver.py
+++ b/src/python-frontend/parser/import_resolver.py
@@ -95,7 +95,13 @@ def _mark_import_resolution(
 
 
 def _has_model_file(module_name: str, output_dir: str) -> bool:
-    base = os.path.join(output_dir, "models", _base_module_name(module_name))
+    """Whether a model stands in for this exact module.
+
+    The dotted name matters: `_emit_model_jsons` emits one JSON per
+    `models/*.py`, so a model for `string` says nothing about
+    `string.templatelib`, which the converter would then look for in vain.
+    """
+    base = os.path.join(output_dir, "models", *module_name.split("."))
     return os.path.exists(base + ".py") or os.path.exists(
         os.path.join(base, "__init__.py"))
 

--- a/src/python-frontend/parser/import_resolver.py
+++ b/src/python-frontend/parser/import_resolver.py
@@ -42,6 +42,7 @@ module_imports: dict[str, ModuleImportInfo] = {}
 module_exports: dict[str, tuple[set[str], dict[str, str], set[str] | None]] = {}
 _reported_cycles: set[tuple[str, ...]] = set()
 _reported_resolution_failures: set[tuple[str, str, str]] = set()
+_reported_unmodelled: set[str] = set()
 
 
 @dataclass(frozen=True)
@@ -61,6 +62,7 @@ def reset_state() -> None:
     module_exports.clear()
     _reported_cycles.clear()
     _reported_resolution_failures.clear()
+    _reported_unmodelled.clear()
     imported_signature_sources.clear()
     default_helper_exports.clear()
 
@@ -92,6 +94,28 @@ def _mark_import_resolution(
     node.module_resolution_reason = reason
 
 
+def _has_model_file(module_name: str, output_dir: str) -> bool:
+    base = os.path.join(output_dir, "models", _base_module_name(module_name))
+    return os.path.exists(base + ".py") or os.path.exists(
+        os.path.join(base, "__init__.py"))
+
+
+def _warn_unmodelled_module(module_name: str) -> None:
+    if module_name in _reported_unmodelled:
+        return
+    _reported_unmodelled.add(module_name)
+    _resolver_warning(
+        f"no operational model for module '{module_name}'; "
+        "its names will be unresolved")
+
+
+def _warn_module_file_not_found(module_name: str) -> None:
+    """Report a module with no emit-able AST, unless already reported."""
+    if module_name in _reported_unmodelled:
+        return
+    _resolver_warning(f"{module_name} module-file-not-found")
+
+
 def _warn_resolution_failure(module_name: str, node: ast.AST, reason: str) -> None:
     location = _node_location(node)
     key = (module_name, reason, location)
@@ -118,6 +142,7 @@ def _is_imported_model(module_name: str) -> bool:
         "queue",
         "torch",
         "unittest",
+        "sys",
     }
     return module_name in models
 
@@ -274,9 +299,17 @@ def process_imports(node: ast.Import | ast.ImportFrom, output_dir: str) -> None:
             continue
         filename = _module_filename(module)
         if filename is None:
-            # Keep historical behavior: modules without an emit-able file
-            # (e.g., standard library/builtins) are skipped, not treated as
-            # missing imports.
+            # The module imports under CPython but has no AST to emit: a
+            # builtin (`sys`), or a stdlib file `_is_standard_library_file`
+            # filters out (`json`). Without a model to stand in for it, the
+            # converter must skip the import rather than look for an AST that
+            # was never written (#7674). This is deliberately *not*
+            # `module_not_found`: that flag makes `except ImportError` the
+            # statically-selected branch, which would be wrong for a module
+            # CPython imports fine.
+            if not _has_model_file(module_name, output_dir):
+                node.module_unmodelled = True
+                _warn_unmodelled_module(module_name)
             continue
         _mark_import_resolution(node, ok=True, full_path=filename)
 
@@ -423,7 +456,7 @@ def process_collected_imports(output_dir: str, callbacks: ResolverCallbacks) -> 
             visited.add(module_name)
             filename = resolve_module_file(module_name, output_dir)
             if not filename:
-                _resolver_warning(f"{module_name} module-file-not-found")
+                _warn_module_file_not_found(module_name)
                 continue
             try:
                 tree, preprocessor = callbacks.parse_file_canonicalised(filename)
@@ -588,7 +621,7 @@ def emit_module_json(
     """Parse and emit JSON for one module resolved by qualified name."""
     filename = resolve_module_file(module_qualname, output_dir)
     if not filename:
-        _resolver_warning(f"{module_qualname} module-file-not-found")
+        _warn_module_file_not_found(module_qualname)
         return
     try:
         tree, _preprocessor = parse_file_canonicalised_fn(filename)

--- a/src/python-frontend/parser/import_resolver.py
+++ b/src/python-frontend/parser/import_resolver.py
@@ -102,17 +102,15 @@ def _has_model_file(module_name: str, output_dir: str) -> bool:
     `string.templatelib`, which the converter would then look for in vain.
     """
     base = os.path.join(output_dir, "models", *module_name.split("."))
-    return os.path.exists(base + ".py") or os.path.exists(
-        os.path.join(base, "__init__.py"))
+    return os.path.exists(base + ".py") or os.path.exists(os.path.join(base, "__init__.py"))
 
 
 def _warn_unmodelled_module(module_name: str) -> None:
     if module_name in _reported_unmodelled:
         return
     _reported_unmodelled.add(module_name)
-    _resolver_warning(
-        f"no operational model for module '{module_name}'; "
-        "its names will be unresolved")
+    _resolver_warning(f"no operational model for module '{module_name}'; "
+                      "its names will be unresolved")
 
 
 def _warn_module_file_not_found(module_name: str) -> None:

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -428,10 +428,8 @@ void python_converter::convert_module_imports(code_blockt &all_imports_block)
       return;
     }
 
-    // The module imports under CPython but has neither an emit-able source
-    // file nor an operational model, so there is no AST to convert. Skip it
-    // and let each use of its names fail at its own site, as an unresolvable
-    // import does; the parser has already named it (#7674).
+    // No AST was emitted for this module; its names fail at their use sites
+    // instead, as an unresolvable import's do (#7674).
     if (node.value("module_unmodelled", false))
       return;
 

--- a/src/python-frontend/python_converter.cpp
+++ b/src/python-frontend/python_converter.cpp
@@ -361,7 +361,9 @@ void python_converter::pre_collect_module_asts(
   auto try_collect = [&](const nlohmann::json &node) {
     if (node["_type"] != "ImportFrom" && node["_type"] != "Import")
       return;
-    if (node.value("module_not_found", false))
+    if (
+      node.value("module_not_found", false) ||
+      node.value("module_unmodelled", false))
       return;
     const std::string module_name = import_module_name(node);
     if (module_ast_pool_.count(module_name))
@@ -417,32 +419,43 @@ void python_converter::convert_module_imports(code_blockt &all_imports_block)
     modules.push_back({&entry.second, &entry.second, entry.first});
   python_param_annotations::propagate_tuple_list_params(modules);
 
-  for (const auto &elem : (*ast_json)["body"])
-  {
-    if (elem["_type"] == "ImportFrom" || elem["_type"] == "Import")
+  auto convert_import = [&](const nlohmann::json &node) {
+    const std::string module_name = import_module_name(node);
+
+    if (node.value("module_not_found", false))
     {
-      if (elem.value("module_not_found", false))
-      {
-        const std::string module_name = import_module_name(elem);
-        log_warning("skipping unresolvable import: {}", module_name);
-        continue;
-      }
-      is_importing_module = true;
-      if (!import_module_into_block(elem, locator, all_imports_block))
-      {
-        const std::string module_name = import_module_name(elem);
-        // Relative import with no module name (`from . import X`): there is no
-        // module file to open. Treat it as unresolved and continue (#6281).
-        if (module_name.empty())
-        {
-          log_warning("skipping relative import with no module name");
-          continue;
-        }
-        throw std::runtime_error(
-          "Cannot open file: " + locator.module_path(module_name));
-      }
+      log_warning("skipping unresolvable import: {}", module_name);
+      return;
     }
-  }
+
+    // The module imports under CPython but has neither an emit-able source
+    // file nor an operational model, so there is no AST to convert. Skip it
+    // and let each use of its names fail at its own site, as an unresolvable
+    // import does; the parser has already named it (#7674).
+    if (node.value("module_unmodelled", false))
+      return;
+
+    is_importing_module = true;
+    if (import_module_into_block(node, locator, all_imports_block))
+      return;
+
+    // Relative import with no module name (`from . import X`): there is no
+    // module file to open. Treat it as unresolved and continue (#6281).
+    if (module_name.empty())
+    {
+      log_warning("skipping relative import with no module name");
+      return;
+    }
+
+    throw std::runtime_error(
+      "Cannot open the AST of module '" + module_name + "' imported at line " +
+      std::to_string(node.value("lineno", 0)) + "; expected " +
+      locator.module_path(module_name));
+  };
+
+  for (const auto &elem : (*ast_json)["body"])
+    if (elem["_type"] == "ImportFrom" || elem["_type"] == "Import")
+      convert_import(elem);
 
   // Do the same for imports that appear directly inside functions.
   for (const auto &elem : (*ast_json)["body"])
@@ -453,25 +466,8 @@ void python_converter::convert_module_imports(code_blockt &all_imports_block)
       continue;
 
     for (const auto &stmt : elem["body"])
-    {
-      if (stmt["_type"] != "ImportFrom" && stmt["_type"] != "Import")
-        continue;
-
-      is_importing_module = true;
-      if (!import_module_into_block(stmt, locator, all_imports_block))
-      {
-        const std::string module_name = import_module_name(stmt);
-        // Relative import with no module name (`from . import X`): nothing to
-        // open — treat as unresolved and continue (#6281).
-        if (module_name.empty())
-        {
-          log_warning("skipping relative import with no module name");
-          continue;
-        }
-        throw std::runtime_error(
-          "Cannot open file: " + locator.module_path(module_name));
-      }
-    }
+      if (stmt["_type"] == "ImportFrom" || stmt["_type"] == "Import")
+        convert_import(stmt);
   }
 
   is_importing_module = false;


### PR DESCRIPTION
A module CPython imports but that has no AST to emit -- a builtin like `sys`,
or a stdlib file the resolver filters out like `json` -- was left unmarked, so
the converter looked for an AST nobody wrote and aborted with a raw temp path.
Mark it with `module_unmodelled` and skip it, and add a data-only `sys` model.

The flag is deliberately separate from `module_not_found`, which statically
selects an `except ImportError` branch. A function-scope import of an absent
module now verifies clean instead of aborting, matching module scope;
`github_7674_unresolved_local_import_fail` records that as a KNOWNBUG.

Fixes #7674