### PR TITLE
[irep2] Make the IREP2 adjust arm table generic over the pass

### DIFF
--- a/src/clang-c-frontend/clang_c_adjust_irep2.cpp
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.cpp
@@ -314,7 +314,9 @@ void clang_c_adjust_irep2::adjust_comma_type(expr2tc &expr)
 
 /// Name and member from one token, so the string the ordering test matches on
 /// and the member it names cannot drift apart.
-#define ARM(member) #member, &clang_c_adjust_irep2::member
+#define ARM(member)                                                            \
+#  member,                                                                     \
+    +[](clang_c_adjust_irep2 & self, expr2tc & expr) { self.member(expr); }
 
 /// The arms that run when this pass is the sole adjuster, in application order.
 ///
@@ -371,9 +373,7 @@ std::vector<clang_c_adjust_irep2::arm_info> clang_c_adjust_irep2::arm_order()
 
 void clang_c_adjust_irep2::adjust_sole_arms(expr2tc &expr)
 {
-  for (const arm &a : arms)
-    if (!a.when || a.when(expr))
-      (this->*a.run)(expr);
+  run_adjust_arms(*this, arms, expr);
 }
 
 /// One of a family of spellings differing only by the argument's width:

--- a/src/clang-c-frontend/clang_c_adjust_irep2.h
+++ b/src/clang-c-frontend/clang_c_adjust_irep2.h
@@ -3,6 +3,7 @@
 #include <util/symtab/context.h>
 #include <util/symtab/namespace.h>
 #include <irep2/irep2.h>
+#include <cstddef>
 #include <vector>
 
 /// Phase 6 (C.3) IREP2-native adjuster for the C frontend.
@@ -32,6 +33,40 @@
 /// it does for Python after `clang_cpp_adjust`; for C it does not. 12 of the
 /// 1686 tests in regression/esbmc reach it. Left unguarded on purpose: this is
 /// the defect the walk exists to surface, and the flag is opt-in.
+/// One arm of an IREP2 adjust pass's dispatch: its name, the guard that decides
+/// whether it claims a node, and the rewrite it then applies. A null `when` is
+/// offered every node and guards itself.
+///
+/// Templated on the pass so a second frontend can order the arms it inherits
+/// alongside its own in one table. `run` is a trampoline rather than a
+/// pointer-to-member deliberately: a base member pointer stored in a
+/// derived-typed table is legal, but GCC 13's array-bounds analysis mis-reads
+/// the call once the runner inlines and rejects it at -O2
+/// (docs/roadmap/scope-clang-cpp-irep2.md §3.1). A captureless lambda converts
+/// to a function pointer and is an address constant, so the table stays
+/// constant-initialised.
+template <class Pass>
+struct adjust_arm
+{
+  const char *name;
+  void (*run)(Pass &, expr2tc &);
+  bool (*when)(const expr2tc &);
+};
+
+/// Apply a pass's arms to one node in table order. Each guard is re-evaluated
+/// against the current node, so an arm that rewrites a node into another kind
+/// hands it to that kind's arm below.
+template <class Pass, std::size_t N>
+void run_adjust_arms(
+  Pass &self,
+  const adjust_arm<Pass> (&arms)[N],
+  expr2tc &expr)
+{
+  for (const adjust_arm<Pass> &a : arms)
+    if (!a.when || a.when(expr))
+      a.run(self, expr);
+}
+
 class clang_c_adjust_irep2
 {
 public:
@@ -218,15 +253,7 @@ private:
   /// as adjust_comma_at_dispatch, which the --clang-c-irep2-adjust probe uses.
   void adjust_comma_type(expr2tc &expr);
 
-  /// One arm of adjust_sole_arms' dispatch: its name, the guard that decides
-  /// whether it claims a node, and the rewrite it then applies. A null `when`
-  /// is offered every node and guards itself.
-  struct arm
-  {
-    const char *name;
-    void (clang_c_adjust_irep2::*run)(expr2tc &);
-    bool (*when)(const expr2tc &);
-  };
+  using arm = adjust_arm<clang_c_adjust_irep2>;
 
   /// The chain in application order. Defined in clang_c_adjust_irep2.cpp,
   /// beside the predicates it names. An unknown-bound declaration completed

--- a/unit/clang-c-frontend/adjust_arms.test.cpp
+++ b/unit/clang-c-frontend/adjust_arms.test.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace
@@ -327,4 +328,47 @@ int main(int argc, char *argv[])
   // would race its constructor (unit/util/c_typecast.test.cpp does the same).
   config.ansi_c.set_data_model(configt::LP64);
   return Catch::Session().run(argc, argv);
+}
+
+// A second frontend has to be able to order the arms it inherits alongside its
+// own in one table. That rests on three language properties, and the table is
+// the only place they are relied on, so pin them here rather than in a comment
+// (docs/roadmap/scope-clang-cpp-irep2.md §3.1).
+namespace
+{
+struct base_pass
+{
+  int seen = 0;
+  void inherited(expr2tc &)
+  {
+    seen |= 1;
+  }
+};
+
+struct derived_pass : base_pass
+{
+  void own(expr2tc &)
+  {
+    seen |= 2;
+  }
+};
+
+// Constant-initialised: a dynamic initialiser here would cost start-up work on
+// every run, which is why the real table is declared the way it is.
+constexpr adjust_arm<derived_pass> mixed_table[] = {
+  {"inherited", +[](derived_pass &s, expr2tc &e) { s.inherited(e); }, nullptr},
+  {"own", +[](derived_pass &s, expr2tc &e) { s.own(e); }, nullptr},
+};
+} // namespace
+
+TEST_CASE(
+  "a derived pass's table holds inherited and own arms",
+  "[core][clang-c-frontend]")
+{
+  derived_pass pass;
+  expr2tc node = gen_zero(get_int_type(32));
+  run_adjust_arms(pass, mixed_table, node);
+
+  // Both arms ran, through one table typed on the derived pass.
+  REQUIRE(pass.seen == 3);
 }


### PR DESCRIPTION
Phase 7 needs a C++ adjuster that can order the arms it inherits from the C pass
alongside its own in one table, and `arm::run` was
`void (clang_c_adjust_irep2::*)(expr2tc &)` on a `static const` member of that
class — so a derived row had nowhere to go.

`adjust_arm` and `run_adjust_arms` are now templated on the pass.

**Each row carries a trampoline rather than a pointer-to-member, for a measured
reason.** Storing a base member pointer in a derived-typed table is legal and
stays constant-initialisable, but GCC 13.3 mis-reads the call once the runner
inlines and rejects it:

```
error: array subscript 'int (**)(...)[0]' is partly outside array bounds
       of 'Derived [1]' [-Werror=array-bounds=]
```

Measured across both toolchains on a reduced probe: clang 18 accepts it at `-O0`
and `-O2`; GCC is clean at `-O0` and fails at `-O2`, i.e. only once inlined. A
captureless lambda converts to a function pointer, sidesteps the analysis, and is
still an address constant — `nm | grep GLOBAL__sub_I` finds no dynamic
initialiser either way, which is the property the table's own comment protects.

**Behaviour-preserving.** The 24 C rows and their order are untouched; the goto
program is byte-identical on all 95 `regression/esbmc/irep2_only_*` tests against
a binary built from master; 855 unit tests pass.

`unit/clang-c-frontend/adjust_arms.test.cpp` gains a case that builds a
`constexpr` table typed on a derived pass, holding one inherited and one own arm,
and asserts both run — so the template parameter is exercised for more than one
pass rather than being untested generality.

Refs #4715
