### PR TITLE
[clang-c-frontend] Report an unmodelled initializer list, do not abort

### DIFF
--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2076,6 +2076,28 @@ bool clang_c_convertert::get_base_flattened_inits(
   return false;
 }
 
+/// Report an initializer list none of get_expr's arms models. Reported and not
+/// asserted: an assertion aborts the process, leaving the user without a
+/// diagnostic, a source location or a verdict (#7643).
+bool clang_c_convertert::report_unsupported_init_list(
+  const clang::InitListExpr &init_stmt)
+{
+  locationt location;
+  get_start_location_from_stmt(init_stmt, location);
+
+  std::ostringstream oss;
+  llvm::raw_os_ostream ross(oss);
+  enable_ast_dump_colors(ross, *ASTContext);
+  ross << "Conversion of unsupported initializer list of type \""
+       << init_stmt.getType().getAsString() << "\" with "
+       << init_stmt.getNumInits() << " initializer(s) at "
+       << location.as_string() << "\n";
+  init_stmt.dump(ross, *ASTContext);
+  ross.flush();
+  log_error("{}", oss.str());
+  return true;
+}
+
 bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
 {
   locationt location;
@@ -2855,8 +2877,7 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
             init_union_field->getName().str());
       }
     }
-    else if (
-      init_stmt.getNumInits() == 0 && init_stmt.getType()->isScalarType())
+    else if (init_stmt.getNumInits() == 0)
     {
       /* We have a list initializer with no elements.
        * So per https://en.cppreference.com/w/cpp/language/list_initialization
@@ -2867,15 +2888,22 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
        * > ...
        * > - Otherwise, the object is zero-initialized.
        * So we just zero-initialize the object.
+       * The rule is the type's, not the scalar types' alone; gen_zero answers
+       * nil for a type it cannot build a value of (an incomplete struct, as
+       * `std::hash<std::thread::id>` stays in #7643), which is reported below
+       * rather than propagated as a nil expression.
        */
       inits = gen_zero(t);
+      if (inits.is_nil())
+        return report_unsupported_init_list(init_stmt);
     }
-    else
+    else if (init_stmt.getNumInits() == 1)
     {
-      assert(init_stmt.getNumInits() == 1);
       if (get_expr(*init_stmt.getInit(0), inits))
         return true;
     }
+    else
+      return report_unsupported_init_list(init_stmt);
 
     new_expr = inits;
     break;

--- a/src/clang-c-frontend/clang_c_convert.cpp
+++ b/src/clang-c-frontend/clang_c_convert.cpp
@@ -2888,11 +2888,10 @@ bool clang_c_convertert::get_expr(const clang::Stmt &stmt, exprt &new_expr)
        * > ...
        * > - Otherwise, the object is zero-initialized.
        * So we just zero-initialize the object.
-       * The rule is the type's, not the scalar types' alone; gen_zero answers
-       * nil for a type it cannot build a value of (an incomplete struct, as
-       * `std::hash<std::thread::id>` stays in #7643), which is reported below
-       * rather than propagated as a nil expression.
        */
+      /* The rule is the type's, not the scalar types' alone, but gen_zero
+       * answers nil for a type it cannot build a value of (an incomplete
+       * struct, as `std::hash<std::thread::id>` stays in #7643). */
       inits = gen_zero(t);
       if (inits.is_nil())
         return report_unsupported_init_list(init_stmt);

--- a/src/clang-c-frontend/clang_c_convert.h
+++ b/src/clang-c-frontend/clang_c_convert.h
@@ -268,6 +268,10 @@ protected:
   void
   get_start_location_from_stmt(const clang::Stmt &stmt, locationt &location);
 
+  /// Report an initializer list none of get_expr's arms models, with its type
+  /// and source location. Always returns true (conversion failed).
+  bool report_unsupported_init_list(const clang::InitListExpr &init_stmt);
+
   void
   get_final_location_from_stmt(const clang::Stmt &stmt, locationt &location);
 


### PR DESCRIPTION
An `InitListExpr` none of `get_expr`'s arms models reached a bare `assert(init_stmt.getNumInits() == 1)`, which aborts the process: no diagnostic, no source location, no verdict — the Impact section of #7643. Report the list's type, arity, location and AST instead, and let an empty list value-initialize whatever the type per [dcl.init.list]/3.5 rather than the scalar types alone; `gen_zero` answers nil for a type it cannot build a value of, which is now reported rather than propagated as a nil expression.

On the issue's reproducer this names the input #7643 says is not yet established:

```
ERROR: Conversion of unsupported initializer list of type "std::hash<std::thread::id>" with 0 initializer(s)
  at file src/irep2/irep2.h line 514 column 40 function current_thread_tag
```

That is `std::hash<std::thread::id>{}(std::this_thread::get_id())` — an empty class, value-initialized, whose record ESBMC converts to `incomplete_struct`. **The header still does not convert**: the remaining defect is that the same line converts when `irep2/irep2.h` is included directly and does not when it is reached through `irep2/irep2_type.h`, so the record is left incomplete depending on include context. This PR fixes the abort and names the culprit; it does not fix that asymmetry.

**No regression test, deliberately.** Reaching either changed arm needs a type clang considers complete but ESBMC converts to `incomplete_struct`, which is the upstream defect itself. Shapes tried that do not reproduce: an empty class, an empty class template, `std::hash<int>` and `std::hash<std::thread::id>` both as a variable and as a value-initialized temporary, a lambda closure type, `_Complex` with `{}`, and excess-element scalar and union initializers (clang normalizes those away). The only reproducer is the full `irep2_type.h` translation unit, which needs the source tree, immer and specific `-I` flags, so it does not port to a `test.desc`. The added lines are therefore a diagnostic-only path with no covering test.

The 263 regression tests under `regression/{esbmc,esbmc-unix,esbmc-cpp/cpp}` whose sources contain a brace initializer pass, except `esbmc-unix/github_6831_smt_during_symex_crash`, which fails identically on a control binary built without this patch.