### PR TITLE
[test] Reduce the aws-c-common false alarm to a struct copy

### DIFF
--- a/regression/esbmc/github_5393/main.c
+++ b/regression/esbmc/github_5393/main.c
@@ -1,0 +1,36 @@
+/* KNOWNBUG (#5393). Assigning a struct whose type has a flexible array member
+ * must copy only the header: C17 6.7.2.1p18 says the size of the structure is
+ * as if the flexible array member were omitted. ESBMC copies the flexible tail
+ * as well, so the assignment overwrites the calloc'd zeroes that follow the
+ * header with the source local's indeterminate bytes, and a read of the tail
+ * reports a spurious violation.
+ *
+ * This is the SV-COMP aws_hash_table_init_bounded_harness false alarm reduced:
+ * there the tail is the hash table's slot array, zeroed by aws_mem_calloc and
+ * then apparently clobbered by `*state = *template`, so assert_all_zeroes over
+ * the slots fails on a correct program. See github_5393_control for the same
+ * program without the struct assignment, which verifies. */
+#include <assert.h>
+#include <stdlib.h>
+
+struct e
+{
+  void *k, *v;
+};
+struct s
+{
+  void *a;
+  struct e slots[];
+};
+
+int main(void)
+{
+  struct s tmpl;
+  tmpl.a = (void *)0x1234;
+  struct s *p = calloc(1, sizeof(struct s) + 2 * sizeof(struct e));
+  if (!p)
+    return 0;
+  *p = tmpl;
+  assert(((unsigned char *)&p->slots[0])[1] == 0);
+  return 0;
+}

--- a/regression/esbmc/github_5393/test.desc
+++ b/regression/esbmc/github_5393/test.desc
@@ -1,0 +1,4 @@
+KNOWNBUG
+main.c
+--force-malloc-success --64
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5393_control/main.c
+++ b/regression/esbmc/github_5393_control/main.c
@@ -1,0 +1,24 @@
+/* Control for github_5393: the identical program writing the header field
+ * directly instead of by struct assignment. It verifies, which is what
+ * attributes that test's spurious violation to the assignment copying the
+ * flexible array member rather than to the allocation or the tail read. */
+#include <assert.h>
+#include <stdlib.h>
+struct e
+{
+  void *k, *v;
+};
+struct s
+{
+  void *a;
+  struct e slots[];
+};
+int main(void)
+{
+  struct s *p = calloc(1, sizeof(struct s) + 2 * sizeof(struct e));
+  if (!p)
+    return 0;
+  p->a = (void *)0x1234;
+  assert(((unsigned char *)&p->slots[0])[1] == 0);
+  return 0;
+}

--- a/regression/esbmc/github_5393_control/test.desc
+++ b/regression/esbmc/github_5393_control/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --64
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
#5393's false alarm on `aws_hash_table_init_bounded_harness` reduces to
fourteen lines. Assigning a struct whose type has a flexible array member must
copy only the header — C17 6.7.2.1p18 makes the structure's size as if the
member were omitted — but ESBMC copies the flexible tail as well. The
assignment therefore overwrites the `calloc`'d zeroes that follow the header
with the source local's indeterminate bytes, and reading the tail reports a
violation on a correct program.

The mechanism is visible in `--goto-functions-only`: `clang_c_convert.cpp:1101`
converts an `IncompleteArray` to `array_typet(sub_type, gen_one(...))`, so the
member is modelled as a one-element array. `ASSIGN tmpl=NONDET(struct s {...
struct e [1] slots; })` then makes `tmpl.slots[0]` nondet and `ASSIGN *p=tmpl`
copies it over the zeroed tail.

Modelling it as zero-length instead is not the fix: changing that `gen_one` to
`gen_zero` makes the reduction SIGSEGV in symex. The fix belongs where the
struct copy or its size is computed, not in the array type.

In the benchmark that tail is the hash table's slot array, zeroed by
`aws_mem_calloc` and then clobbered by `*state = *template`, so
`assert_all_zeroes` over the slots fails. Worth noting for anyone reading the
issue: the counterexample's innermost frame is `__VERIFIER_assert` at line 223,
which reads as though `aws_hash_table_is_valid` failed; the trace actually
reaches it from `assert_all_zeroes`, and every `is_valid` conjunct holds.

Refs #5393

Tests: github_5393 (KNOWNBUG, the reduction) and github_5393_control, the same
program writing the header field directly, which verifies — that is what
attributes the violation to the assignment rather than to the allocation or the
tail read. Both assertions hold under clang.