### PR TITLE
[python] Compare two lists of tagged scalars with a bounded compare

### DIFF
--- a/regression/python/dynamic_type_scalar_tag_list_count_unsupported/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_count_unsupported/main.py
@@ -1,0 +1,10 @@
+# count/index/remove over a tagged element are not modelled: the untagged
+# element-info path stamps the wrapper's static type hash, which never matches
+# the element's runtime type_id, and count then proved `count(x) == 0`.
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+assert lst.count(x) == 0

--- a/regression/python/dynamic_type_scalar_tag_list_count_unsupported/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_count_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: this list operation on a dynamically-typed element is not yet supported$

--- a/regression/python/dynamic_type_scalar_tag_list_eq/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_eq/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+a = [x]
+b = [x]
+assert a == b

--- a/regression/python/dynamic_type_scalar_tag_list_eq/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_eq/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_list_eq_cross/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_eq_cross/main.py
@@ -1,0 +1,12 @@
+# A tagged element compares equal to the plain element it holds, in both
+# directions, so the tagged path is not answering "unequal" for everything.
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+a = [x]
+if cond:
+    assert a == [1]
+else:
+    assert a == ["a"]

--- a/regression/python/dynamic_type_scalar_tag_list_eq_cross/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_eq_cross/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_list_eq_cross_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_eq_cross_fail/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+a = [x]
+if cond:
+    assert a == ["a"]

--- a/regression/python/dynamic_type_scalar_tag_list_eq_cross_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_eq_cross_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_list_eq_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_eq_fail/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+a = [x]
+b = [1]
+assert a == b

--- a/regression/python/dynamic_type_scalar_tag_list_eq_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_eq_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_scalar_tag_list_extend/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_extend/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+lst.extend([x])
+assert len(lst) == 2
+assert lst[1] == 1 or lst[1] == "a"

--- a/regression/python/dynamic_type_scalar_tag_list_extend/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_extend/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_list_extend_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_extend_fail/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+lst.extend([x])
+assert len(lst) == 1

--- a/regression/python/dynamic_type_scalar_tag_list_extend_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_extend_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -906,6 +906,33 @@ void __ESBMC_list_extend(
   }
 }
 
+// Extend variant for a source list of tagged scalars: their payload width is
+// per-element and symbolic, so the elem_size above and __ESBMC_copy_value's
+// o->size fallback both overrun (#7716). Reuses the bounded copy.
+void __ESBMC_list_extend_tagged(
+  PyListObject *l,
+  const PyListObject *other,
+  size_t float_type_id)
+{
+  if (!l || !other)
+    return;
+
+  size_t i = 0;
+  while (i < other->size)
+  {
+    const PyObject *elem = &other->items[i];
+    if (elem->size == 0)
+    {
+      l->items[l->size] = *elem;
+      l->size++;
+    }
+    else
+      __ESBMC_list_push_tagged(
+        l, elem->value, elem->type_id, elem->size, float_type_id);
+    ++i;
+  }
+}
+
 void __ESBMC_list_clear(PyListObject *l)
 {
   if (!l)

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -4,6 +4,12 @@
 #include <string.h>
 #include "python_types.h"
 
+int __python_scalar_eq_obj(
+  const PyObject *a,
+  const PyObject *b,
+  size_t num_type_id,
+  size_t bool_type_id);
+
 // Allocate a Python object instance. The frontend emits a call to this for
 // `ClassName(...)` so class instances get CPython reference semantics (a
 // pointer to a non-expiring object) and survive escaping their defining
@@ -532,6 +538,31 @@ bool __ESBMC_list_eq(
         return false;
     }
   }
+  return true;
+}
+
+// Element-wise equality for two lists of tagged scalars (#7723). A tag only
+// ever holds a bool, int, float or str, so there is no nesting to walk and no
+// depth stack; and its payload width is symbolic after a branch join, so the
+// byte compare has to be the bounded one __python_scalar_eq_obj already
+// implements rather than __ESBMC_values_equal's memcmp fallback.
+bool __ESBMC_list_eq_tagged(
+  const PyListObject *l1,
+  const PyListObject *l2,
+  size_t num_type_id,
+  size_t bool_type_id)
+{
+  if (!l1 || !l2)
+    return false;
+  if (__ESBMC_same_object(l1, l2))
+    return true;
+  if (l1->size != l2->size)
+    return false;
+
+  for (size_t i = 0; i < l1->size; ++i)
+    if (!__python_scalar_eq_obj(
+          &l1->items[i], &l2->items[i], num_type_id, bool_type_id))
+      return false;
   return true;
 }
 

