### PR TITLE
[test] Record what the concurrency_fail revisit found

### DIFF
--- a/regression/python/concurrency_fail/main.py
+++ b/regression/python/concurrency_fail/main.py
@@ -1,4 +1,17 @@
 # example_14_concurrency.py
+#
+# KNOWNBUG (#4566). The frontend gaps this test was filed against are closed:
+# threading.Thread, queue.Queue, callables stored in instance fields and
+# random.choice all convert now, and the program reaches symex instead of being
+# rejected at parse time. What is left is convergence -- --incremental-bmc does
+# not terminate on it.
+#
+# Do not "fix" this by switching to a bounded run. `--unwind N` reports
+# VERIFICATION FAILED at every N tried (1..4), but the violated property is
+# `unwinding assertion loop 192` at run_guarded_commands, not the
+# `assert number < 100` this test exists to catch -- a vacuous pass of the
+# expected-FAILED contract. Adding --no-unwinding-assertions to reach the real
+# assertion does not converge either.
 import random
 import threading
 import time


### PR DESCRIPTION
#4566 asks for a revisit once `threading.Thread` and `queue.Queue` land. They
have: this test now parses, converts and reaches symex rather than being
rejected at parse time, so the frontend gaps it was filed against are closed.
What remains is convergence — `--incremental-bmc` does not terminate on it, so
it stays KNOWNBUG.

The trap worth recording is the obvious way to flip it. `--unwind N` reports
VERIFICATION FAILED at every N from 1 to 4, which looks like the expected
verdict, but the violated property is `unwinding assertion loop 192` rather
than the `assert number < 100` the test exists to catch — the expected-FAILED
contract would be satisfied vacuously. Adding `--no-unwinding-assertions` to
reach the real assertion does not converge. Comment only; no behaviour change.

Refs #4566