### PR TITLE
[python] Fix storing a tagged scalar in a list

### DIFF
--- a/regression/python/dynamic_type_scalar_tag_list_append/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_append/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = []
+lst.append(x)
+assert lst[0] == 1 or lst[0] == "a"

--- a/regression/python/dynamic_type_scalar_tag_list_append/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_append/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_list_append_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_append_fail/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = []
+lst.append(x)
+assert lst[0] == 1 and lst[0] == "a"

--- a/regression/python/dynamic_type_scalar_tag_list_append_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_append_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_list_float/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_float/main.py
@@ -1,0 +1,12 @@
+# A tag holding a float keeps its type through a list round-trip. Comparing a
+# tag against a float literal is not supported yet, so this pins the type_id.
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+if cond:
+    x = 1.5
+lst = []
+lst.append(x)
+assert isinstance(lst[0], float) or isinstance(lst[0], str)

--- a/regression/python/dynamic_type_scalar_tag_list_float/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_float/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_list_float_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_float_fail/main.py
@@ -3,6 +3,8 @@ if cond:
     x = 1
 else:
     x = "a"
+if cond:
+    x = 1.5
 lst = []
 lst.append(x)
-assert lst[0] == 1
+assert isinstance(lst[0], float)

--- a/regression/python/dynamic_type_scalar_tag_list_float_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_float_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_list_insert/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_insert/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+lst.insert(0, x)
+assert lst[0] == 1 or lst[0] == "a"
+assert lst[1] == 1 or lst[1] == "a"

--- a/regression/python/dynamic_type_scalar_tag_list_insert/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_insert/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_list_insert_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_insert_fail/main.py
@@ -3,6 +3,6 @@ if cond:
     x = 1
 else:
     x = "a"
-lst = []
-lst.append(x)
+lst = [x]
+lst.insert(0, x)
 assert lst[0] == 1

--- a/regression/python/dynamic_type_scalar_tag_list_insert_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_insert_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_list_store/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_store/main.py
@@ -1,0 +1,7 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+assert lst[0] == 1 or lst[0] == "a"

--- a/regression/python/dynamic_type_scalar_tag_list_store/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_store/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_list_store_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_store_fail/main.py
@@ -4,4 +4,4 @@ if cond:
 else:
     x = "a"
 lst = [x]
-assert lst[0] == 1 and lst[0] == "a"
+assert lst[0] == 1

--- a/regression/python/dynamic_type_scalar_tag_list_store_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_store_fail/main.py
@@ -1,0 +1,7 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+assert lst[0] == 1 and lst[0] == "a"

--- a/regression/python/dynamic_type_scalar_tag_list_store_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_store_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -204,17 +204,26 @@ bool __ESBMC_list_push(
   return true;
 }
 