--- a/src/python-frontend/python-list/list_mutation.cpp
+++ b/src/python-frontend/python-list/list_mutation.cpp
@@ -52,10 +52,24 @@ exprt python_list::tagged_float_type_id(bool enable_float_path) const
   return converter_.get_type_handler().tagged_scalar_type_id(double_type());
 }
 
+// Only build_push_list_call and build_insert_list_call handle a tagged element;
+// they call get_tagged_element_info directly. Every other caller stamps the
+// hash of the wrapper's static C type, which never matches the element's
+// runtime type_id, so list.count() answered 0 and proved `count(x) == 0`.
+// Refuse the way `operator In` already does rather than answer wrongly.
+static void reject_tagged_element(const type_handler &th, const exprt &elem)
+{
+  if (th.is_tagged_scalar_type(elem.type()))
+    throw std::runtime_error(
+      "this list operation on a dynamically-typed element is not yet "
+      "supported");
+}
+
 list_elem_info
 python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
 {
   const type_handler type_handler_ = converter_.get_type_handler();
+  reject_tagged_element(type_handler_, elem);
   locationt location = converter_.get_location_from_decl(op);
 
   const std::string elem_type_name = type_handler_.type_to_string(elem.type());
@@ -1042,6 +1056,17 @@ bool python_list::has_tagged_elements(const exprt &list) const
   return false;
 }
 
+// Same split as select_shallow_push, for list.extend().
+python_list::shallow_push_call python_list::select_list_extend(
+  const exprt &src,
+  const exprt &untagged_elem_size) const
+{
+  const bool tagged = has_tagged_elements(src);
+  const symbolt *func = converter_.symbol_table().find_symbol(
+    tagged ? "c:@F@__ESBMC_list_extend_tagged" : "c:@F@__ESBMC_list_extend");
+  return {func, tagged ? tagged_float_type_id(true) : untagged_elem_size};
+}
+
 python_list::shallow_push_call python_list::select_shallow_push(
   const exprt &src,
   const exprt &untagged_last_arg) const
