### PR TITLE
[python] Pin a user class shadowed by an operational model

### DIFF
--- a/regression/python/python_class_shadows_model_class/main.py
+++ b/regression/python/python_class_shadows_model_class/main.py
@@ -1,0 +1,17 @@
+# KNOWNBUG. A class type symbol is keyed `tag-<Name>` with no module
+# component, and an always-loaded operational model registers its classes under
+# the program file, so a user class named after one of them is silently
+# discarded: every use binds to the model's class and the assertion below is
+# reported FAILED even though CPython holds it. The same shape with an
+# *imported* model is refused instead (github_7397_model_shadow); only the
+# always-loaded ones reach this path. Resolving it needs per-module class tags.
+class Exception:
+    def __init__(self) -> None:
+        self.v: int = 2
+
+    def get(self) -> int:
+        return self.v
+
+
+o = Exception()
+assert o.get() == 2

--- a/regression/python/python_class_shadows_model_class/test.desc
+++ b/regression/python/python_class_shadows_model_class/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/python_class_shadows_model_class_control/main.py
+++ b/regression/python/python_class_shadows_model_class_control/main.py
@@ -1,0 +1,13 @@
+# Control for python_class_shadows_model_class: the identical class under a
+# name no operational model defines. It verifies, which is what attributes that
+# test's wrong verdict to the name collision rather than to the class body.
+class MyError:
+    def __init__(self) -> None:
+        self.v: int = 2
+
+    def get(self) -> int:
+        return self.v
+
+
+o = MyError()
+assert o.get() == 2

--- a/regression/python/python_class_shadows_model_class_control/test.desc
+++ b/regression/python/python_class_shadows_model_class_control/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+--incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
A class type symbol is keyed `tag-<Name>` with no module component, and an
always-loaded operational model registers its classes under the program file, so
a user class named after one is silently discarded: every use binds to the
model's class. This nine-line program holds in CPython and reports
VERIFICATION FAILED — a false alarm, with no import involved.

Renaming the class to a name no model defines makes the identical program
verify, which is what attributes the wrong verdict to the collision rather than
to the class body. The same shape with an *imported* model is refused instead
(github_7397_model_shadow in #7731); only the always-loaded ones reach this
path, since they are exempted by the same-file test. Resolving it needs
per-module class tags, so this pins the defect rather than fixing it.

Tests: python_class_shadows_model_class (KNOWNBUG, flips to a reclassification
failure once fixed) and its control pinning VERIFICATION SUCCESSFUL.