### PR TITLE
[python] Reclassify the stale FUTURE on problem1_fail

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -615,11 +615,6 @@ set(_slow_regression_tests
     # the run (see shortest_path_lengths note below; #4927).
     "regression/quixbugs/knapsack"
     "regression/quixbugs/knapsack_fail"
-    # problem1_fail runs the real DP body (nested loops + dp[-1] + max over a
-    # defaultdict-free list). It does not converge under --unwind 9, so it is
-    # marked FUTURE (BMC scalability); the larger inner timeout lets
-    # testing_tool record the FUTURE verdict instead of ctest hard-killing it.
-    "regression/python-intensive/problem1_fail"
     # next_permutation(_fail) used to fast-crash with "Tuple unpacking only
     # supports simple names, not Subscript". With subscript-target unpacking
     # support (#4792) the swap converts and ESBMC reaches the real nested-loop
@@ -769,6 +764,12 @@ set(_very_slow_regression_tests
     # but on the DebugOpt Linux runner it is still mid-symex when the 120s cap
     # fires, so 2x has no guaranteed headroom; give it the 3x budget.
     "regression/python/list-slice-step-reverse"
+    # problem1_fail was FUTURE for scalability (#4932); it converges now, at
+    # ~90s under the harness on a local RelWithDebInfo build. humaneval_62
+    # above is ~70s locally against ~248s with assertions on, and that ratio
+    # puts this past the 2x tier's 240s (#7679). Its VmPeak is ~4.7GiB against
+    # the global 8GiB RLIMIT_AS, which has no per-test override.
+    "regression/python-intensive/problem1_fail"
 )
 
 foreach(_t IN LISTS _slow_regression_tests)

--- a/regression/python-intensive/problem1/main.py
+++ b/regression/python-intensive/problem1/main.py
@@ -1,0 +1,14 @@
+def lengthOfLongestSubsequence(nums: list[int], target: int) -> int:
+    dp = [-1] * (target + 1)
+    dp[0] = 0
+    for a in nums:
+        for i in range(target - a, -1, -1):
+            if dp[i] == -1:
+                continue
+            dp[i + a] = max(dp[i + a], dp[i] + 1)
+    return dp[-1]
+
+
+# The longest subsequence of [1, 2, 3] summing to target 2 is [2], so the
+# correct length is 1.
+assert lengthOfLongestSubsequence([1, 2, 3], 2) == 1

--- a/regression/python-intensive/problem1/test.desc
+++ b/regression/python-intensive/problem1/test.desc
@@ -1,0 +1,5 @@
+THOROUGH
+main.py
+--force-malloc-success --unwind 9
+^VERIFICATION SUCCESSFUL$
+^  PASSED +\[global\.assertion\.\d+\] +line +14 +assertion .* == 1$

--- a/regression/python-intensive/problem1_fail/test.desc
+++ b/regression/python-intensive/problem1_fail/test.desc
@@ -1,4 +1,6 @@
-FUTURE
+THOROUGH
 main.py
 --force-malloc-success --unwind 9
 ^VERIFICATION FAILED$
+^  file .*main\.py line 14 column 0
+^  FAILED +\[global\.assertion\.\d+\] +line +14 +assertion .* == 3$


### PR DESCRIPTION
problem1_fail now reaches its pinned VERIFICATION FAILED, so testing_tool.py
exits 77 and the test is red. It moves to THOROUGH on the 3x budget, its
failure is pinned to the intended line-14 assertion, and the missing passing
counterpart is added. Neither runs in the PR leg (`ctest -LE python-intensive`).

Fixes #7679