@@ -1065,10 +1090,6 @@ exprt python_list::build_extend_list_call(
   const nlohmann::json &op,
   const exprt &other_list)
 {
-  const symbolt *extend_func_sym =
-    converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_extend");
-  assert(extend_func_sym);
-
   locationt location = converter_.get_location_from_decl(op);
 
   exprt actual_list = other_list;
@@ -1267,14 +1288,14 @@ exprt python_list::build_extend_list_call(
   // element to be the same scalar width: extend applies one length to all of
   // them, so a mixed-width list must keep the model's symbolic elem->size
   // fallback (0).
-  BigInt elem_size_bytes = uniform_elem_size(actual_list);
+  const shallow_push_call extend_target = select_list_extend(
+    actual_list, from_integer(uniform_elem_size(actual_list), size_type()));
 
   code_function_callt extend_func_call;
-  extend_func_call.function() = build_symbol(*extend_func_sym);
+  extend_func_call.function() = build_symbol(*extend_target.func);
   extend_func_call.arguments().push_back(build_symbol(list));
   extend_func_call.arguments().push_back(actual_list);
-  extend_func_call.arguments().push_back(
-    from_integer(elem_size_bytes, size_type()));
+  extend_func_call.arguments().push_back(extend_target.last_arg);
   extend_func_call.type() = empty_typet();
   extend_func_call.location() = location;
 

--- a/src/python-frontend/python-list/list_query.cpp
+++ b/src/python-frontend/python-list/list_query.cpp
@@ -3,6 +3,25 @@
 using namespace python_expr;
 using namespace python_list_detail;
 
+python_list::list_eq_target python_list::select_list_eq(
+  const exprt &l1,
+  const exprt &l2,
+  const symbolt &generic_func,
+  const std::vector<exprt> &generic_trailing_args) const
+{
+  if (!has_tagged_elements(l1) && !has_tagged_elements(l2))
+    return {&generic_func, generic_trailing_args};
+
+  const symbolt *eq_tagged_sym =
+    converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_eq_tagged");
+  assert(eq_tagged_sym);
+  const type_handler &th = converter_.get_type_handler();
+  return {
+    eq_tagged_sym,
+    {th.tagged_scalar_type_id(long_long_int_type()),
+     th.tagged_scalar_type_id(bool_type())}};
+}
+
 exprt python_list::compare(
   const exprt &l1,
   const exprt &l2,
@@ -553,18 +572,25 @@ exprt python_list::compare(
     (lhs_elem_size != 0 && lhs_elem_size == rhs_elem_size) ? lhs_elem_size
                                                            : BigInt(0);
 
+  const list_eq_target eq_target = select_list_eq(
+    converted_l1,
+    converted_l2,
+    *list_eq_func_sym,
+    {list_type_id,
+     max_depth_expr,
+     from_integer(float_type_id, size_type()),
+     from_integer(eq_elem_size_bytes, size_type())});
+
   code_function_callt list_eq_func_call;
-  list_eq_func_call.function() = build_symbol(*list_eq_func_sym);
   list_eq_func_call.lhs() = build_symbol(eq_ret);
-  // passing arguments
-  list_eq_func_call.arguments().push_back(build_symbol(*lhs_symbol)); // l1
-  list_eq_func_call.arguments().push_back(build_symbol(*rhs_symbol)); // l2
-  list_eq_func_call.arguments().push_back(list_type_id);   // list_type_id
-  list_eq_func_call.arguments().push_back(max_depth_expr); // max_depth
-  list_eq_func_call.arguments().push_back(
-    from_integer(float_type_id, size_type())); // float_type_id
-  list_eq_func_call.arguments().push_back(
-    from_integer(eq_elem_size_bytes, size_type())); // elem_size
+  list_eq_func_call.function() = build_symbol(*eq_target.func);
+  exprt::operandst &eq_args = list_eq_func_call.arguments();
+  eq_args.push_back(build_symbol(*lhs_symbol)); // l1
+  eq_args.push_back(build_symbol(*rhs_symbol)); // l2
+  eq_args.insert(
+    eq_args.end(),
+    eq_target.trailing_args.begin(),
+    eq_target.trailing_args.end());
   list_eq_func_call.type() = bool_type();
   list_eq_func_call.location() = converter_.get_location_from_decl(list_value_);
   converter_.add_instruction(list_eq_func_call);

--- a/src/python-frontend/python-list/python_list.h
+++ b/src/python-frontend/python-list/python_list.h
@@ -591,6 +591,9 @@ public:
   shallow_push_call
   select_shallow_push(const exprt &src, const exprt &untagged_last_arg) const;
 
+  shallow_push_call
+  select_list_extend(const exprt &src, const exprt &untagged_elem_size) const;
+
   struct list_eq_target
   {
     const symbolt *func;

--- a/src/python-frontend/python-list/python_list.h
+++ b/src/python-frontend/python-list/python_list.h
@@ -591,6 +591,22 @@ public:
   shallow_push_call
   select_shallow_push(const exprt &src, const exprt &untagged_last_arg) const;
 
+  struct list_eq_target
+  {
+    const symbolt *func;
+    std::vector<exprt> trailing_args;
+  };
+
+  /** Equality entry point for `l1 == l2` and the arguments that follow the two
+   *  list operands. A tagged element has no single static width and cannot hold
+   *  a nested list, so neither elem_size nor the depth stack applies (#7723).
+   */
+  list_eq_target select_list_eq(
+    const exprt &l1,
+    const exprt &l2,
+    const symbolt &generic_func,
+    const std::vector<exprt> &generic_trailing_args) const;
+
   /**
    * @brief Unpack a list variable into multiple targets, supporting starred
    * expressions.


### PR DESCRIPTION
Comparing two lists of dynamically-typed (tagged) scalars did not terminate,
and gave the wrong answer when the unwinding was truncated. `uniform_elem_size`
measures the `PyObject` wrapper, so `__ESBMC_values_equal` read 32 bytes of a
payload that is 2 bytes for `"a"`; passing 0 instead falls back to the symbolic
`o->size`, where `memcmp` does not converge. `__ESBMC_list_eq_tagged` reuses
`__python_scalar_eq_obj`, which is already bounded and carries Python's type
rules, and a tag holds only a bool, int, float or str, so it needs neither the
nested-list branch nor the depth stack.

Fixes #7723

Tests: `dynamic_type_scalar_tag_list_eq{,_fail}` and
`dynamic_type_scalar_tag_list_eq_cross{,_fail}`. Both SUCCESSFUL cases hang
without the tagged dispatch; the cross pair pins that a tagged element still
compares equal to the plain element it holds, in both the int and str branches.
