### PR TITLE
[python] Address review on the tagged-scalar list fix

### DIFF
--- a/regression/python/dynamic_type_scalar_tag_list_float/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_float/main.py
@@ -1,0 +1,12 @@
+# A tag holding a float keeps its type through a list round-trip. Comparing a
+# tag against a float literal is not supported yet, so this pins the type_id.
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+if cond:
+    x = 1.5
+lst = []
+lst.append(x)
+assert isinstance(lst[0], float) or isinstance(lst[0], str)

--- a/regression/python/dynamic_type_scalar_tag_list_float/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_float/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_list_float_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_float_fail/main.py
@@ -3,6 +3,8 @@ if cond:
     x = 1
 else:
     x = "a"
+if cond:
+    x = 1.5
 lst = []
 lst.append(x)
-assert lst[0] == 1
+assert isinstance(lst[0], float)

--- a/regression/python/dynamic_type_scalar_tag_list_float_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_float_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_list_insert/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_insert/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+lst.insert(0, x)
+assert lst[0] == 1 or lst[0] == "a"
+assert lst[1] == 1 or lst[1] == "a"

--- a/regression/python/dynamic_type_scalar_tag_list_insert/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_insert/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_list_insert_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_insert_fail/main.py
@@ -3,6 +3,6 @@ if cond:
     x = 1
 else:
     x = "a"
-lst = []
-lst.append(x)
+lst = [x]
+lst.insert(0, x)
 assert lst[0] == 1

--- a/regression/python/dynamic_type_scalar_tag_list_insert_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_insert_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_list_store_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_store_fail/main.py
@@ -4,4 +4,4 @@ if cond:
 else:
     x = "a"
 lst = [x]
-assert lst[0] == 1 and lst[0] == "a"
+assert lst[0] == 1

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -204,17 +204,26 @@ bool __ESBMC_list_push(
   return true;
 }
 
