### PR TITLE
[python] Lower a comprehension the assert rewrite hoists

### DIFF
--- a/regression/python/github_7692/main.py
+++ b/regression/python/github_7692/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    assert [(i, i + 1) for i in range(3)][1] == (1, 2)
+    assert [(i, i + 1) for i in range(3)][-1] == (2, 3)
+
+
+main()

--- a/regression/python/github_7692/test.desc
+++ b/regression/python/github_7692/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7692_fail/main.py
+++ b/regression/python/github_7692_fail/main.py
@@ -1,0 +1,5 @@
+def main() -> None:
+    assert [(i, i + 1) for i in range(3)][1] == (1, 3)
+
+
+main()

--- a/regression/python/github_7692_fail/test.desc
+++ b/regression/python/github_7692_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--unwind 5
+^Violated property:$
+^  file .*main\.py line 2 column \d+ function main$
+^VERIFICATION FAILED$

--- a/src/python-frontend/preprocessor/expression_rewrite_mixin.py
+++ b/src/python-frontend/preprocessor/expression_rewrite_mixin.py
@@ -482,6 +482,15 @@ class ExpressionRewriteMixin:
         tuple_eq_prefix, rewritten = self._apply_assert_eq_rewrites(node)
         if rewritten is not None:
             node.test = rewritten
+            # The rewrite deep-copies part of the test into its prefix, and only
+            # node.test is lowered below, so a comprehension carried into the
+            # prefix would reach the converter raw (#7692).
+            hoisted = []
+            for stmt in tuple_eq_prefix:
+                comp_prefix, stmt.value, _ = self._lower_listcomp_in_expr(stmt.value)
+                hoisted.extend(comp_prefix)
+                hoisted.append(stmt)
+            tuple_eq_prefix = hoisted
         eq_prefix, maybe_eq_test = self._lower_assert_eq_literal(node.test, node)
         node.test = maybe_eq_test
         node.test = self._simplify_isinstance(node.test)


### PR DESCRIPTION
`assert <listcomp>[i] == (..)` is unpacked through a prefix assignment that deep-copies the subscripted expression, and only the assert's own test is lowered afterwards — so the comprehension reached the converter as a raw `ListComp` ("Unsupported expression ListComp"). Lower each hoisted statement's value as it is built.

`regression/python/github_7692{,_fail}` pin it; both fail without the patch. Over the 6619 `main.py` files under `regression/`, the patch changes the preprocessor's output for those two tests and for nothing else.

Fixes #7692