### PR TITLE
[python] Copy an array tuple element out element by element

### DIFF
--- a/regression/python/github_7693/main.py
+++ b/regression/python/github_7693/main.py
@@ -1,0 +1,15 @@
+def main() -> None:
+    a = [(1, "x"), (2, "y")]
+    assert a[0] == (1, "x")
+
+    b = [("x", 1), ("y", 2)]
+    assert b[1] == ("y", 2)
+
+    c = [("ab", "cd"), ("ef", "gh")]
+    assert c[0] == ("ab", "cd")
+
+    p, q = a[1]
+    assert p == 2 and q == "y"
+
+
+main()

--- a/regression/python/github_7693/test.desc
+++ b/regression/python/github_7693/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--unwind 5
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7693_fail/main.py
+++ b/regression/python/github_7693_fail/main.py
@@ -1,0 +1,8 @@
+def main() -> None:
+    a = [(1, "abc"), (2, "def")]
+    # Differs from a[0] only in the last byte: the element read has to carry
+    # the whole string buffer, not just its first character.
+    assert a[0] == (1, "abd")
+
+
+main()

--- a/regression/python/github_7693_fail/test.desc
+++ b/regression/python/github_7693_fail/test.desc
@@ -1,0 +1,6 @@
+CORE
+main.py
+--unwind 5
+^Violated property:$
+^  file .*main\.py line 5 column \d+ function main$
+^VERIFICATION FAILED$

--- a/src/python-frontend/tuple/tuple_handler.cpp
+++ b/src/python-frontend/tuple/tuple_handler.cpp
@@ -612,8 +612,8 @@ void tuple_handler::handle_tuple_unpacking(
       member_type.is_array() && to_array_type(member_type).size().is_constant())
     {
       const array_typet &arr_t = to_array_type(member_type);
-      const BigInt n = binary2integer(
-        to_constant_expr(arr_t.size()).value().c_str(), false);
+      const BigInt n =
+        binary2integer(to_constant_expr(arr_t.size()).value().c_str(), false);
       for (BigInt k = 0; k < n; k = k + 1)
       {
         const exprt idx = from_integer(k, index_type());

--- a/src/python-frontend/tuple/tuple_handler.cpp
+++ b/src/python-frontend/tuple/tuple_handler.cpp
@@ -599,12 +599,36 @@ void tuple_handler::handle_tuple_unpacking(
 
     // Create member access: temp.element_i
     std::string member_name = "element_" + std::to_string(i);
-    exprt member_access =
-      build_member(rhs, member_name, tuple_type.components()[i].type());
+    const typet &member_type = tuple_type.components()[i].type();
+    exprt member_access = build_member(rhs, member_name, member_type);
+    const locationt loc = converter_.get_location_from_decl(ast_node);
+    const exprt target = build_symbol(*var_symbol);
+
+    // A tuple held in a list is reached through a dereference, and the
+    // dereference layer refuses to build a whole-array rvalue, as C does. A
+    // string element is such an array, so copy it element by element; its size
+    // is static, so the two are the same assignment (#7693).
+    if (
+      member_type.is_array() && to_array_type(member_type).size().is_constant())
+    {
+      const array_typet &arr_t = to_array_type(member_type);
+      const BigInt n = binary2integer(
+        to_constant_expr(arr_t.size()).value().c_str(), false);
+      for (BigInt k = 0; k < n; k = k + 1)
+      {
+        const exprt idx = from_integer(k, index_type());
+        code_assignt store(
+          build_index(target, idx, arr_t.subtype()),
+          build_index(member_access, idx, arr_t.subtype()));
+        store.location() = loc;
+        target_block.copy_to_operands(store);
+      }
+      continue;
+    }
 
     // Create assignment
-    code_assignt assign(build_symbol(*var_symbol), member_access);
-    assign.location() = converter_.get_location_from_decl(ast_node);
+    code_assignt assign(target, member_access);
+    assign.location() = loc;
     target_block.copy_to_operands(assign);
   }
 }


### PR DESCRIPTION
Unpacking a tuple assigned each element whole. A tuple held in a list is reached through a dereference, where the memory model refuses to build an rvalue of array type ("Can't construct rvalue reference to array type"), so a string element aborted esbmc during symex — `[(1, "x"), (2, "y")][0] == (1, "x")` did not produce a verdict at all. Store a fixed-size element index by index instead, as the ctor boxing path in `converter_stmt.cpp` already does for the same reason. The size is static, so it is the same assignment.

`regression/python/github_7693{,_fail}` pin it; both fail without the patch. The `_fail` case differs from the value read only in the string's last byte, so it also pins that the whole buffer is carried, not just its first character.

Fixes #7693