### PR TITLE
[test] Pin signbit of a NaN under the native FP backend

### DIFF
--- a/regression/floats-regression/github_7021/main.c
+++ b/regression/floats-regression/github_7021/main.c
@@ -1,0 +1,14 @@
+// copysign(NAN, -2.0) is a NaN carrying the sign of -2.0, and signbit is
+// nonzero iff the sign is negative -- for a NaN as much as for a finite value
+// (C17 7.12.11.1, 7.12.3.6). The native-FP backend left the sign of a NaN
+// unconstrained, so this held under --fp2bv but not under --z3 (#7021).
+#include <assert.h>
+#include <math.h>
+
+int main(void)
+{
+  double s = copysign(NAN, -2.0);
+  assert(isnan(s));
+  assert(signbit(s));
+  return 0;
+}

--- a/regression/floats-regression/github_7021/test.desc
+++ b/regression/floats-regression/github_7021/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--z3 --multi-property
+^VERIFICATION SUCCESSFUL$
+^  PASSED +\[main\.assertion\.\d+\] +line +12 +assertion signbit\(s\)$

--- a/regression/floats-regression/github_7021_fail/main.c
+++ b/regression/floats-regression/github_7021_fail/main.c
@@ -1,0 +1,13 @@
+// Negative counterpart of github_7021: the NaN's sign comes from -2.0, so
+// signbit is nonzero and this assertion must be refuted rather than held
+// vacuously by an unconstrained sign.
+#include <assert.h>
+#include <math.h>
+
+int main(void)
+{
+  double s = copysign(NAN, -2.0);
+  assert(isnan(s));
+  assert(!signbit(s));
+  return 0;
+}

--- a/regression/floats-regression/github_7021_fail/test.desc
+++ b/regression/floats-regression/github_7021_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--z3 --multi-property
+^VERIFICATION FAILED$
+^  FAILED +\[main\.assertion\.\d+\] +line +11 +assertion !signbit\(s\)$


### PR DESCRIPTION
`copysign(NAN, -2.0)` is a NaN carrying the sign of `-2.0`, and `signbit` is
nonzero iff the sign is negative — for a NaN as much as for a finite value
(C17 7.12.11.1, 7.12.3.6). #7021 reported the native FP backend leaving a
NaN's sign unconstrained, so the assertion held under `--fp2bv` but not
under plain `--z3`.

Both spellings now agree with the host toolchain, but no test covered the
`--z3` path: `floats-regression/copysign` runs `--floatbv --interval-analysis`,
and the three `ir-ra` signbit tests are `--ir-ieee` underflow and negative-zero
cases. This adds the missing pair so the fix cannot regress silently. Each test
pins its named claim row, not just the verdict, and flipping either assertion
flips its verdict.

Fixes #7021