### PR TITLE
[docs] Require a KNOWNBUG check before working an issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -558,12 +558,80 @@ an open PR.
   each candidate's reproducer on your build; for every one that now passes,
   add `Fixes #N` and a `github_<N>` regression test.
 
+## Known-Bug Check Before Working an Issue
+
+Before investigating, reducing, or fixing any issue, check whether its
+reproducer is already pinned as a KNOWNBUG test. Over 200 exist, and a new
+issue is often one of them under a different description.
+
+There is no `regression/knownbugs/` directory — `KNOWNBUG` is line 1 of a
+`test.desc`, so the suite is spread across every category. Search by issue
+number, by construct, and by the verdict the issue reports.
+
+```sh
+# every KNOWNBUG test in the tree
+grep -rl '^KNOWNBUG' regression --include=test.desc | sed 's:/test.desc::'
+
+# tests already tied to an issue number (find, not a glob: suites nest,
+# e.g. regression/esbmc-cpp/cpp/ and regression/disabled/esbmc/)
+find regression -type d -name 'github_<N>*'
+
+# KNOWNBUG tests whose sources use the same construct
+grep -rl '^KNOWNBUG' regression --include=test.desc | sed 's:/test.desc::' \
+  | xargs -I{} grep -rls '<construct>' {}
+
+# narrow by the verdict the issue wants: a false alarm is pinned by a KNOWNBUG
+# expecting SUCCESSFUL, a missed bug by one expecting FAILED
+grep -rl '^KNOWNBUG' regression --include=test.desc \
+  | xargs grep -l 'VERIFICATION SUCCESSFUL'
+```
+
+**Run the candidate first.** A KNOWNBUG test that passes ctest is the bug
+still being live; one that fails with
+`passed but is marked as KNOWNBUG. Consider reclassifying it as CORE.`
+(`testing_tool.py` exit 77, which ctest reports as a failure —
+`SKIP_RETURN_CODE` is 10) means the bug is already gone on master, and the
+issue can be closed by flipping that test to CORE. The exception is a timeout,
+which KNOWNBUG accepts as satisfying the expectation — see the
+`accepted under KNOWNBUG` caveat under *Before committing*.
+
+**The bar for "same bug" is high — be conservative.** Two reproducers are the
+same bug only when one defect in ESBMC explains both: same component, same
+reason for the wrong verdict. A shared surface is not evidence — the same
+`VERIFICATION FAILED` line, the same crash site, the same construct, or the same
+file touched are all equally consistent with two distinct defects; a
+counterexample or `--goto-functions-only` dump that diverges between the two
+inputs is evidence they are not one bug. When it is unclear, treat them as
+distinct: a wrongly merged issue buries a live bug, while a wrongly separate
+one costs one duplicate test directory.
+
+When it is a match:
+
+- Comment on the issue naming the existing test path (e.g.
+  `regression/python/github_7552_len`), and say what makes it the same defect,
+  not merely the same symptom.
+- Do not add a second reproducer for it. A `github_<N>` directory that
+  re-pins a defect another KNOWNBUG already covers is a duplicate.
+- When you fix it, flip the existing test from KNOWNBUG to CORE in that same
+  PR rather than adding a parallel directory, and add its `VERIFICATION FAILED`
+  counterpart — see *Regression tests come in pairs*.
+- Do not write the annotation into `test.desc`: line 4+ have no comment syntax,
+  so every line there is a required regex. Put the issue number in the
+  reproducer source (`main.c` / `main.py`) and in the commit message.
+
+A match under `regression/disabled/` is not a gate: that tree is absent from the
+`REGRESSIONS` list in `regression/CMakeLists.txt`, so nothing in it runs. Treat
+it as a record that the reproducer exists, and re-home the test into a live
+suite when you fix the bug.
+
 ## Issue Conventions
 
 - Before opening an issue, search open and closed issues for the error text,
   the construct, and the flags involved
   (`gh search issues --repo esbmc/esbmc --include-prs "<terms>"`). If one
-  matches, add your reproducer there as a comment instead.
+  matches, add your reproducer there as a comment instead. Search the KNOWNBUG
+  tests in the same pass — see *Known-Bug Check Before Working an Issue*; a
+  reproducer pinned there may have no issue open against it at all.
 - Give the fields the matching form in `.github/ISSUE_TEMPLATE/` asks for: a
   reproducer (program, command, output, version) plus at most 150 words. Put
   root-cause analysis in the PR that fixes it, once.


### PR DESCRIPTION
A new issue is often already pinned by one of the 220 KNOWNBUG tests, but there is no `regression/knownbugs/` directory to look in: `KNOWNBUG` is line 1 of a `test.desc`, so they are spread across every suite. This adds a CLAUDE.md/AGENTS.md section covering how to search them (by issue number with `find`, since suites nest; by construct; by the expected verdict), a deliberately conservative bar for calling two reproducers the same defect, and what to do on a match — annotate the issue with the existing test path, do not add a second reproducer, and flip the test to CORE when fixing it.

Two traps are documented because both read as green: a KNOWNBUG whose bug is already fixed makes ctest fail with `passed but is marked as KNOWNBUG` (`testing_tool.py` exit 77), and a match under `regression/disabled/` never runs, as that tree is absent from `REGRESSIONS` in `regression/CMakeLists.txt`.

Tests: none — documentation only. Every command in the section was run against the tree, and the exit-77 behaviour was checked by temporarily marking a passing CORE test KNOWNBUG.