-// Push an already-tagged scalar's own value/type_id/size. `size` may be
-// symbolic across branches (e.g. int vs str), so this copies with a bounded
-// loop rather than __ESBMC_copy_value's memcpy fallback, which never
-// finishes unwinding over a symbolic n.
-bool __ESBMC_list_push_tagged(
-  PyListObject *l,
+// Copy a tagged scalar's payload. `size` may be symbolic across branches (e.g.
+// int vs str), so this uses a bounded loop rather than __ESBMC_copy_value's
+// memcpy fallback, which never finishes unwinding over a symbolic n. A float
+// payload goes through __ESBMC_copy_value instead, so the element keeps this
+// library's invariant that a float's value lives in __ESBMC_float_buf at
+// float_idx -- __ESBMC_list_push_object and __ESBMC_list_push_shallow_sz both
+// read it back that way.
+static void *__ESBMC_copy_tagged_value(
   const void *value,
   size_t type_id,
-  size_t size)
+  size_t size,
+  size_t float_type_id,
+  size_t *out_float_idx)
 {
-  assert(l != NULL);
+  *out_float_idx = 0;
+
+  if (size == 8 && float_type_id != 0 && type_id == float_type_id)
+    return __ESBMC_copy_value(
+      value, size, type_id, float_type_id, out_float_idx, 0);
+
   __ESBMC_assert(
     size <= ESBMC_PY_STRNLEN_BOUND,
     "tagged list element exceeds the modelled bound");
@@ -226,10 +235,26 @@ bool __ESBMC_list_push_tagged(
       break;
     ((char *)copied)[i] = ((const char *)value)[i];
   }
+  return copied;
+}
+
+// Push an already-tagged scalar's own value/type_id/size.
+bool __ESBMC_list_push_tagged(
+  PyListObject *l,
+  const void *value,
+  size_t type_id,
+  size_t size,
+  size_t float_type_id)
+{
+  assert(l != NULL);
+
+  size_t float_idx = 0;
+  void *copied =
+    __ESBMC_copy_tagged_value(value, type_id, size, float_type_id, &float_idx);
 
   PyObject *item = &l->items[l->size];
   item->value = copied;
-  item->float_idx = 0;
+  item->float_idx = float_idx;
   item->type_id = type_id;
   item->size = size;
   l->size++;
@@ -629,15 +654,15 @@ bool __ESBMC_list_insert(
   return true;
 }
 
-// Insert variant of __ESBMC_list_push_tagged: `size` may be symbolic, so this
-// copies with the same bounded loop rather than __ESBMC_copy_value's memcpy
-// fallback.
+// Insert variant of __ESBMC_list_push_tagged. Index normalisation matches
+// __ESBMC_list_insert.
 bool __ESBMC_list_insert_tagged(
   PyListObject *l,
   int64_t index,
   const void *value,
   size_t type_id,
-  size_t size)
+  size_t size,
+  size_t float_type_id)
 {
   int64_t n = (int64_t)l->size;
   if (index < 0)
@@ -648,18 +673,11 @@ bool __ESBMC_list_insert_tagged(
   }
 
   if (index >= n)
-    return __ESBMC_list_push_tagged(l, value, type_id, size);
+    return __ESBMC_list_push_tagged(l, value, type_id, size, float_type_id);
 
-  __ESBMC_assert(
-    size <= ESBMC_PY_STRNLEN_BOUND,
-    "tagged list element exceeds the modelled bound");
-  void *copied = __ESBMC_alloca(size);
-  for (size_t i = 0; i < ESBMC_PY_STRNLEN_BOUND; ++i)
-  {
-    if (i >= size)
-      break;
-    ((char *)copied)[i] = ((const char *)value)[i];
-  }
+  size_t float_idx = 0;
+  void *copied =
+    __ESBMC_copy_tagged_value(value, type_id, size, float_type_id, &float_idx);
 
   size_t i = l->size;
   while (i > (size_t)index)
@@ -669,7 +687,7 @@ bool __ESBMC_list_insert_tagged(
   }
 
   l->items[index].value = copied;
-  l->items[index].float_idx = 0;
+  l->items[index].float_idx = float_idx;
   l->items[index].type_id = type_id;
   l->items[index].size = size;
   l->size++;

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -204,6 +204,38 @@ bool __ESBMC_list_push(
   return true;
 }
 
+// Push an already-tagged scalar's own value/type_id/size. `size` may be
+// symbolic across branches (e.g. int vs str), so this copies with a bounded
+// loop rather than __ESBMC_copy_value's memcpy fallback, which never
+// finishes unwinding over a symbolic n.
+bool __ESBMC_list_push_tagged(
+  PyListObject *l,
+  const void *value,
+  size_t type_id,
+  size_t size)
+{
+  assert(l != NULL);
+  __ESBMC_assert(
+    size <= ESBMC_PY_STRNLEN_BOUND,
+    "tagged list element exceeds the modelled bound");
+
+  void *copied = __ESBMC_alloca(size);
+  for (size_t i = 0; i < ESBMC_PY_STRNLEN_BOUND; ++i)
+  {
+    if (i >= size)
+      break;
+    ((char *)copied)[i] = ((const char *)value)[i];
+  }
+
+  PyObject *item = &l->items[l->size];
+  item->value = copied;
+  item->float_idx = 0;
+  item->type_id = type_id;
+  item->size = size;
+  l->size++;
+  return true;
+}
+
 bool __ESBMC_list_push_object(
   PyListObject *l,
   PyObject *o,
@@ -593,6 +625,53 @@ bool __ESBMC_list_insert(
   l->items[index].float_idx = float_idx;
   l->items[index].type_id = type_id;
   l->items[index].size = type_size;
+  l->size++;
+  return true;
+}
+
+// Insert variant of __ESBMC_list_push_tagged: `size` may be symbolic, so this
+// copies with the same bounded loop rather than __ESBMC_copy_value's memcpy
+// fallback.
+bool __ESBMC_list_insert_tagged(
+  PyListObject *l,
+  int64_t index,
+  const void *value,
+  size_t type_id,
+  size_t size)
+{
+  int64_t n = (int64_t)l->size;
+  if (index < 0)
+  {
+    index += n;
+    if (index < 0)
+      index = 0;
+  }
+
+  if (index >= n)
+    return __ESBMC_list_push_tagged(l, value, type_id, size);
+
+  __ESBMC_assert(
+    size <= ESBMC_PY_STRNLEN_BOUND,
+    "tagged list element exceeds the modelled bound");
+  void *copied = __ESBMC_alloca(size);
+  for (size_t i = 0; i < ESBMC_PY_STRNLEN_BOUND; ++i)
+  {
+    if (i >= size)
+      break;
+    ((char *)copied)[i] = ((const char *)value)[i];
+  }
+
+  size_t i = l->size;
+  while (i > (size_t)index)
+  {
+    l->items[i] = l->items[i - 1];
+    i--;
+  }
+
+  l->items[index].value = copied;
+  l->items[index].float_idx = 0;
+  l->items[index].type_id = type_id;
+  l->items[index].size = size;
   l->size++;
   return true;
 }

--- a/src/python-frontend/python-list/list_access.cpp
+++ b/src/python-frontend/python-list/list_access.cpp
@@ -4208,6 +4208,14 @@ exprt python_list::extract_pyobject_value(
     return migrate_expr_back(if2tc(et2, is_float, fv2, iaf2));
   }
 
+  // A tagged-scalar element (a variable that was itself dynamically typed
+  // before being stored) already IS a PyObject header with its own
+  // value/type_id/size -- unlike every other element kind, item->value does
+  // not point at a nested payload to dereference. Read the item directly
+  // instead of treating .value as a pointer to unwrap.
+  if (converter_.get_type_handler().is_tagged_scalar_type(elem_type))
+    return build_dereference(pyobject_expr, elem_type);
+
   // Extract value from PyObject: (*pyobject_expr).value
   exprt obj_value =
     build_deref_member(pyobject_expr, "value", pointer_typet(empty_typet()));

--- a/src/python-frontend/python-list/list_mutation.cpp
+++ b/src/python-frontend/python-list/list_mutation.cpp
@@ -10,6 +10,41 @@ python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
 {
   const type_handler type_handler_ = converter_.get_type_handler();
   locationt location = converter_.get_location_from_decl(op);
+
+  // A tagged (PyObject-shaped) element already carries its own runtime
+  // value/type_id/size -- hashing its wrapper struct's static C type here
+  // would bake in a single compile-time type_id, losing whichever branch
+  // actually ran. Forward its own fields instead, exactly like list
+  // elements already store their type_id alongside the value.
+  if (type_handler_.is_tagged_scalar_type(elem.type()))
+  {
+    symbolt &elem_type_sym = converter_.create_tmp_symbol(
+      op, "$list_elem_type$", size_type(), exprt());
+    code_assignt type_id_assign(
+      build_symbol(elem_type_sym), build_member(elem, "type_id", size_type()));
+    type_id_assign.location() = location;
+    converter_.add_instruction(type_id_assign);
+
+    const typet char_ptr_type = pointer_typet(char_type());
+    symbolt &elem_symbol = converter_.create_tmp_symbol(
+      op, "$list_elem_value$", char_ptr_type, exprt());
+    code_assignt value_assign(
+      build_symbol(elem_symbol),
+      build_typecast(
+        build_member(elem, "value", pointer_typet(empty_typet())),
+        char_ptr_type));
+    value_assign.location() = location;
+    converter_.add_instruction(value_assign);
+
+    list_elem_info tagged_info;
+    tagged_info.elem_type_sym = &elem_type_sym;
+    tagged_info.elem_symbol = &elem_symbol;
+    tagged_info.elem_size = build_member(elem, "size", size_type());
+    tagged_info.location = location;
+    tagged_info.is_tagged_scalar = true;
+    return tagged_info;
+  }
+
   const std::string elem_type_name = type_handler_.type_to_string(elem.type());
 
   // Create type name as null-terminated char array
@@ -266,6 +301,26 @@ exprt python_list::build_push_list_call(
 {
   list_elem_info elem_info = get_list_element_info(op, elem);
 
+  if (elem_info.is_tagged_scalar)
+  {
+    const symbolt *push_tagged_sym =
+      converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_tagged");
+    if (!push_tagged_sym)
+      throw std::runtime_error("Push (tagged) function symbol not found");
+
+    code_function_callt push_tagged_call;
+    push_tagged_call.function() = build_symbol(*push_tagged_sym);
+    push_tagged_call.arguments().push_back(build_symbol(list));
+    push_tagged_call.arguments().push_back(
+      build_symbol(*elem_info.elem_symbol));
+    push_tagged_call.arguments().push_back(
+      build_symbol(*elem_info.elem_type_sym));
+    push_tagged_call.arguments().push_back(elem_info.elem_size);
+    push_tagged_call.type() = bool_type();
+    push_tagged_call.location() = elem_info.location;
+    return push_tagged_call;
+  }
+
   const symbolt *push_func_sym =
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push");
 
@@ -369,6 +424,27 @@ exprt python_list::build_insert_list_call(
   const exprt &elem)
 {
   list_elem_info elem_info = get_list_element_info(op, elem);
+
+  if (elem_info.is_tagged_scalar)
+  {
+    const symbolt *insert_tagged_sym =
+      converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_insert_tagged");
+    if (!insert_tagged_sym)
+      throw std::runtime_error("Insert (tagged) function symbol not found");
+
+    code_function_callt insert_tagged_call;
+    insert_tagged_call.function() = build_symbol(*insert_tagged_sym);
+    insert_tagged_call.arguments().push_back(build_symbol(list));
+    insert_tagged_call.arguments().push_back(index);
+    insert_tagged_call.arguments().push_back(
+      build_symbol(*elem_info.elem_symbol));
+    insert_tagged_call.arguments().push_back(
+      build_symbol(*elem_info.elem_type_sym));
+    insert_tagged_call.arguments().push_back(elem_info.elem_size);
+    insert_tagged_call.type() = bool_type();
+    insert_tagged_call.location() = elem_info.location;
+    return converter_.convert_expression_to_code(insert_tagged_call);
+  }
 
   const symbolt *insert_func_sym =
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_insert");

--- a/src/python-frontend/python-list/list_mutation.cpp
+++ b/src/python-frontend/python-list/list_mutation.cpp
@@ -5,45 +5,58 @@
 using namespace python_expr;
 using namespace python_list_detail;
 
+// A tagged (PyObject-shaped) element already carries its own runtime
+// value/type_id/size -- hashing its wrapper struct's static C type would bake
+// in a single compile-time type_id, losing whichever branch actually ran.
+// Forward its own fields instead, exactly like list elements already store
+// their type_id alongside the value.
+list_elem_info python_list::get_tagged_element_info(
+  const nlohmann::json &op,
+  const exprt &elem)
+{
+  const locationt location = converter_.get_location_from_decl(op);
+
+  symbolt &elem_type_sym =
+    converter_.create_tmp_symbol(op, "$list_elem_type$", size_type(), exprt());
+  code_assignt type_id_assign(
+    build_symbol(elem_type_sym), build_member(elem, "type_id", size_type()));
+  type_id_assign.location() = location;
+  converter_.add_instruction(type_id_assign);
+
+  const typet char_ptr_type = pointer_typet(char_type());
+  symbolt &elem_symbol = converter_.create_tmp_symbol(
+    op, "$list_elem_value$", char_ptr_type, exprt());
+  code_assignt value_assign(
+    build_symbol(elem_symbol),
+    build_typecast(
+      build_member(elem, "value", pointer_typet(empty_typet())),
+      char_ptr_type));
+  value_assign.location() = location;
+  converter_.add_instruction(value_assign);
+
+  list_elem_info tagged_info;
+  tagged_info.elem_type_sym = &elem_type_sym;
+  tagged_info.elem_symbol = &elem_symbol;
+  tagged_info.elem_size = build_member(elem, "size", size_type());
+  tagged_info.location = location;
+  return tagged_info;
+}
+
+// The tag stamps a float payload with the hash of `double`, the same hash the
+// non-tagged push path passes as float_type_id, so the model can route it
+// through __ESBMC_float_buf.
+exprt python_list::tagged_float_type_id(bool enable_float_path) const
+{
+  if (!enable_float_path)
+    return from_integer(BigInt(0), size_type());
+  return converter_.get_type_handler().tagged_scalar_type_id(double_type());
+}
+
 list_elem_info
 python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
 {
   const type_handler type_handler_ = converter_.get_type_handler();
   locationt location = converter_.get_location_from_decl(op);
-
-  // A tagged (PyObject-shaped) element already carries its own runtime
-  // value/type_id/size -- hashing its wrapper struct's static C type here
-  // would bake in a single compile-time type_id, losing whichever branch
-  // actually ran. Forward its own fields instead, exactly like list
-  // elements already store their type_id alongside the value.
-  if (type_handler_.is_tagged_scalar_type(elem.type()))
-  {
-    symbolt &elem_type_sym = converter_.create_tmp_symbol(
-      op, "$list_elem_type$", size_type(), exprt());
-    code_assignt type_id_assign(
-      build_symbol(elem_type_sym), build_member(elem, "type_id", size_type()));
-    type_id_assign.location() = location;
-    converter_.add_instruction(type_id_assign);
-
-    const typet char_ptr_type = pointer_typet(char_type());
-    symbolt &elem_symbol = converter_.create_tmp_symbol(
-      op, "$list_elem_value$", char_ptr_type, exprt());
-    code_assignt value_assign(
-      build_symbol(elem_symbol),
-      build_typecast(
-        build_member(elem, "value", pointer_typet(empty_typet())),
-        char_ptr_type));
-    value_assign.location() = location;
-    converter_.add_instruction(value_assign);
-
-    list_elem_info tagged_info;
-    tagged_info.elem_type_sym = &elem_type_sym;
-    tagged_info.elem_symbol = &elem_symbol;
-    tagged_info.elem_size = build_member(elem, "size", size_type());
-    tagged_info.location = location;
-    tagged_info.is_tagged_scalar = true;
-    return tagged_info;
-  }
 
   const std::string elem_type_name = type_handler_.type_to_string(elem.type());
 
@@ -299,10 +312,9 @@ exprt python_list::build_push_list_call(
   const exprt &elem,
   bool enable_float_path)
 {
-  list_elem_info elem_info = get_list_element_info(op, elem);
-
-  if (elem_info.is_tagged_scalar)
+  if (converter_.get_type_handler().is_tagged_scalar_type(elem.type()))
   {
+    const list_elem_info elem_info = get_tagged_element_info(op, elem);
     const symbolt *push_tagged_sym =
       converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_tagged");
     if (!push_tagged_sym)
@@ -316,10 +328,14 @@ exprt python_list::build_push_list_call(
     push_tagged_call.arguments().push_back(
       build_symbol(*elem_info.elem_type_sym));
     push_tagged_call.arguments().push_back(elem_info.elem_size);
+    push_tagged_call.arguments().push_back(
+      tagged_float_type_id(enable_float_path));
     push_tagged_call.type() = bool_type();
     push_tagged_call.location() = elem_info.location;
     return push_tagged_call;
   }
+
+  list_elem_info elem_info = get_list_element_info(op, elem);
 
   const symbolt *push_func_sym =
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push");
@@ -423,10 +439,9 @@ exprt python_list::build_insert_list_call(
   const nlohmann::json &op,
   const exprt &elem)
 {
-  list_elem_info elem_info = get_list_element_info(op, elem);
-
-  if (elem_info.is_tagged_scalar)
+  if (converter_.get_type_handler().is_tagged_scalar_type(elem.type()))
   {
+    const list_elem_info elem_info = get_tagged_element_info(op, elem);
     const symbolt *insert_tagged_sym =
       converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_insert_tagged");
     if (!insert_tagged_sym)
@@ -441,10 +456,13 @@ exprt python_list::build_insert_list_call(
     insert_tagged_call.arguments().push_back(
       build_symbol(*elem_info.elem_type_sym));
     insert_tagged_call.arguments().push_back(elem_info.elem_size);
+    insert_tagged_call.arguments().push_back(tagged_float_type_id(true));
     insert_tagged_call.type() = bool_type();
     insert_tagged_call.location() = elem_info.location;
     return converter_.convert_expression_to_code(insert_tagged_call);
   }
+
+  const list_elem_info elem_info = get_list_element_info(op, elem);
 
   const symbolt *insert_func_sym =
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_insert");

--- a/src/python-frontend/python-list/python_list.h
+++ b/src/python-frontend/python-list/python_list.h
@@ -21,10 +21,6 @@ struct list_elem_info
   symbolt *elem_symbol;
   exprt elem_size;
   locationt location;
-  // True when elem_symbol already holds the element's raw value pointer
-  // (its size may be symbolic post-join), so callers must use the
-  // bounded-copy push/insert path instead of the generic byte-copy one.
-  bool is_tagged_scalar = false;
 };
 
 class python_list
@@ -622,6 +618,13 @@ private:
 
   list_elem_info
   get_list_element_info(const nlohmann::json &op, const exprt &elem);
+
+  list_elem_info
+  get_tagged_element_info(const nlohmann::json &op, const exprt &elem);
+
+  // The type_id a tagged scalar carries when it holds a float, or 0 when the
+  // caller opts out of the float path (dict values compare via void*).
+  exprt tagged_float_type_id(bool enable_float_path) const;
 
   symbolt &create_list();
 

--- a/src/python-frontend/python-list/python_list.h
+++ b/src/python-frontend/python-list/python_list.h
@@ -21,6 +21,10 @@ struct list_elem_info
   symbolt *elem_symbol;
   exprt elem_size;
   locationt location;
+  // True when elem_symbol already holds the element's raw value pointer
+  // (its size may be symbolic post-join), so callers must use the
+  // bounded-copy push/insert path instead of the generic byte-copy one.
+  bool is_tagged_scalar = false;
 };
 
 class python_list


### PR DESCRIPTION
Storing a dynamically-typed (tagged) scalar in a list, then reading it back, produced a wrong verdict or an unwind explosion depending on the element's runtime size.

- `get_list_element_info` hashed the tagged wrapper struct's own static C type instead of forwarding the scalar's real runtime type_id/value/size, so every element got the same wrong type_id regardless of which branch actually ran.
- The read function (`extract_pyobject_value`) double-dereferenced item->value as if it pointed at a nested PyObject, when the list item already is the tagged scalar's own PyObject.
- Added a bounded-copy push/insert path (__ESBMC_list_push_tagged/__ESBMC_list_insert_tagged) instead of the generic memcpy-based one, since a tagged scalar's size can be symbolic after a branch join and the generic copy never finishes unwinding over it.

Follow-up to #7573.