### PR TITLE
[irep2] Port the derived-to-base and string-to-array typecast arms

### DIFF
--- a/src/util/lang/c_typecast.cpp
+++ b/src/util/lang/c_typecast.cpp
@@ -763,6 +763,34 @@ void c_typecastt::implicit_typecast_followed(
     do_typecast(expr, dest_type);
 }
 
+// The generous pointer rules, as one decision: the warning this conversion
+// earns, or nullptr when it earns none.
+static const char *incompatible_pointer_warning(
+  const namespacet &ns,
+  const type2tc &src_subtype,
+  const type2tc &dest_subtype)
+{
+  const type2tc &src_sub = ns.follow(src_subtype);
+  const type2tc &dest_sub = ns.follow(dest_subtype);
+
+  // from/to void is always good
+  if (is_empty_type(src_sub) || is_empty_type(dest_sub))
+    return nullptr;
+
+  if (base_type_eq(dest_subtype, src_subtype, ns))
+    return nullptr;
+
+  // very generous: between any two function pointers it's ok
+  if (is_code_type(src_sub) && is_code_type(dest_sub))
+    return nullptr;
+
+  // also generous: between any two scalar types it's ok
+  if (is_bv_type(src_sub) && is_bv_type(dest_sub))
+    return nullptr;
+
+  return "incompatible pointer types";
+}
+
 void c_typecastt::implicit_typecast_followed(
   expr2tc &expr,
   const type2tc &src_type,
@@ -790,27 +818,10 @@ void c_typecastt::implicit_typecast_followed(
       else
         src_subtype = to_array_type(src_type).subtype;
 
-      const type2tc &src_sub = ns.follow(src_subtype);
-      const type2tc &dest_sub = ns.follow(dest_ptr_type.subtype);
-
-      if (is_empty_type(src_sub) || is_empty_type(dest_sub))
-      {
-        // from/to void is always good
-      }
-      else if (base_type_eq(dest_ptr_type.subtype, src_subtype, ns))
-      {
-      }
-      else if (is_code_type(src_sub) && is_code_type(dest_sub))
-      {
-        // very generous:
-        // between any two function pointers it's ok
-      }
-      else if (is_bv_type(src_sub) && is_bv_type(dest_sub))
-      {
-        // also generous: between any to scalar types it's ok
-      }
-      else
-        warnings.push_back("incompatible pointer types");
+      const char *warning =
+        incompatible_pointer_warning(ns, src_subtype, dest_ptr_type.subtype);
+      if (warning)
+        warnings.push_back(warning);
 
       if (src_type == dest_type)
       {

--- a/src/util/lang/c_typecast.cpp
+++ b/src/util/lang/c_typecast.cpp
@@ -823,6 +823,23 @@ void c_typecastt::implicit_typecast_followed(
 
       return; // ok
     }
+
+    if (is_struct_type(src_type) || is_union_type(src_type))
+    {
+      // Derived object to base-class pointer: `derived_obj` becomes
+      // `&derived_obj` typed as the base pointer, reached when a base method
+      // is called on a derived object. address_of2t takes the *pointee*, so
+      // the destination's subtype is what reproduces dest_type.
+      expr = address_of2tc(dest_ptr_type.subtype, expr);
+    }
+  }
+  else if (is_array_type(dest_type) && is_constant_string2t(expr))
+  {
+    // string2array in the irept copy: the constant becomes the array of its
+    // characters, at the destination's type rather than its own.
+    const expr2tc retyped = expr->with_type(dest_type);
+    expr = to_constant_string2t(retyped).to_array();
+    return;
   }
 
   if (check_c_implicit_typecast(src_type, dest_type))

--- a/unit/util/c_typecast.test.cpp
+++ b/unit/util/c_typecast.test.cpp
@@ -22,6 +22,7 @@
 #include <util/symtab/namespace.h>
 #include <util/irep/migrate.h>
 #include <util/irep/std_expr.h>
+#include <util/expr/string_constant.h>
 #include <util/arith/arith_tools.h>
 #include <irep2/irep2_utils.h>
 
@@ -712,5 +713,47 @@ TEST_CASE(
   SECTION("fixedbv symbol converts to int")
   {
     require_overloads_agree(ns, symbol_exprt("f", float_type()), int_type());
+  }
+}
+
+// The C++-shaped arms of implicit_typecast_followed
+// (docs/roadmap/scope-clang-cpp-irep2.md §2). These are Phase 7 pre-flight:
+// the irept copy has them and the expr2tc copy does not, so each section here
+// fails until the corresponding arm is ported.
+TEST_CASE(
+  "both implicit_typecast_followed copies agree on the C++ arms",
+  "[c_typecast]")
+{
+  contextt ctx;
+  namespacet ns(ctx);
+
+  struct_typet base;
+  base.tag("Base");
+  struct_union_typet::componentt field;
+  field.set_name("x");
+  field.pretty_name("x");
+  field.type() = int_type();
+  base.components().push_back(field);
+
+  SECTION("a struct source to a pointer destination takes its address")
+  {
+    require_overloads_agree(ns, symbol_exprt("obj", base), pointer_typet(base));
+  }
+
+  SECTION("a union source to a pointer destination takes its address")
+  {
+    union_typet u;
+    u.tag("U");
+    u.components().push_back(field);
+    require_overloads_agree(ns, symbol_exprt("obj", u), pointer_typet(u));
+  }
+
+  SECTION("a string constant to an array destination becomes an array")
+  {
+    const typet char_array =
+      array_typet(char_type(), from_integer(3, size_type()));
+    string_constantt str("ab");
+    str.type() = char_array;
+    require_overloads_agree(ns, str, char_array);
   }
 }

--- a/unit/util/c_typecast.test.cpp
+++ b/unit/util/c_typecast.test.cpp
@@ -96,10 +96,12 @@ static void require_arith_result(
 // get_c_type ranks an operand against config.ansi_c, which is zero-initialised
 // bar int_128_width. Pin a model in main() rather than at namespace scope:
 // `config` lives in another translation unit, so a static initialiser here
-// would race its constructor.
+// would race its constructor. set_data_model leaves the byte order alone, and
+// constant_string2t::to_array asserts on NO_ENDIANESS.
 int main(int argc, char *argv[])
 {
   config.ansi_c.set_data_model(configt::LP64);
+  config.ansi_c.endianess = configt::ansi_ct::IS_LITTLE_ENDIAN;
   return Catch::Session().run(argc, argv);
 }
 


### PR DESCRIPTION
`c_typecastt::implicit_typecast_followed` exists twice in
`src/util/lang/c_typecast.cpp` — an irept copy and an expr2tc one, written
independently — and the IREP2 copy lacks seven arms the irept one has
(`docs/roadmap/scope-coupled-arith-assign-conversion.md` §20.1). This ports the
two that are representable today, as Phase 7 pre-flight:

- **Derived object to base-class pointer.** `address_of2t`'s constructor takes
  the *pointee* and builds the pointer itself, so the arm passes
  `dest_ptr_type.subtype` where the irept copy assigns `dest_type` whole.
- **String constant to array.** `migrate_expr` maps a `string-constant` to
  `constant_string2t`, not to an array, so the arm was genuinely missing rather
  than performed by migration; `constant_string2t::to_array()` is the
  counterpart of `string2array`.

**No end-to-end regression pair is possible here, so this PR does not add one.**
The IREP2 copy is reached only under `--clang-c-irep2-adjust[-only]`, and a
`--goto-functions-only` A/B of every `regression/esbmc/irep2_only_*` test
against master is **95 same, 0 differing** — goto-convert already normalises the
one shape the string arm changes. What pins the change is the unit test
`unit/util/c_typecast.test.cpp` ("both implicit_typecast_followed copies agree
on the C++ arms"): three sections over the struct, union and string-constant
sources, each of which fails when its own arm is removed and passes when it is
restored, with the other arm left in place.

Note the sections pin *parity*, not *admission* — `require_overloads_agree` only
requires the two copies to agree, so they would not notice both rejecting a
conversion.

Pointer-to-member (§20.1 item 2) is deliberately not ported: instrumenting the
arms over a stride-10 `regression/esbmc-cpp` sample fires it in 0 of 283 tests.
Items 1 and 5 need `pointer_type2t` to carry a reference kind and are recorded
in `docs/roadmap/scope-clang-cpp-irep2.md` §2.1.

Refs #4715
