### PR TITLE
[python] Probe the RHS type when copying a tagged name at module scope

### DIFF
--- a/regression/python/dynamic_type_copy_module_scope/main.py
+++ b/regression/python/dynamic_type_copy_module_scope/main.py
@@ -1,0 +1,10 @@
+# Copying a tagged name at module scope aborted in member2t: the RHS type probe
+# that adopts the tagged type runs only in function scope.
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+y = x
+z = y
+assert z == 1 or z == "a"

--- a/regression/python/dynamic_type_copy_module_scope/test.desc
+++ b/regression/python/dynamic_type_copy_module_scope/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_copy_module_scope_fail/main.py
+++ b/regression/python/dynamic_type_copy_module_scope_fail/main.py
@@ -1,0 +1,7 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+y = x
+assert y == 1

--- a/regression/python/dynamic_type_copy_module_scope_fail/test.desc
+++ b/regression/python/dynamic_type_copy_module_scope_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/dynamic_type_loop_module_scope/main.py
+++ b/regression/python/dynamic_type_loop_module_scope/main.py
@@ -1,0 +1,10 @@
+# The preprocessor unrolls this loop into a chain of tagged-name copies, which
+# is why it aborted at module scope and not inside a function.
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+for e in lst:
+    assert e == 1 or e == "a"

--- a/regression/python/dynamic_type_loop_module_scope/test.desc
+++ b/regression/python/dynamic_type_loop_module_scope/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/dynamic_type_loop_module_scope_fail/main.py
+++ b/regression/python/dynamic_type_loop_module_scope_fail/main.py
@@ -1,0 +1,8 @@
+cond = nondet_bool()
+if cond:
+    x = 1
+else:
+    x = "a"
+lst = [x]
+for e in lst:
+    assert e == 1

--- a/regression/python/dynamic_type_loop_module_scope_fail/test.desc
+++ b/regression/python/dynamic_type_loop_module_scope_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/src/python-frontend/converter/converter_stmt.cpp
+++ b/src/python-frontend/converter/converter_stmt.cpp
@@ -5480,6 +5480,28 @@ void python_converter::propagate_list_type_info(
   }
 }
 
+/// Whether a module-scope assignment has to probe its RHS type before choosing
+/// the target's type.
+///
+/// The probe runs unconditionally for a symbol id carrying `@F`. At module
+/// scope it used to run only when the annotation already resolved to a tagged
+/// type, so copying a tagged name there (`y = x`) left the target scalar and
+/// the scalar path built a member over the tagged struct, aborting in member2t.
+/// The same assignment inside a function already worked. A `for` over a list of
+/// tagged scalars hits this too: the preprocessor unrolls it into exactly such
+/// a chain of tagged-name copies.
+bool python_converter::module_scope_rhs_needs_type_probe(
+  const nlohmann::json &value)
+{
+  if (!current_func_name_.empty())
+    return false;
+  if (type_handler_.is_tagged_scalar_type(current_element_type))
+    return true;
+  return value.is_object() && value.value("_type", "") == "Name" &&
+         value.contains("id") &&
+         dynamic_type_handler_.is_tagged(value["id"].get<std::string>());
+}
+
 void python_converter::get_var_assign(
   const nlohmann::json &ast_node,
   codet &target_block)
@@ -5784,8 +5806,7 @@ void python_converter::get_var_assign(
     if (
       (sid.to_string().find("@F") != std::string::npos &&
        sid.to_string().find("@C") == std::string::npos) ||
-      (type_handler_.is_tagged_scalar_type(current_element_type) &&
-       current_func_name_.empty()))
+      module_scope_rhs_needs_type_probe(ast_node["value"]))
     {
       is_right = true;
       if (!ast_node["value"].is_null())

--- a/src/python-frontend/python_converter.h
+++ b/src/python-frontend/python_converter.h
@@ -965,6 +965,10 @@ private:
   bool
   try_tagged_var_assign(const nlohmann::json &ast_node, codet &target_block);
 
+  /// Whether a module-scope assignment must probe its RHS type before fixing
+  /// the target's type.
+  bool module_scope_rhs_needs_type_probe(const nlohmann::json &value);
+
   /// Mints a fresh symbol of `new_type` to hold `orig`'s value from here on,
   /// declares it in `target_block` when it is a local, and records the
   /// redirection in retype_aliases_ under `alias_key`.


### PR DESCRIPTION
Copying a dynamically-typed name at module scope aborted ESBMC:

```python
cond = nondet_bool()
if cond:
    x = 1
else:
    x = "a"
y = x
```

```
Assertion failed: (source->type->type_id == type2t::struct_id || ...),
function member2t, file irep2_expr.h, line 1610.
```

`member2t` asserts its source is an aggregate, and the target kept its scalar
type, so the scalar assignment path built a member over the tagged struct. The
probe that adopts the RHS's type for the target ran only for a symbol id
carrying `@F`, which is why the same assignment inside a function verified
normally. A `for` over a list of tagged scalars aborts for the same reason: the
preprocessor unrolls the loop into exactly such a chain of tagged-name copies.

Tests: `dynamic_type_copy_module_scope{,_fail}` and
`dynamic_type_loop_module_scope{,_fail}`. Both SUCCESSFUL cases abort again when
the module-scope arm of the probe condition is disabled.
