### PR TITLE
[docs] Price Phase 7 adjuster dispatch against the real arm table

### DIFF
--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -343,6 +343,56 @@ options, none yet costed:
 Option B is the one that follows from work already merged, and it should be
 priced first. Deciding this wrong means re-doing Phase 6 inside Phase 7.
 
+### 3.1 §3 answered: neither recorded option, and the working one is cheap (2026-09-10)
+
+Measured against the table #7455 actually built, not against §3's sketch.
+
+```cpp
+struct arm
+{
+  const char *name;
+  void (clang_c_adjust_irep2::*run)(expr2tc &);
+  bool (*when)(const expr2tc &);
+};
+static const arm arms[];          // 24 rows, constant-initialised
+```
+
+**Option B as §3 states it does not compile.** "A second frontend supplying its
+own table entries" cannot work while `run` is a pointer-to-member of
+`clang_c_adjust_irep2`: a derived arm's type does not convert to the base's, and
+the table is `static const` on the base, so a C++ row has nowhere to go.
+
+**Option A is still the wrong shape**, for §3's original reason: retrofitting
+virtuals re-imports the per-statement seams the unified
+`adjust_statement_condition` removed, and only where C++ needs them.
+
+**What does work — B′: each frontend owns a table typed on its own class, and
+the runner becomes a template.** Four properties, each compiled rather than
+recalled:
+
+| property | result |
+|---|---|
+| `decltype(&Derived::shared)` | `void (Base::*)(…)` — the *naming* class decides, so the C rows keep their type |
+| a table of `void (Derived::*)(…)` | holds **both** `&Derived::own` and `&Base::shared`, via the implicit base→derived member-pointer conversion |
+| that table declared `constexpr` | **0 dynamic initialisers** — constant-initialisation survives, which is the property the table's own comment protects |
+| `template <class T, size_t N> run_all(T &, const Row (&)[N], …)` | drives either frontend's table |
+
+So a `clang_cpp_adjust_irep2` table can list the 24 inherited C arms **by name**
+alongside its own, in one ordered table, with no virtual dispatch, no
+`std::function`, and no start-up cost. The C table does not change.
+
+The cost is confined to making `arm` and `adjust_sole_arms` generic over the
+concrete pass type — the only two places in the dispatch machinery that name
+`clang_c_adjust_irep2` — plus `arm_order()`, which
+`unit/clang-c-frontend/adjust_arms.test.cpp` reads and which stays per-class.
+
+**What this does not answer.** B′ settles how a C++ pass *dispatches*; it says
+nothing about which arms C++ needs. §3's mapping table stands: only
+`adjust_member` and `adjust_function_call_arguments` line up by name with an
+IREP2 arm, and `adjust_code`, `adjust_decl_block`, `adjust_symbol`,
+`adjust_reference` and `adjust_side_effect` have no counterpart at all. Those are
+the real Phase 7 work, and §4.1 says representation will not obstruct them.
+
 ## 4. What does not exist yet
 
 - **No hop-off flag** — though a census instrument now exists, §4.1.
@@ -476,7 +526,11 @@ spellings (§33) — so W3's carriage problem lands here first.
    ~~Port item 1~~ — **done**, §2.6, PR #7705.
 3. ~~Wire a census instrument on the C++ path~~ — **done**, §4.1. It says
    representation is not the blocker, so §3 is now the critical path.
-4. Price option B in §3 against option A.
-5. Then the replacement mode, and the census by verdict.
+4. ~~Price option B against option A~~ — **done**, §3.1: neither, but B′
+   (per-frontend typed table, template runner) is measured cheap.
+5. Make `arm` and `adjust_sole_arms` generic over the pass type (§3.1), then
+   stand up `clang_cpp_adjust_irep2` with the arms §3's mapping table shows are
+   missing.
+6. Then the replacement mode, and the census by verdict.
 
 Only then does a slice make sense.

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -790,6 +790,51 @@ Their displacement uses ESBMC's own layout rather than clang's
 warns about — the port must take the offset from the same oracle the legacy arm
 does, not recompute it.
 
+### 3.12 The soundness fix is blocked on carriage, and the precedent is §2.5
+
+Porting §3.11's two arms is not a port. Both are **marker-driven**:
+
+| arm | fires on | set by |
+|---|---|---|
+| `adjust_derived_to_base` | `#derived_to_base` (`clang_c_adjust_expr.cpp:92`) | the converter, for a conversion it could not route through a `@base@` component |
+| `adjust_base_to_derived` | `#base_to_derived` (`:482`) | the converter, for the downcast |
+
+Both markers are irept **attributes**, and:
+
+- `grep -c` for either in `migrate.cpp` is **0** — nothing carries them across
+  the seam;
+- `typecast2t` has two fields, `from` and `rounding_mode`. There is nowhere to
+  put one.
+
+So an IREP2 pass cannot see that a cast needs displacement. It is not that the
+arm is unwritten; the information it dispatches on does not survive migration.
+
+**The displacement cannot simply be applied earlier.** The converter's own
+comment says why: *"the displacement is only computable once the layout is
+padded, which is here"* (`clang_c_adjust_expr.cpp:90`, #7025). Computing it in
+`clang_cpp_convertert` is the option the legacy design already rejected.
+
+**This is a W3 instance that blocks a soundness fix**, which is a different
+weight class from the two this scope has recorded so far — §137's was a printer
+difference and §3.4's changes one exception id. Here the missing carriage is why
+three `_fail` tests are silently proved.
+
+**The fix has a precedent in this same document.** §2.4 and §2.5 added
+`pointer_ref_kindt` to `pointer_type2t`: a defaulted field, in the `fields`
+tuple, carried both ways by `migrate`, pinned by a round-trip unit test and
+costing no construction site. A base-conversion marker on `typecast2t` is the
+same shape — most of `pointer_ref_kindt`'s cost was discovering the pattern, and
+that is now paid. Two cautions from doing it once:
+
+- `fields_cover_class` will **not** catch the field being dropped from the tuple
+  if the shortfall sits under the alignment tolerance (§2.5). Pin equality
+  explicitly.
+- Whatever rebuilds a `typecast2t` must forward it, as
+  `rebuild_with_type<address_of2t>` had to (§2.6).
+
+Sequencing: the field first, on its own, with the round-trip test — then the two
+arms become an ordinary port against a marker they can read.
+
 ## 4. What does not exist yet
 
 - **No hop-off flag** — though a census instrument now exists, §4.1.
@@ -935,10 +980,12 @@ spellings (§33) — so W3's carriage problem lands here first.
    not yet ported.
 8. The three remaining false alarms (§3.8), which are three causes: a queue
    reference, a bitset alignment and a vector pointer.