-// Push an already-tagged scalar's own value/type_id/size. `size` may be
-// symbolic across branches (e.g. int vs str), so this copies with a bounded
-// loop rather than __ESBMC_copy_value's memcpy fallback, which never
-// finishes unwinding over a symbolic n.
-bool __ESBMC_list_push_tagged(
-  PyListObject *l,
+// Copy a tagged scalar's payload. `size` may be symbolic across branches (e.g.
+// int vs str), so this uses a bounded loop rather than __ESBMC_copy_value's
+// memcpy fallback, which never finishes unwinding over a symbolic n. A float
+// payload goes through __ESBMC_copy_value instead, so the element keeps this
+// library's invariant that a float's value lives in __ESBMC_float_buf at
+// float_idx -- __ESBMC_list_push_object and __ESBMC_list_push_shallow_sz both
+// read it back that way.
+static void *__ESBMC_copy_tagged_value(
   const void *value,
   size_t type_id,
-  size_t size)
+  size_t size,
+  size_t float_type_id,
+  size_t *out_float_idx)
 {
-  assert(l != NULL);
+  *out_float_idx = 0;
+
+  if (size == 8 && float_type_id != 0 && type_id == float_type_id)
+    return __ESBMC_copy_value(
+      value, size, type_id, float_type_id, out_float_idx, 0);
+
   __ESBMC_assert(
     size <= ESBMC_PY_STRNLEN_BOUND,
     "tagged list element exceeds the modelled bound");
@@ -226,10 +235,26 @@ bool __ESBMC_list_push_tagged(
       break;
     ((char *)copied)[i] = ((const char *)value)[i];
   }
+  return copied;
+}
+
+// Push an already-tagged scalar's own value/type_id/size.
+bool __ESBMC_list_push_tagged(
+  PyListObject *l,
+  const void *value,
+  size_t type_id,
+  size_t size,
+  size_t float_type_id)
+{
+  assert(l != NULL);
+
+  size_t float_idx = 0;
+  void *copied =
+    __ESBMC_copy_tagged_value(value, type_id, size, float_type_id, &float_idx);
 
   PyObject *item = &l->items[l->size];
   item->value = copied;
-  item->float_idx = 0;
+  item->float_idx = float_idx;
   item->type_id = type_id;
   item->size = size;
   l->size++;
@@ -629,15 +654,15 @@ bool __ESBMC_list_insert(
   return true;
 }
 
-// Insert variant of __ESBMC_list_push_tagged: `size` may be symbolic, so this
-// copies with the same bounded loop rather than __ESBMC_copy_value's memcpy
-// fallback.
+// Insert variant of __ESBMC_list_push_tagged. Index normalisation matches
+// __ESBMC_list_insert.
 bool __ESBMC_list_insert_tagged(
   PyListObject *l,
   int64_t index,
   const void *value,
   size_t type_id,
-  size_t size)
+  size_t size,
+  size_t float_type_id)
 {
   int64_t n = (int64_t)l->size;
   if (index < 0)
@@ -648,18 +673,11 @@ bool __ESBMC_list_insert_tagged(
   }
 
   if (index >= n)
-    return __ESBMC_list_push_tagged(l, value, type_id, size);
+    return __ESBMC_list_push_tagged(l, value, type_id, size, float_type_id);
 
-  __ESBMC_assert(
-    size <= ESBMC_PY_STRNLEN_BOUND,
-    "tagged list element exceeds the modelled bound");
-  void *copied = __ESBMC_alloca(size);
-  for (size_t i = 0; i < ESBMC_PY_STRNLEN_BOUND; ++i)
-  {
-    if (i >= size)
-      break;
-    ((char *)copied)[i] = ((const char *)value)[i];
-  }
+  size_t float_idx = 0;
+  void *copied =
+    __ESBMC_copy_tagged_value(value, type_id, size, float_type_id, &float_idx);
 
   size_t i = l->size;
   while (i > (size_t)index)
@@ -669,7 +687,7 @@ bool __ESBMC_list_insert_tagged(
   }
 
   l->items[index].value = copied;
-  l->items[index].float_idx = 0;
+  l->items[index].float_idx = float_idx;
   l->items[index].type_id = type_id;
   l->items[index].size = size;
   l->size++;

--- a/src/python-frontend/python-list/list_mutation.cpp
+++ b/src/python-frontend/python-list/list_mutation.cpp
@@ -5,45 +5,58 @@
 using namespace python_expr;
 using namespace python_list_detail;
 
+// A tagged (PyObject-shaped) element already carries its own runtime
+// value/type_id/size -- hashing its wrapper struct's static C type would bake
+// in a single compile-time type_id, losing whichever branch actually ran.
+// Forward its own fields instead, exactly like list elements already store
+// their type_id alongside the value.
+list_elem_info python_list::get_tagged_element_info(
+  const nlohmann::json &op,
+  const exprt &elem)
+{
+  const locationt location = converter_.get_location_from_decl(op);
+
+  symbolt &elem_type_sym =
+    converter_.create_tmp_symbol(op, "$list_elem_type$", size_type(), exprt());
+  code_assignt type_id_assign(
+    build_symbol(elem_type_sym), build_member(elem, "type_id", size_type()));
+  type_id_assign.location() = location;
+  converter_.add_instruction(type_id_assign);
+
+  const typet char_ptr_type = pointer_typet(char_type());
+  symbolt &elem_symbol = converter_.create_tmp_symbol(
+    op, "$list_elem_value$", char_ptr_type, exprt());
+  code_assignt value_assign(
+    build_symbol(elem_symbol),
+    build_typecast(
+      build_member(elem, "value", pointer_typet(empty_typet())),
+      char_ptr_type));
+  value_assign.location() = location;
+  converter_.add_instruction(value_assign);
+
+  list_elem_info tagged_info;
+  tagged_info.elem_type_sym = &elem_type_sym;
+  tagged_info.elem_symbol = &elem_symbol;
+  tagged_info.elem_size = build_member(elem, "size", size_type());
+  tagged_info.location = location;
+  return tagged_info;
+}
+
+// The tag stamps a float payload with the hash of `double`, the same hash the
+// non-tagged push path passes as float_type_id, so the model can route it
+// through __ESBMC_float_buf.
+exprt python_list::tagged_float_type_id(bool enable_float_path) const
+{
+  if (!enable_float_path)
+    return from_integer(BigInt(0), size_type());
+  return converter_.get_type_handler().tagged_scalar_type_id(double_type());
+}
+
 list_elem_info
 python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
 {
   const type_handler type_handler_ = converter_.get_type_handler();
   locationt location = converter_.get_location_from_decl(op);
-
-  // A tagged (PyObject-shaped) element already carries its own runtime
-  // value/type_id/size -- hashing its wrapper struct's static C type here
-  // would bake in a single compile-time type_id, losing whichever branch
-  // actually ran. Forward its own fields instead, exactly like list
-  // elements already store their type_id alongside the value.
-  if (type_handler_.is_tagged_scalar_type(elem.type()))
-  {
-    symbolt &elem_type_sym = converter_.create_tmp_symbol(
-      op, "$list_elem_type$", size_type(), exprt());
-    code_assignt type_id_assign(
-      build_symbol(elem_type_sym), build_member(elem, "type_id", size_type()));
-    type_id_assign.location() = location;
-    converter_.add_instruction(type_id_assign);
-
-    const typet char_ptr_type = pointer_typet(char_type());
-    symbolt &elem_symbol = converter_.create_tmp_symbol(
-      op, "$list_elem_value$", char_ptr_type, exprt());
-    code_assignt value_assign(
-      build_symbol(elem_symbol),
-      build_typecast(
-        build_member(elem, "value", pointer_typet(empty_typet())),
-        char_ptr_type));
-    value_assign.location() = location;
-    converter_.add_instruction(value_assign);
-
-    list_elem_info tagged_info;
-    tagged_info.elem_type_sym = &elem_type_sym;
-    tagged_info.elem_symbol = &elem_symbol;
-    tagged_info.elem_size = build_member(elem, "size", size_type());
-    tagged_info.location = location;
-    tagged_info.is_tagged_scalar = true;
-    return tagged_info;
-  }
 
   const std::string elem_type_name = type_handler_.type_to_string(elem.type());
 
@@ -299,10 +312,9 @@ exprt python_list::build_push_list_call(
   const exprt &elem,
   bool enable_float_path)
 {
-  list_elem_info elem_info = get_list_element_info(op, elem);
-
-  if (elem_info.is_tagged_scalar)
+  if (converter_.get_type_handler().is_tagged_scalar_type(elem.type()))
   {
+    const list_elem_info elem_info = get_tagged_element_info(op, elem);
     const symbolt *push_tagged_sym =
       converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push_tagged");
     if (!push_tagged_sym)
@@ -316,10 +328,14 @@ exprt python_list::build_push_list_call(
     push_tagged_call.arguments().push_back(
       build_symbol(*elem_info.elem_type_sym));
     push_tagged_call.arguments().push_back(elem_info.elem_size);
+    push_tagged_call.arguments().push_back(
+      tagged_float_type_id(enable_float_path));
     push_tagged_call.type() = bool_type();
     push_tagged_call.location() = elem_info.location;
     return push_tagged_call;
   }
+
+  list_elem_info elem_info = get_list_element_info(op, elem);
 
   const symbolt *push_func_sym =
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_push");
@@ -423,10 +439,9 @@ exprt python_list::build_insert_list_call(
   const nlohmann::json &op,
   const exprt &elem)
 {
-  list_elem_info elem_info = get_list_element_info(op, elem);
-
-  if (elem_info.is_tagged_scalar)
+  if (converter_.get_type_handler().is_tagged_scalar_type(elem.type()))
   {
+    const list_elem_info elem_info = get_tagged_element_info(op, elem);
     const symbolt *insert_tagged_sym =
       converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_insert_tagged");
     if (!insert_tagged_sym)
@@ -441,10 +456,13 @@ exprt python_list::build_insert_list_call(
     insert_tagged_call.arguments().push_back(
       build_symbol(*elem_info.elem_type_sym));
     insert_tagged_call.arguments().push_back(elem_info.elem_size);
+    insert_tagged_call.arguments().push_back(tagged_float_type_id(true));
     insert_tagged_call.type() = bool_type();
     insert_tagged_call.location() = elem_info.location;
     return converter_.convert_expression_to_code(insert_tagged_call);
   }
+
+  const list_elem_info elem_info = get_list_element_info(op, elem);
 
   const symbolt *insert_func_sym =
     converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_insert");

--- a/src/python-frontend/python-list/python_list.h
+++ b/src/python-frontend/python-list/python_list.h
@@ -21,10 +21,6 @@ struct list_elem_info
   symbolt *elem_symbol;
   exprt elem_size;
   locationt location;
-  // True when elem_symbol already holds the element's raw value pointer
-  // (its size may be symbolic post-join), so callers must use the
-  // bounded-copy push/insert path instead of the generic byte-copy one.
-  bool is_tagged_scalar = false;
 };
 
 class python_list
@@ -622,6 +618,13 @@ private:
 
   list_elem_info
   get_list_element_info(const nlohmann::json &op, const exprt &elem);
+
+  list_elem_info
+  get_tagged_element_info(const nlohmann::json &op, const exprt &elem);
+
+  // The type_id a tagged scalar carries when it holds a float, or 0 when the
+  // caller opts out of the float path (dict values compare via void*).
+  exprt tagged_float_type_id(bool enable_float_path) const;
 
   symbolt &create_list();
 


### PR DESCRIPTION
Addresses the review on #7708. `__ESBMC_list_push_tagged` stamped `float_idx = 0`
on every element, so a tagged float (`type_id == float_type_id`, size 8) would
later be read back from `__ESBMC_float_buf[0]`; both tagged helpers now share one
copy routine that takes the float path when the payload is a float. The tagged
dispatch also moves out of `get_list_element_info`, where it fired for the dict,
set-ops and query callers that pass a raw value pointer where an address is
expected, and pushed the function past the core complexity threshold.

Tests: `dynamic_type_scalar_tag_list_insert{,_fail}` and
`dynamic_type_scalar_tag_list_float{,_fail}`; the two existing `*_fail` cases
asserted `lst[0] == 1 and lst[0] == "a"`, which no element satisfies, and now
assert `lst[0] == 1`. Comparing a tag against a float literal is unsupported, so
the float pair pins the `type_id` via `isinstance`.
