### PR TITLE
[python] Stop proving list.count() == 0 over a tagged element

### DIFF
--- a/regression/python/dynamic_type_scalar_tag_list_count_unsupported/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_count_unsupported/main.py
@@ -1,0 +1,10 @@
+# count/index/remove over a tagged element are not modelled: the untagged
+# element-info path stamps the wrapper's static type hash, which never matches
+# the element's runtime type_id, and count then proved `count(x) == 0`.
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+assert lst.count(x) == 0

--- a/regression/python/dynamic_type_scalar_tag_list_count_unsupported/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_count_unsupported/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^ERROR: this list operation on a dynamically-typed element is not yet supported$

--- a/regression/python/dynamic_type_scalar_tag_list_extend/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_extend/main.py
@@ -1,0 +1,9 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+lst.extend([x])
+assert len(lst) == 2
+assert lst[1] == 1 or lst[1] == "a"

--- a/regression/python/dynamic_type_scalar_tag_list_extend/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_extend/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_scalar_tag_list_extend_fail/main.py
+++ b/regression/python/dynamic_type_scalar_tag_list_extend_fail/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+lst.extend([x])
+assert len(lst) == 1

--- a/regression/python/dynamic_type_scalar_tag_list_extend_fail/test.desc
+++ b/regression/python/dynamic_type_scalar_tag_list_extend_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/c2goto/library/python/list.c
+++ b/src/c2goto/library/python/list.c
@@ -906,6 +906,33 @@ void __ESBMC_list_extend(
   }
 }
 
+// Extend variant for a source list of tagged scalars: their payload width is
+// per-element and symbolic, so the elem_size above and __ESBMC_copy_value's
+// o->size fallback both overrun (#7716). Reuses the bounded copy.
+void __ESBMC_list_extend_tagged(
+  PyListObject *l,
+  const PyListObject *other,
+  size_t float_type_id)
+{
+  if (!l || !other)
+    return;
+
+  size_t i = 0;
+  while (i < other->size)
+  {
+    const PyObject *elem = &other->items[i];
+    if (elem->size == 0)
+    {
+      l->items[l->size] = *elem;
+      l->size++;
+    }
+    else
+      __ESBMC_list_push_tagged(
+        l, elem->value, elem->type_id, elem->size, float_type_id);
+    ++i;
+  }
+}
+
 void __ESBMC_list_clear(PyListObject *l)
 {
   if (!l)

--- a/src/python-frontend/python-list/list_mutation.cpp
+++ b/src/python-frontend/python-list/list_mutation.cpp
@@ -52,10 +52,24 @@ exprt python_list::tagged_float_type_id(bool enable_float_path) const
   return converter_.get_type_handler().tagged_scalar_type_id(double_type());
 }
 
+// Only build_push_list_call and build_insert_list_call handle a tagged element;
+// they call get_tagged_element_info directly. Every other caller stamps the
+// hash of the wrapper's static C type, which never matches the element's
+// runtime type_id, so list.count() answered 0 and proved `count(x) == 0`.
+// Refuse the way `operator In` already does rather than answer wrongly.
+static void reject_tagged_element(const type_handler &th, const exprt &elem)
+{
+  if (th.is_tagged_scalar_type(elem.type()))
+    throw std::runtime_error(
+      "this list operation on a dynamically-typed element is not yet "
+      "supported");
+}
+
 list_elem_info
 python_list::get_list_element_info(const nlohmann::json &op, const exprt &elem)
 {
   const type_handler type_handler_ = converter_.get_type_handler();
+  reject_tagged_element(type_handler_, elem);
   locationt location = converter_.get_location_from_decl(op);
 
   const std::string elem_type_name = type_handler_.type_to_string(elem.type());
@@ -1042,6 +1056,17 @@ bool python_list::has_tagged_elements(const exprt &list) const
   return false;
 }
 
+// Same split as select_shallow_push, for list.extend().
+python_list::shallow_push_call python_list::select_list_extend(
+  const exprt &src,
+  const exprt &untagged_elem_size) const
+{
+  const bool tagged = has_tagged_elements(src);
+  const symbolt *func = converter_.symbol_table().find_symbol(
+    tagged ? "c:@F@__ESBMC_list_extend_tagged" : "c:@F@__ESBMC_list_extend");
+  return {func, tagged ? tagged_float_type_id(true) : untagged_elem_size};
+}
+
 python_list::shallow_push_call python_list::select_shallow_push(
   const exprt &src,
   const exprt &untagged_last_arg) const
@@ -1065,10 +1090,6 @@ exprt python_list::build_extend_list_call(
   const nlohmann::json &op,
   const exprt &other_list)
 {
-  const symbolt *extend_func_sym =
-    converter_.symbol_table().find_symbol("c:@F@__ESBMC_list_extend");
-  assert(extend_func_sym);
-
   locationt location = converter_.get_location_from_decl(op);
 
   exprt actual_list = other_list;
@@ -1267,14 +1288,14 @@ exprt python_list::build_extend_list_call(
   // element to be the same scalar width: extend applies one length to all of
   // them, so a mixed-width list must keep the model's symbolic elem->size
   // fallback (0).
-  BigInt elem_size_bytes = uniform_elem_size(actual_list);
+  const shallow_push_call extend_target = select_list_extend(
+    actual_list, from_integer(uniform_elem_size(actual_list), size_type()));
 
   code_function_callt extend_func_call;
-  extend_func_call.function() = build_symbol(*extend_func_sym);
+  extend_func_call.function() = build_symbol(*extend_target.func);
   extend_func_call.arguments().push_back(build_symbol(list));
   extend_func_call.arguments().push_back(actual_list);
-  extend_func_call.arguments().push_back(
-    from_integer(elem_size_bytes, size_type()));
+  extend_func_call.arguments().push_back(extend_target.last_arg);
   extend_func_call.type() = empty_typet();
   extend_func_call.location() = location;
 

--- a/src/python-frontend/python-list/python_list.h
+++ b/src/python-frontend/python-list/python_list.h
@@ -591,6 +591,9 @@ public:
   shallow_push_call
   select_shallow_push(const exprt &src, const exprt &untagged_last_arg) const;
 
+  shallow_push_call
+  select_list_extend(const exprt &src, const exprt &untagged_elem_size) const;
+
   struct list_eq_target
   {
     const symbolt *func;


### PR DESCRIPTION
`list.count()` over a dynamically-typed (tagged) element verified
`count(x) == 0` on a list that holds `x`, which CPython counts as 1 — an unsound
result. Only the push and insert builders handle a tagged element; every other
caller of `get_list_element_info` stamps the hash of the wrapper's static C
type, which never matches the element's runtime `type_id`. `index()` and
`remove()` gave wrong verdicts the same way, and they now refuse as
`operator In` already does.

`list.extend()` had the separate #7716 fault instead — an `elem_size` measured
on the 32-byte wrapper, overrunning a 2-byte payload in `memcpy` — so it gets
the bounded copy and keeps working.

Tests: `dynamic_type_scalar_tag_list_extend{,_fail}` pin the bounded copy;
`dynamic_type_scalar_tag_list_count_unsupported` pins the refusal and would
verify SUCCESSFUL against a false property without it.