-9. **Port `adjust_base_to_derived` and `adjust_derived_to_base` (§3.11)** — the
-   two unported C arms behind the base-subobject displacement, and so behind the
-   three false proofs. Take the offset from the legacy oracle, not a fresh
-   computation. Then the 122 no-verdict cases.
+9. **Carry the base-conversion markers on `typecast2t` (§3.12)** — a defaulted
+   field in the `fields` tuple, following `pointer_ref_kindt`. Without it §3.11's
+   arms have nothing to dispatch on.
+10. Then port `adjust_base_to_derived` and `adjust_derived_to_base` (§3.11),
+    taking the offset from `base_displacement`, not a fresh computation.
+11. Then the 122 no-verdict cases.
 10. Then §134.4's ternary decay, which reaches the goto program on C++ (§3.6).
     `finalize_exception_specification` is *not* on this list: §3.9 refutes it.
 

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -415,6 +415,39 @@ IREP2 arm, and `adjust_code`, `adjust_decl_block`, `adjust_symbol`,
 `adjust_reference` and `adjust_side_effect` have no counterpart at all. Those are
 the real Phase 7 work, and §4.1 says representation will not obstruct them.
 
+### 3.2 The pass stands up, and one arm is 95 % of the gap (2026-09-10)
+
+`clang_cpp_adjust_irep2` derives from the C pass and substitutes its own table
+(PR #7717). One virtual selects the table; the C arms become `protected`. Its
+table lists only the inherited C arms, so running it as the sole adjuster under
+`--clang-cpp-irep2-adjust-only` *measures* what C++ needs.
+
+Over 80 `regression/esbmc-cpp` tests, verdict against the default path:
+
+| | count |
+|---|---:|
+| agree | 17 |
+| diverge | 63 |
+| …of which one signature | **54** |
+
+```
+ERROR: do_function_call: unexpected callee expression (id: member)
+```
+
+A C++ method call. Six of the other nine are multi-file tests the sweep fed only
+their first source, one expects a parse error. **So one arm — member-function
+call lowering — accounts for essentially the whole gap**, and it is the next
+slice. §3's mapping table guessed five missing arms from names; the corpus says
+start with the one the legacy `adjust_side_effect_function_call` override covers.
+
+Worth noting what already works with inherited arms alone: a reference bind
+through a method-free struct verifies identically on both paths. The C arms are
+not merely inert on C++ input.
+
+The nine table guards moved to a shared header (one definition, two tables), and
+`adjust_arms.test.cpp` pins that the two tables stay in the same order — a row
+added to one and not the other should be a decision, not an accident.
+
 ## 4. What does not exist yet
 
 - **No hop-off flag** — though a census instrument now exists, §4.1.
@@ -550,9 +583,9 @@ spellings (§33) — so W3's carriage problem lands here first.
    representation is not the blocker, so §3 is now the critical path.
 4. ~~Price option B against option A~~ — **done**, §3.1: neither, but B′
    (per-frontend typed table, template runner) is measured cheap.
-5. Make `arm` and `adjust_sole_arms` generic over the pass type (§3.1), then
-   stand up `clang_cpp_adjust_irep2` with the arms §3's mapping table shows are
-   missing.
+5. ~~Make the table generic and stand up `clang_cpp_adjust_irep2`~~ — **done**,
+   §3.1 and §3.2 (PRs #7714, #7717). The corpus, not the name mapping, says what
+   is missing: write the member-call arm first (54 of 57 real divergences).
 6. Then the replacement mode, and the census by verdict.
 
 Only then does a slice make sense.

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -740,6 +740,56 @@ the four directories above supersede them.
 Until the three false proofs are closed, the flag is not merely incomplete; it is
 unsound on inheritance, and no verdict it produces there can be trusted.
 
+### 3.11 The false proofs are two unported arms, and they are C arms
+
+`inheritance/mi_base_subobject_layout_fail` is three lines:
+
+```cpp
+struct A { int a; A() : a(1) {} };
+struct P { virtual ~P() {} int p; P() : p(9) {} };
+struct AP : A, P {};
+int main() { AP ap; A &as = ap; assert(as.a == 9); }
+```
+
+`as.a` is 1, so the assertion is false and the test is a `_fail`. `main`'s goto
+body is **byte-identical** on both paths — both emit
+`as = &ap.@base@tag-A` and `ASSERT as->a == 9` — so the reference bind is not
+where it goes wrong. The symbol table is:
+
+```
+~AP(this == 0 ? 0 : (struct AP *)((signed char *)this - 8))   default
+~AP((struct AP *)this)                                        hop-off
+```
+
+The hop-off drops the base displacement, so `A`'s subobject aliases `P`'s and
+`a` reads 9.
+
+**The two arms that compute it are unported**:
+`clang_c_adjust::adjust_base_to_derived` and `adjust_derived_to_base`
+(`clang_c_adjust_expr.cpp:424,480`) — `grep -c` in
+`clang_c_adjust_irep2.cpp` is **0** for both.
+
+Three things follow:
+
+- **They are C arms, missing from the C pass.** `adjust_base_to_derived` runs
+  from `clang_c_adjust`'s default `else` branch (`clang_c_adjust_expr.cpp:205`),
+  i.e. on every expression the C path adjusts. The C hop-off has the same gap
+  and never shows it, because C has no base classes. §3.2's method — give the
+  C++ pass the inherited C arms and measure — cannot find a hole in the arms it
+  inherits.
+- **This is why the corpus, not the inventory, keeps being right.** §3's mapping
+  compared `clang_cpp_adjust`'s overrides against the IREP2 arms. These two are
+  not overrides; they are base-class arms the IREP2 pass never had, so no
+  comparison of the C++ subclass could have named them.
+- **It plausibly accounts for all three false proofs**, which are all
+  base-subobject layout. Stated as located, not proven: the fix has not been
+  written, and §3.9 is a recent reminder that the obvious cause can be refuted.
+
+Their displacement uses ESBMC's own layout rather than clang's
+(`clang_cpp_convert.cpp:1914`), which `scope-clang-c-irep2.md`'s #3894 note also
+warns about — the port must take the offset from the same oracle the legacy arm
+does, not recompute it.
+
 ## 4. What does not exist yet
 
 - **No hop-off flag** — though a census instrument now exists, §4.1.
@@ -885,9 +935,10 @@ spellings (§33) — so W3's carriage problem lands here first.
    not yet ported.
 8. The three remaining false alarms (§3.8), which are three causes: a queue
    reference, a bitset alignment and a vector pointer.
-9. **Close the three false proofs (§3.10)** — base-subobject layout, and the
-   only class of defect that makes a verdict untrustworthy rather than noisy.
-   Then the 122 no-verdict cases.
+9. **Port `adjust_base_to_derived` and `adjust_derived_to_base` (§3.11)** — the
+   two unported C arms behind the base-subobject displacement, and so behind the
+   three false proofs. Take the offset from the legacy oracle, not a fresh
+   computation. Then the 122 no-verdict cases.
 10. Then §134.4's ternary decay, which reaches the goto program on C++ (§3.6).
     `finalize_exception_specification` is *not* on this list: §3.9 refutes it.
 

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -598,6 +598,38 @@ in `scope-clang-c-irep2.md`, recorded there as not reaching symex on C; on C++ i
 reaches the goto program. Worth its own row rather than being folded into the vptr
 work.
 
+### 3.7 The hook exists, and the corpus is at 91 % (2026-09-10)
+
+PR #7724 gives the pass a `gen_symbol_code` hook beside the node walk and ports
+`gen_vptr_initializations` into it. The C pass generates nothing, so the hook is
+a no-op there.
+
+| over 80 tests | §3.4 | after |
+|---|---:|---:|
+| agree | 51 | **73** |
+| false alarms | 23 | **3** |
+| **missed bugs** | 0 | **0** |
+| no verdict one side | 6 | 4 |
+
+Vtable-pointer writes go 0 → **55**, matching the default path exactly.
+
+**Generation runs before the walk, not after.** The legacy pass generates after
+adjusting the body; doing that here would mean migrating the value back to legacy
+form, mutating it and migrating forward again — the round trip §137 shows is
+lossy. Generating first lets the emitted assignments go through the arms like any
+other statement. Worth knowing the two passes differ in that order.
+
+**Freeing a member exposes dead code that private status hid.** Making
+`gen_vptr_initializations` a free function left `gen_vptr_init_code` and
+`gen_vptr_init_lhs` with no callers — `-Werror=unused-function` says so, and
+nothing in `src/` or `unit/` referenced either. Both were already dead on master;
+as private members nothing could observe that. Removed with the compiler as the
+proof.
+
+**What is left.** Three false alarms and four harness artefacts. One of the three
+is §3.4's builtin exception spelling (`throw 1` yields `signedbv` where legacy
+yields `signed_int`). The others are unexamined.
+
 ## 4. What does not exist yet
 
 - **No hop-off flag** — though a census instrument now exists, §4.1.
@@ -738,10 +770,9 @@ spellings (§33) — so W3's carriage problem lands here first.
    is missing: write the member-call arm first (54 of 57 real divergences).
 6. ~~Port the `exception_id` assignment~~ — **done**, §3.4, PR #7719. Crashes are
    gone; the residue is the builtin spelling the seam drops.
-7. Give the pass a per-symbol code-generation hook and port
-   `gen_vptr_initializations` into it (§3.6) — 0 of 55 vptr writes happen today,
-   which is the cause behind all 23 remaining real divergences. Take
-   `finalize_exception_specification` at the same time.
+7. ~~Per-symbol code-generation hook and `gen_vptr_initializations`~~ — **done**,
+   §3.7, PR #7724. `finalize_exception_specification` has the same shape and is
+   not yet ported.
 8. Then §134.4's ternary decay, which reaches the goto program on C++ (§3.6).
 
 Only then does a slice make sense.

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -699,6 +699,47 @@ Two things the attempt did establish, both worth keeping:
   merged: a change that cannot be pinned is the dead instrumentation the gates
   exist to catch, however plausible its motivation.
 
+### 3.10 The hop-off DOES produce false proofs — the sample hid them (2026-09-10)
+
+§3.9 said the stride-10 sample under-covers the exception paths. Censusing four
+directories in full says something worse, and it corrects a claim §3.5, §3.7 and
+§3.8 all repeated:
+
+| suite | agree | false alarm | **missed bug** | no verdict |
+|---|---:|---:|---:|---:|
+| `try_catch` | 68 | 52 | 0 | 52 |
+| `destructors` | 2 | 0 | **1** | 11 |
+| `inheritance` | 56 | 25 | **2** | 23 |
+| `polymorphism_bringup` | 9 | 1 | 0 | 36 |
+| **total** | 135 | 78 | **3** | 122 |
+
+**"Zero missed bugs" was false.** It held on the 80-test stride sample and I
+restated it four times as though it were a property of the pass. It is a property
+of the sample. Three tests verify SUCCESSFUL under the hop-off where the default
+path finds the bug:
+
+- `destructors/github_6263_nonvirtual_base_delete`
+- `inheritance/github_7025_vbase_nonfirst_member_fail`
+- `inheritance/mi_base_subobject_layout_fail`
+
+All three are base-subobject layout — the area `scope-clang-c-irep2.md` §3894 and
+#7025 already record as having two competing layout oracles. A pass that silently
+proves those is unsound in exactly the way that matters, and the `_fail` suffix on
+two of them means the corpus was built to catch this.
+
+**And 122 tests produce no verdict at all**, against 4 on the sample. The crash
+class §3.3 closed was not the only one.
+
+**What this says about the method.** Sampling by stride over a directory listing
+weights by directory size, so the suites that concentrate a *semantic* area —
+inheritance, destructors, exceptions — are the ones a stride under-samples, and
+they are exactly where a frontend migration breaks. Every number in §3.2 through
+§3.8 is a stride-sample number and should be read as such. Full-suite figures for
+the four directories above supersede them.
+
+Until the three false proofs are closed, the flag is not merely incomplete; it is
+unsound on inheritance, and no verdict it produces there can be trusted.
+
 ## 4. What does not exist yet
 
 - **No hop-off flag** — though a census instrument now exists, §4.1.
@@ -844,8 +885,9 @@ spellings (§33) — so W3's carriage problem lands here first.
    not yet ported.
 8. The three remaining false alarms (§3.8), which are three causes: a queue
    reference, a bitset alignment and a vector pointer.
-9. Census the exception directories properly (§3.9) — the stride-10 sample
-   under-covers them, and one of their divergences produces no verdict at all.
+9. **Close the three false proofs (§3.10)** — base-subobject layout, and the
+   only class of defect that makes a verdict untrustworthy rather than noisy.
+   Then the 122 no-verdict cases.
 10. Then §134.4's ternary decay, which reaches the goto program on C++ (§3.6).
     `finalize_exception_specification` is *not* on this list: §3.9 refutes it.
 

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -448,6 +448,46 @@ The nine table guards moved to a shared header (one definition, two tables), and
 `adjust_arms.test.cpp` pins that the two tables stay in the same order — a row
 added to one and not the other should be a decision, not an accident.
 
+### 3.3 The crashes are one cause, and it is not one §3 predicted (2026-09-10)
+
+§3.2 left 24 of 80 tests crashing under `--clang-cpp-irep2-adjust-only` once the
+member-call arm landed. Symbolised and clustered by top frame — SIGSEGV is not a
+cause, and this file has split symptom-named clusters before — **all 23 that
+produce a backtrace share one site**:
+
+```
+remove_exceptions(goto_functionst &, contextt &, namespacet const &)
+    src/goto-programs/remove_exceptions.cpp:1857
+```
+
+Reduced to two lines, with the control beside it:
+
+| program | default | hop-off |
+|---|---|---|
+| a method call, no exceptions | SUCCESSFUL | SUCCESSFUL |
+| `int main(){try{throw 1;}catch(int e){return e-1;}return 1;}` | SUCCESSFUL | **SIGSEGV** |
+
+**Cause.** `clang_cpp_adjust::adjust_catch`
+(`clang_cpp_adjust_code.cpp:319-336`) sets `exception_id` on each catch block,
+and the throw arm (`clang_cpp_adjust_expr.cpp:483`) does the same, both via
+`convert_exception_id`. The IREP2 pass *replaces* `clang_cpp_adjust`, so none of
+that runs, and `remove_exceptions` reaches catch/throw nodes with no catchable-type
+id.
+
+**It is not a representation gap.** `migrate_expr`'s cpp-catch arm carries
+`exception_id` across the seam in both directions, so §4.1's conclusion stands —
+what is missing is the arm that *computes* the ids, not a field to hold them.
+Worth stating because the migrate census could not have found this: the census
+runs after the legacy adjuster, so the attributes were already present when it
+looked.
+
+**What it says about §3's mapping.** Neither of the two arms the corpus has now
+demanded — member-call lowering and exception-id assignment — is among the five
+§3 predicted from name comparison (`adjust_code`, `adjust_decl_block`,
+`adjust_symbol`, `adjust_reference`, `adjust_side_effect`). Two for two, the
+corpus named a different arm than the names did. Treat §3's table as an inventory,
+not a work order.
+
 ## 4. What does not exist yet
 
 - **No hop-off flag** — though a census instrument now exists, §4.1.
@@ -586,6 +626,9 @@ spellings (§33) — so W3's carriage problem lands here first.
 5. ~~Make the table generic and stand up `clang_cpp_adjust_irep2`~~ — **done**,
    §3.1 and §3.2 (PRs #7714, #7717). The corpus, not the name mapping, says what
    is missing: write the member-call arm first (54 of 57 real divergences).
-6. Then the replacement mode, and the census by verdict.
+6. Port `adjust_catch` / the throw arm's `exception_id` assignment (§3.3) — one
+   cause behind all 23 symbolised crashes.
+7. Then the remaining verdict divergences (15 of 80 report FAILED where the
+   default path succeeds).
 
 Only then does a slice make sense.

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -481,6 +481,35 @@ Worth stating because the migrate census could not have found this: the census
 runs after the legacy adjuster, so the attributes were already present when it
 looked.
 
+### 3.4 The ids are computed, and the residue is a spelling the seam drops
+
+PR #7719 ports both arms: `convert_exception_id` becomes a free function taking a
+namespace (it read no other instance state), and the IREP2 arms populate
+`code_cpp_catch2t`'s and `code_cpp_throw2t`'s `exception_list` fields.
+
+| over 80 tests | before | after |
+|---|---:|---:|
+| agree | 31 | **51** |
+| diverge | 49 | 29 |
+| crash | 23 | **0** |
+
+**The residue on the reproducer is a W3 instance that reaches a verdict, not a
+printer.** `throw 1` yields the id `signedbv` on the hop-off where the legacy path
+yields `signed_int`: the id is computed from `migrate_type_back(...)`, and the C
+spelling does not survive `migrate_type`. The throw and the handler then disagree
+and the exception escapes, so the two-line reproducer still reports FAILED where
+the default path succeeds.
+
+Class-typed exceptions are unaffected — their id comes from the tag name, which
+does survive — which is why the corpus improves from 31 to 51 regardless.
+
+This is worth separating from §5's R6 as stated. R6 anticipated a dropped
+attribute surfacing as a *printer* difference; here it changes a verdict. The
+spelling has to be carried, or the ids computed before migration. Reconstructing
+`signed_int` from a 32-bit `signedbv` is available and is the wrong answer, for
+§137's reason: do not rebuild what the representation dropped, either carry it or
+do not claim it.
+
 **What it says about §3's mapping.** Neither of the two arms the corpus has now
 demanded — member-call lowering and exception-id assignment — is among the five
 §3 predicted from name comparison (`adjust_code`, `adjust_decl_block`,
@@ -626,8 +655,8 @@ spellings (§33) — so W3's carriage problem lands here first.
 5. ~~Make the table generic and stand up `clang_cpp_adjust_irep2`~~ — **done**,
    §3.1 and §3.2 (PRs #7714, #7717). The corpus, not the name mapping, says what
    is missing: write the member-call arm first (54 of 57 real divergences).
-6. Port `adjust_catch` / the throw arm's `exception_id` assignment (§3.3) — one
-   cause behind all 23 symbolised crashes.
+6. ~~Port the `exception_id` assignment~~ — **done**, §3.4, PR #7719. Crashes are
+   gone; the residue is the builtin spelling the seam drops.
 7. Then the remaining verdict divergences (15 of 80 report FAILED where the
    default path succeeds).
 

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -257,6 +257,42 @@ Two things the gates caught that are worth carrying forward:
   pointer itself. The item 1 arms must build the pointer type directly rather
   than route an address-of through `with_type`. PR **#7703**.
 
+### 2.6 Item 1 ported, and what it took (PR #7705)
+
+Both reference arms are in. Three things worth carrying forward, none of which
+was visible before the differential harness rejected a first attempt.
+
+**The address-of must carry the destination's own kind.** irept hardcodes
+`#reference` in `take_reference_address` and gets away with it because
+`operator==` skips comment attributes (`irep.cpp`, literally "comments are NOT
+checked") — so `T&` and `T&&` are the same type there. `ref_kind` is a real
+field, so a hardcoded kind leaves `do_typecast`'s `dest_type != type` guard true
+and appends a cast irept never produces. Two further carriage sites had to
+follow: `migrate_expr`'s address-of arm built its pointer from the pointee and
+dropped the spelling, and `rebuild_with_type<address_of2t>` re-defaulted it —
+that one silently affected every `with_type` caller, not just this one.
+
+**One shape the two copies cannot agree on, and irept is the wrong side.** For a
+`T&&` destination irept produces an address-of spelled `#reference`, i.e. an
+lvalue reference. Measured, neither side adds a cast and only the spelling
+differs:
+
+```
+legacy_migrated:  address_of  ref_kind : lvalue_reference
+native:           address_of  ref_kind : rvalue_reference
+```
+
+The IREP2 side is the faithful one, so that section pins the shape rather than
+byte equality. A port is not obliged to reproduce a defect it can see.
+
+**The complexity gate was already failing before any of this.**
+`implicit_typecast_followed` sits at 19 against a `core` threshold of 15 on
+master, so *any* edit to it fails the gate — which is what #7701 and #7703 were
+failing on, not their own additions. Split into `convert_reference` and
+`convert_to_pointer`, with the pointer-compatibility disjunction factored out;
+the gate then reports no function over threshold. Anything else touching this
+function inherits the same obligation.
+
 ## 3. The design question Phase 6 leaves open: the pass is not extensible
 
 The legacy frontends are one class specialising another:
@@ -309,14 +345,110 @@ priced first. Deciding this wrong means re-doing Phase 6 inside Phase 7.
 
 ## 4. What does not exist yet
 
-- **No hop-off flag.** `--clang-c-irep2-adjust-only` has no C++ counterpart
-  (`grep -n 'cpp-irep2' src/esbmc/options.cpp` is empty). Phase 6's entire
-  instrument — A/B one binary against itself with and without the flag — is
-  unavailable until one is added. That is the second work item, and it is a
-  prerequisite for any census by verdict.
+- **No hop-off flag** — though a census instrument now exists, §4.1.
+  The reason there is no hop-off:
+  `clang_cpp_languaget::typecheck` (`clang_cpp_language.cpp`'s `typecheck`) runs
+  `clang_cpp_adjust` unconditionally: no option is read, and no IREP2 pass is
+  constructed. Compare `clang_c_languaget` (`clang_c_language.cpp:460-490`),
+  which reads `clang-c-irep2-adjust-only` and either replaces or shadows the
+  legacy pass.
+
+  Measured consequence: instrumenting the IREP2 `implicit_typecast_followed` at
+  entry, a C source under `--clang-c-irep2-adjust-only` reaches it (2 entries)
+  and a C++ source reaches it **zero** times. So every arm Phase 7 ports is
+  dormant until this is wired — §2.3 and §2.6 both had to say "no regression
+  pair is possible", and this is why.
+
+  **The cheap first move is the shadow mode, not the replacement.** Phase 6's
+  `--clang-c-irep2-adjust` runs the IREP2 walk *in addition* to the legacy pass:
+  read-only, byte-identical by construction, and what it buys is migrating every
+  value in the corpus through `get_value2()`, which aborts on any construct
+  `migrate_expr` cannot represent. Wiring that on the C++ path needs no
+  `clang_cpp_adjust_irep2` and no answer to §3 — it is a census instrument, and
+  it would price the whole C++ corpus in one run. That is the next work item.
 - **No scope-doc census by construct.** §39.1's "census before writing" prices
   every construct once, at the start. For clang-cpp that census cannot be run
   until the flag exists, so §1's counts are the static census only.
+
+### 4.1 The census exists, and it inverts the expected risk (2026-09-10)
+
+`--clang-cpp-irep2-migrate-census` migrates every adjusted symbol's type and
+value through IREP2 and discards the result. It is not a shadow of
+`clang_c_adjust_irep2`: that pass writes back whatever it changes and its arms
+are C-shaped, so on C++ it would re-adjust bodies `clang_cpp_adjust` has already
+handled. A census has to leave the program alone.
+
+Read-only, measured with `irep2_canon` over a stride-10 `regression/esbmc-cpp`
+sample: **282 of 282** canonicalised goto programs identical, the one flagged
+difference being an extra `migrate_expr` diagnostic rather than a program change.
+
+Result over 273 tests:
+
+| migrated | count |
+|---|---:|
+| symbol types | **367 738** |
+| symbol values | **86 917** |
+| `migrate_*` diagnostics | **1** |
+| aborts | **0** |
+
+**IREP2 represents everything this corpus's C++ frontend output contains.** That
+was the open question §4 existed to price, and it reframes the phase: the blocker
+is not representation, it is adjuster coverage — §3's arm-table question. W1 was
+already dissolved for structured control flow (`frontends-to-irep2.md` §3); this
+says the same for C++ *values*, over this corpus.
+
+**Where the census runs is load-bearing, and the first version had it wrong.**
+Placed before `c_link` it produced the same counts and looked equally clean — but
+`migrate_namespace_lookup` is the *global* context, so pre-link every symbol of
+the TU under census is absent from it. `sym_name_to_symbol` does not fail on a
+miss: it falls through to building `symbol2tc` from the expression's own type
+instead of `migrate_symbol_type`'s, which `migrate.cpp:670-679` warns "screws up
+future hash tables". So the pre-link census established only that migration ran
+*with every symbol reference on the fallback path*, and any defect reachable only
+through `migrate_symbol_type` — incomplete struct, prototype-versus-definition
+mismatch — was invisible to it.
+
+Nor was the single pre-link diagnostic a measure of the problem: that message is
+`log_debug("migrate", ...)`, so it needs module-level verbosity to appear at all,
+and misses whose names carry `?`/`!` or the k-induction `cs$`/`s$` prefixes
+return silently. Counting one warning said nothing about how many symbols took
+the fallback.
+
+Moved to run after `c_link`, the same test emits **zero** namespace misses under
+`--verbosity migrate:9`, where pre-link it emitted one. The counts are unchanged
+and the failure count is still zero, so the conclusion survives — but it now
+rests on resolved symbol types rather than on substituted ones.
+
+Two consequences worth keeping:
+
+- **The read-only property was true for a reason I had not identified.**
+  `c_link`'s `fix_symbol` (`fix_symbol.cpp:9-14`) round-trips every symbol
+  through `set_type`/`set_value` unconditionally, clearing both IREP2 valid
+  flags — so a pre-link census's migrated values were discarded at the link
+  boundary. That, not the cache-flag argument, is why the goto A/B came out
+  282/282. Post-link that leg is gone, and the 282/282 sweep becomes the actual
+  evidence rather than a construction.
+- **Migration signals failure by throwing a `std::string` on some arms**
+  (`migrate.cpp:395`) and by aborting on others (`:795`, `:837`, `:859`), and
+  the diagnostic names the expression, never the symbol. Each symbol is wrapped,
+  so a *throwing* construct names itself and the walk continues — the difference
+  between a census and a bisection. An aborting arm still stops the run; the
+  wrap does not and cannot cover those.
+- **The counts alone cannot show the census ran.** A symbol or value count is
+  identical on either representation, so replacing `get_type2()` with
+  `get_type()` migrates nothing and prints the same line — a mutant the first
+  version of the test survived, and the natural drift path once the C++
+  frontend starts writing the IREP2 side directly. The line therefore also
+  reports the number of distinct IREP2 `type_id`s, which only the migrated form
+  can produce, and the tests pin it at two or more.
+
+**A measurement trap this cost, recorded because it invalidated a first answer.**
+The C++ goto dump carries `GOTO program creation time:`, which varies run to run.
+A first A/B of this change filtered `time:` and not that prefix, and reported 270
+of 282 tests "differing"; the control — same binary, same flags, twice — reported
+54 of 60. Nothing was diverging. Use `scripts/irep2-migration/lib.sh`'s
+`irep2_canon`, which strips timings, addresses and temp paths, and run the
+same-flags control before believing any A/B on this corpus.
 
 ## 5. Risks, carried forward from Phases 5 and 6
 
@@ -340,8 +472,11 @@ spellings (§33) — so W3's carriage problem lands here first.
    Item 1 is now writable, and it is the next slice: 70 % of the corpus needs
    it, and unlike §2.3's arms it will move verdicts, so it owes a
    `SUCCESSFUL`/`FAILED` pair.
-2. ~~Port items 6 and 7~~ — **done**, see §2.3.
-3. Price option B in §3 against option A.
-4. Add the C++ hop-off flag, then run the census by verdict.
+2. ~~Port items 6 and 7~~ — **done**, §2.3, PR #7701.
+   ~~Port item 1~~ — **done**, §2.6, PR #7705.
+3. ~~Wire a census instrument on the C++ path~~ — **done**, §4.1. It says
+   representation is not the blocker, so §3 is now the critical path.
+4. Price option B in §3 against option A.
+5. Then the replacement mode, and the census by verdict.
 
 Only then does a slice make sense.

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -630,6 +630,41 @@ proof.
 is §3.4's builtin exception spelling (`throw 1` yields `signedbv` where legacy
 yields `signed_int`). The others are unexamined.
 
+### 3.8 The last three false alarms are three causes, not one (2026-09-10)
+
+Named, so the next tick does not re-derive them:
+
+| test | violated property |
+|---|---|
+| `bitset/bitset6` | `cpp/bitset:88` — incorrect alignment accessing a data object |
+| `cpp/ch21_31` | the test's own `assert`, via `std::queue` |
+| `cpp/github_2284_4` | `cpp/vector:325` — invalid pointer |
+
+Three different OMs and three different properties. Nothing links them yet, and
+after §3.3's single-cause cluster it would be easy to assume another; they are
+listed separately until measurement says otherwise.
+
+**`ch21_31` reduced**, with the controls that bound it:
+
+```cpp
+std::queue<int> q; q.push(12); q.push(75);
+q.back() -= q.front();          // default SUCCESSFUL, hop-off FAILED
+```
+
+- Reading only — `assert(q.back() == 75 && q.front() == 12)` — agrees on both
+  paths, so `back()`/`front()` themselves are fine.
+- The same shape on a hand-written struct returning `int &` agrees on both paths,
+  both for `b.back() = 63` and `b.back() -= b.front()`.
+
+So it is **not** compound assignment through a reference in general, which was
+the obvious guess and is wrong. It is specific to the reference `std::queue`'s
+`back()` returns, which reaches through the underlying container. The narrower
+`q.back() = 63` and single-push variants both exceed 90 s under the queue OM, so
+the next step wants a longer budget or a hand-rolled stand-in for the OM's
+indirection rather than a further reduction of the OM itself.
+
+`bitset6` and `github_2284_4` are unexamined.
+
 ## 4. What does not exist yet
 
 - **No hop-off flag** — though a census instrument now exists, §4.1.
@@ -773,6 +808,9 @@ spellings (§33) — so W3's carriage problem lands here first.
 7. ~~Per-symbol code-generation hook and `gen_vptr_initializations`~~ — **done**,
    §3.7, PR #7724. `finalize_exception_specification` has the same shape and is
    not yet ported.
-8. Then §134.4's ternary decay, which reaches the goto program on C++ (§3.6).
+8. The three remaining false alarms (§3.8), which are three causes: a queue
+   reference, a bitset alignment and a vector pointer.
+9. Then §134.4's ternary decay, which reaches the goto program on C++ (§3.6),
+   and `finalize_exception_specification`, which the §3.7 hook can now take.
 
 Only then does a slice make sense.

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -665,6 +665,40 @@ indirection rather than a further reduction of the OM itself.
 
 `bitset6` and `github_2284_4` are unexamined.
 
+### 3.9 The stride-10 sample under-covers try/catch, and one port was refuted
+
+**The sample is not representative of the exception paths.** Over
+`regression/esbmc-cpp/try_catch` (first 14 directories) the hop-off agrees on 8
+and diverges on 6 — 43 % — against 7 of 80 on the stride-10 sample the earlier
+sections use. A stride over a directory listing weights by directory size, and
+`try_catch` is small next to `algorithm` and `cpp`. Quote the sample when quoting
+the 73/80, and census the exception directories separately.
+
+One of the six produces no verdict at all
+(`exception_spec_dynamic_violation_fail`, default FAILED), so a crash survives
+somewhere the sample never looked.
+
+**`finalize_exception_specification` is not the cause, and porting it was
+refuted.** It was the obvious candidate: `clang_cpp_adjust` calls it per code
+symbol, the IREP2 pass replaces that adjuster, and 30 tests in the corpus use a
+dynamic exception specification. Ported into the §3.7 hook it changes **nothing**
+— `try_catch` stays at 8 agree / 6 diverge, and neither
+`exception_spec_dynamic_allowed` nor the violation test moves.
+
+Two things the attempt did establish, both worth keeping:
+
+- **The hook must be offered bodyless symbols.** As first written,
+  `gen_symbol_code` sat inside `adjust()`'s `get_value().is_not_nil()` guard, so
+  a function *declaration* — which is where an exception specification lives —
+  never reached it. Instrumenting showed the resolution firing once under the
+  hop-off against four times on the default path. Whoever ports this next needs
+  the hook moved, not just the function.
+- **The port is unpinnable today.** With no verdict moving and the attribute
+  invisible in `--symbol-table-only`, no test in this repo can distinguish the
+  ported pass from the unported one. It was therefore reverted rather than
+  merged: a change that cannot be pinned is the dead instrumentation the gates
+  exist to catch, however plausible its motivation.
+
 ## 4. What does not exist yet
 
 - **No hop-off flag** — though a census instrument now exists, §4.1.
@@ -810,7 +844,9 @@ spellings (§33) — so W3's carriage problem lands here first.
    not yet ported.
 8. The three remaining false alarms (§3.8), which are three causes: a queue
    reference, a bitset alignment and a vector pointer.
-9. Then §134.4's ternary decay, which reaches the goto program on C++ (§3.6),
-   and `finalize_exception_specification`, which the §3.7 hook can now take.
+9. Census the exception directories properly (§3.9) — the stride-10 sample
+   under-covers them, and one of their divergences produces no verdict at all.
+10. Then §134.4's ternary decay, which reaches the goto program on C++ (§3.6).
+    `finalize_exception_specification` is *not* on this list: §3.9 refutes it.
 
 Only then does a slice make sense.

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -552,13 +552,51 @@ default SUCCESSFUL, hop-off FAILED. The literal form (`std::cout << "hi"`) fails
 identically, so it is not the array-to-pointer decay of a string literal — an
 already-decayed pointer argument reproduces it.
 
-What the trace says, and what it does not: the violated property is at **State 1**
-with no assignment before it, so the call is not being set up rather than an
-argument holding a wrong value. That points at parameter binding for this
-overload — its first parameter is `ostream &`, i.e. the reference machinery §2.6
-touched — but the counterexample does not name which binding, and guessing is how
-§3's mapping table got two arms wrong. The next step is to instrument the argument
-conversion for this call rather than infer it.
+The trace puts the violated property at **State 1** with no assignment before it,
+so the call is not being set up rather than an argument holding a wrong value.
+§3.6 instruments it; the answer was not parameter binding.
+
+### 3.6 The ostream false alarm is a dropped code-generation step, not an arm
+
+Instrumented rather than inferred, and the inference in §3.5 would have been
+wrong. `adjust_call_arguments` converts `operator<<`'s arguments correctly; the
+reference parameter takes the `binds_by_reference` path and the pointer argument
+converts pointer→pointer. Carrying the parameter's `ref_kind` into that
+address-of changes nothing, which rules the reference machinery out.
+
+Diffing the whole canonicalised goto program for the two-line reproducer — 897
+differing lines — finds it:
+
+| | default | hop-off |
+|---|---:|---:|
+| `@vtable_pointer=&virtual_table…` assignments | **55** | **0** |
+| …for `ostream` alone | 7 | 0 |
+
+`clang_cpp_adjust::gen_vptr_initializations`
+(`clang_cpp_adjust_code_gen.cpp:5`) writes each class's vtable pointer at
+constructor entry. The IREP2 pass replaces `clang_cpp_adjust`, so none of it
+runs, every vptr stays uninitialised, and `ostream`'s `_discard()` — dispatched
+through `*o->std::ostream@vtable_pointer->…` — dereferences it. The NULL
+dereference at `ostream:138` is that, one call later.
+
+**It does not fit the arm table, and that is the finding.** `gen_vptr_initializations`
+takes a `symbolt &` and emits statements at the front of a constructor body: it is
+per-symbol code *generation*, not a per-node rewrite. §3.1 settled how a C++ pass
+dispatches arms; it said nothing about a pass that also has to synthesise code.
+`adjust()` walks values and applies the table, and has no hook for this.
+
+So the next step is not a fourth arm but a second kind of work in the pass, and
+the order matters — the vptr writes must precede the constructor's own body, as
+the legacy pass arranges. `clang_cpp_adjust` has one further step of this shape,
+`finalize_exception_specification`, so the hook wants to take both rather than be
+built for one.
+
+**A second divergence the same diff shows**, unrelated and smaller: a ternary over
+string literals decays per arm on the default path (`val ? &"1"[0] : &"0"[0]`) and
+as a whole on the hop-off (`&(val ? "1" : "0")[0]`). That is §134.4's ternary decay
+in `scope-clang-c-irep2.md`, recorded there as not reaching symex on C; on C++ it
+reaches the goto program. Worth its own row rather than being folded into the vptr
+work.
 
 ## 4. What does not exist yet
 
@@ -700,8 +738,10 @@ spellings (§33) — so W3's carriage problem lands here first.
    is missing: write the member-call arm first (54 of 57 real divergences).
 6. ~~Port the `exception_id` assignment~~ — **done**, §3.4, PR #7719. Crashes are
    gone; the residue is the builtin spelling the seam drops.
-7. Fix the `ostream`/`const char *` overload's false alarm (§3.5) — one cause
-   behind all 23 remaining real divergences, reduced to two lines. Instrument the
-   argument conversion; do not infer the binding.
+7. Give the pass a per-symbol code-generation hook and port
+   `gen_vptr_initializations` into it (§3.6) — 0 of 55 vptr writes happen today,
+   which is the cause behind all 23 remaining real divergences. Take
+   `finalize_exception_specification` at the same time.
+8. Then §134.4's ternary decay, which reaches the goto program on C++ (§3.6).
 
 Only then does a slice make sense.

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -366,9 +366,9 @@ the table is `static const` on the base, so a C++ row has nowhere to go.
 virtuals re-imports the per-statement seams the unified
 `adjust_statement_condition` removed, and only where C++ needs them.
 
-**What does work — B′: each frontend owns a table typed on its own class, and
-the runner becomes a template.** Four properties, each compiled rather than
-recalled:
+**What works: each frontend owns a table typed on its own class, and the runner
+becomes a template.** Five properties, each compiled rather than recalled — and
+the fifth changed the design:
 
 | property | result |
 |---|---|
@@ -376,6 +376,28 @@ recalled:
 | a table of `void (Derived::*)(…)` | holds **both** `&Derived::own` and `&Base::shared`, via the implicit base→derived member-pointer conversion |
 | that table declared `constexpr` | **0 dynamic initialisers** — constant-initialisation survives, which is the property the table's own comment protects |
 | `template <class T, size_t N> run_all(T &, const Row (&)[N], …)` | drives either frontend's table |
+| the same table compiled with `-Werror` | clang 18 clean at `-O0` and `-O2`; **GCC 13.3 fails at `-O2`** |
+
+**And that last row is why the member pointer is the wrong carrier.** Legal is
+not enough: once the runner inlines, GCC's array-bounds analysis reads the
+member-pointer discriminator as a vtable index and rejects the call —
+
+```
+error: array subscript 'int (**)(...)[0]' is partly outside array bounds
+       of 'Derived [1]' [-Werror=array-bounds=]
+```
+
+clean at `-O0`, failing at `-O2`, and clang accepts both. ESBMC builds locally
+with GCC and has an `ENABLE_WERROR` option, so B′ as first written would break a
+developer build while passing CI — the worst way round.
+
+**B″, which is what landed (PR #7714).** Each row carries a trampoline —
+`void (*)(Pass &, expr2tc &)`, a captureless lambda the `ARM` macro generates —
+instead of a pointer-to-member. There is then no base→derived conversion for the
+analysis to mis-read, the row is still an address constant (0 dynamic
+initialisers, re-measured), and both compilers accept it at both levels. The 24
+C rows keep their order and the goto program is byte-identical on all 95
+`irep2_only` tests.
 
 So a `clang_cpp_adjust_irep2` table can list the 24 inherited C arms **by name**
 alongside its own, in one ordered table, with no virtual dispatch, no

--- a/docs/roadmap/scope-clang-cpp-irep2.md
+++ b/docs/roadmap/scope-clang-cpp-irep2.md
@@ -517,6 +517,49 @@ demanded — member-call lowering and exception-id assignment — is among the f
 corpus named a different arm than the names did. Treat §3's table as an inventory,
 not a work order.
 
+### 3.5 The residue is 23 false alarms with one cause, and no missed bugs (2026-09-10)
+
+With the crashes gone, the 29 remaining divergences over the 80-test sample split
+by *direction* first, because that is the question that matters for a verifier:
+
+| direction | count |
+|---|---:|
+| false alarm — default SUCCESSFUL, hop-off FAILED | **23** |
+| **missed bug — default FAILED, hop-off SUCCESSFUL** | **0** |
+| no verdict on one side (multi-file tests the sweep fed one source) | 6 |
+
+**Zero missed bugs.** Every divergence the C++ hop-off produces today is in the
+loud direction. That is worth stating explicitly: a pass under construction that
+over-reports is a nuisance, one that under-reports is a soundness hole, and this
+one has not produced a single instance of the latter across the sample.
+
+All 23 false alarms share one property:
+
+```
+file /esbmc-vfs/cpp/ostream line 138 column 3 function operator<<
+dereference failure: NULL pointer
+```
+
+which is `o._put_field(val, strlen(val))` in
+`operator<<(ostream &, const char *)`. Reduced:
+
+```cpp
+#include <iostream>
+int main() { const char *p = "hi"; std::cout << p; return 0; }
+```
+
+default SUCCESSFUL, hop-off FAILED. The literal form (`std::cout << "hi"`) fails
+identically, so it is not the array-to-pointer decay of a string literal — an
+already-decayed pointer argument reproduces it.
+
+What the trace says, and what it does not: the violated property is at **State 1**
+with no assignment before it, so the call is not being set up rather than an
+argument holding a wrong value. That points at parameter binding for this
+overload — its first parameter is `ostream &`, i.e. the reference machinery §2.6
+touched — but the counterexample does not name which binding, and guessing is how
+§3's mapping table got two arms wrong. The next step is to instrument the argument
+conversion for this call rather than infer it.
+
 ## 4. What does not exist yet
 
 - **No hop-off flag** — though a census instrument now exists, §4.1.
@@ -657,7 +700,8 @@ spellings (§33) — so W3's carriage problem lands here first.
    is missing: write the member-call arm first (54 of 57 real divergences).
 6. ~~Port the `exception_id` assignment~~ — **done**, §3.4, PR #7719. Crashes are
    gone; the residue is the builtin spelling the seam drops.
-7. Then the remaining verdict divergences (15 of 80 report FAILED where the
-   default path succeeds).
+7. Fix the `ostream`/`const char *` overload's false alarm (§3.5) — one cause
+   behind all 23 remaining real divergences, reduced to two lines. Instrument the
+   argument conversion; do not infer the binding.
 
 Only then does a slice make sense.

--- a/regression/esbmc-cpp/cpp/irep2_migrate_census/main.cpp
+++ b/regression/esbmc-cpp/cpp/irep2_migrate_census/main.cpp
@@ -1,0 +1,22 @@
+/* The census migrates every adjusted symbol through IREP2 and must leave the
+   program alone: a reference and a heap object between them cover the shapes
+   whose migration is least trivial. */
+#include <cassert>
+
+struct pair
+{
+  int a;
+  int b;
+};
+
+int main()
+{
+  pair p{1, 2};
+  int &r = p.a;
+  r = 3;
+  int *h = new int(4);
+  int sum = p.a + p.b + *h;
+  delete h;
+  assert(sum == 9);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/irep2_migrate_census/test.desc
+++ b/regression/esbmc-cpp/cpp/irep2_migrate_census/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--clang-cpp-irep2-migrate-census
+^IREP2 migrate census: \d+ symbols, \d+ values migrated, ([2-9]|[1-9]\d+) type kinds, 0 failures$
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/irep2_migrate_census_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/irep2_migrate_census_fail/main.cpp
@@ -1,0 +1,22 @@
+/* The census migrates every adjusted symbol through IREP2 and must leave the
+   program alone: a reference and a heap object between them cover the shapes
+   whose migration is least trivial. */
+#include <cassert>
+
+struct pair
+{
+  int a;
+  int b;
+};
+
+int main()
+{
+  pair p{1, 2};
+  int &r = p.a;
+  r = 3;
+  int *h = new int(4);
+  int sum = p.a + p.b + *h;
+  delete h;
+  assert(sum == 8);
+  return 0;
+}

--- a/regression/esbmc-cpp/cpp/irep2_migrate_census_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/irep2_migrate_census_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.cpp
+--clang-cpp-irep2-migrate-census
+^IREP2 migrate census: \d+ symbols, \d+ values migrated, ([2-9]|[1-9]\d+) type kinds, 0 failures$
+^VERIFICATION FAILED$

--- a/src/clang-cpp-frontend/clang_cpp_language.cpp
+++ b/src/clang-cpp-frontend/clang_cpp_language.cpp
@@ -9,6 +9,7 @@ CC_DIAGNOSTIC_POP()
 #include <c2goto/cprover_library.h>
 #include <clang-cpp-frontend/clang_cpp_main.h>
 #include <clang-cpp-frontend/clang_cpp_adjust.h>
+#include <set>
 #include <clang-cpp-frontend/clang_cpp_convert.h>
 #include <clang-cpp-frontend/clang_cpp_language.h>
 #include <util/lang/cpp_expr2string.h>
@@ -145,6 +146,53 @@ void clang_cpp_languaget::set_language_version()
     config.language.cpp_std = cxx_stdt::cpp98;
 }
 
+/// Phase 7 census: force migrate_type/migrate_expr over every symbol this TU
+/// contributed and discard the result, to find what the C++ frontend emits that
+/// IREP2 cannot represent. Runs after c_link so migrate_namespace_lookup can
+/// resolve the TU's own symbols: before the link they are all absent from it,
+/// and sym_name_to_symbol then substitutes the expression's own type for
+/// migrate_symbol_type's, which is the case migrate.cpp warns hashes wrongly.
+///
+/// Migration reports failure by throwing a std::string, so each symbol is
+/// wrapped: one unrepresentable construct names itself and the walk continues,
+/// which is what makes this a census rather than a bisection.
+///
+/// Walks the whole linked context, operational models included, which is the
+/// set goto_convert migrates anyway. On a multi-TU run the later counts
+/// therefore include the earlier TUs' symbols.
+/// Rejected alternatives, and what it measured: scope-clang-cpp-irep2.md §4.
+static void migrate_census(const contextt &context)
+{
+  unsigned long symbols = 0, values = 0, failures = 0;
+  // The kind tally is what stops the census being vacuous: a count of symbols
+  // or values is identical on either representation, so swapping get_type2()
+  // for get_type() would migrate nothing and print the same line. A type_id
+  // exists only on the IREP2 side.
+  std::set<unsigned> kinds;
+  context.foreach_operand_in_order(
+    [&symbols, &values, &failures, &kinds](const symbolt &s) {
+      ++symbols;
+      try
+      {
+        kinds.insert(static_cast<unsigned>(s.get_type2()->type_id));
+        if (!is_nil_expr(s.get_value2()))
+          ++values;
+      }
+      catch (const std::string &e)
+      {
+        ++failures;
+        log_error("IREP2 migrate census: {} on symbol {}", e, s.id);
+      }
+    });
+  log_status(
+    "IREP2 migrate census: {} symbols, {} values migrated, {} type kinds, {} "
+    "failures",
+    symbols,
+    values,
+    kinds.size(),
+    failures);
+}
+
 bool clang_cpp_languaget::typecheck(
   contextt &context,
   const std::string &module)
@@ -165,7 +213,13 @@ bool clang_cpp_languaget::typecheck(
   if (adjuster.adjust())
     return true;
 
-  return c_link(context, new_context, module);
+  if (c_link(context, new_context, module))
+    return true;
+
+  if (config.options.get_bool_option("clang-cpp-irep2-migrate-census"))
+    migrate_census(context);
+
+  return false;
 }
 
 bool clang_cpp_languaget::final(contextt &context)

--- a/src/esbmc/options.cpp
+++ b/src/esbmc/options.cpp
@@ -200,7 +200,12 @@ const struct group_opt_templ all_cmd_options[] = {
      "Diagnostic: make the IREP2-native C adjuster refresh every symbol's "
      "legacy value, not only the ones it changed. Without it a body the pass "
      "did not touch still prints its converter tree under "
-     "--symbol-table-only, which is not what the pass produced"}}},
+     "--symbol-table-only, which is not what the pass produced"},
+    {"clang-cpp-irep2-migrate-census",
+     NULL,
+     "Diagnostic: migrate every adjusted C++ symbol through IREP2 and report "
+     "the count, to find what the C++ frontend emits that IREP2 cannot "
+     "represent (Phase 7; read-only, default off)"}}},
 #ifdef ENABLE_PYTHON_FRONTEND
   {"Python frontend",
    {


### PR DESCRIPTION
**Stacked on #7711** (the C++ migrate census); review that first.

§3 of the Phase 7 scope recorded two options for giving C++ an IREP2 adjuster and
recommended pricing one against the other. Measured against the table #7455
actually built, the answer is neither.

**Option B as recorded cannot compile.** `arm::run` is
`void (clang_c_adjust_irep2::*)(expr2tc &)` and `arms[]` is `static const` on the
base, so "a second frontend supplies its own table entries" has nowhere to put a
derived row: a derived member-pointer does not convert to the base's type.

**Option A stays the wrong shape** for §3's own reason — retrofitting virtuals
re-imports the per-statement seams that unifying `adjust_statement_condition`
removed, and only where C++ needs them.

**B′ works and is cheap**: each frontend owns a table typed on its own class,
and the runner becomes a template. Four compiled probes:

- `decltype(&Derived::shared)` is `void (Base::*)(…)` — the naming class decides,
  so the 24 C rows keep their type.
- A table of `void (Derived::*)(…)` holds both `&Derived::own` and
  `&Base::shared`, via the implicit base→derived member-pointer conversion.
- Declared `constexpr`, that table produces **zero** dynamic initialisers, so
  constant-initialisation — the property the table's own comment protects —
  survives.
- A `template <class T, size_t N>` runner drives either table.

So a C++ table can list the inherited C arms by name alongside its own, with no
virtual dispatch and no start-up cost, and the C table does not change. The cost
is confined to `arm`, `adjust_sole_arms` and `arm_order()`.

Docs only — no code changes. What it does not settle is *which* arms C++ needs;
§3's mapping table already answers that and §4.1 says representation will not
obstruct it.

Refs #4715
