### PR TITLE
[pointer-analysis] Do not read past a zero-width dereference

### DIFF
--- a/regression/esbmc/zero_length_array_member_deref/main.c
+++ b/regression/esbmc/zero_length_array_member_deref/main.c
@@ -1,0 +1,33 @@
+/* Reading through a struct's zero-length array member (the GCC extension) drove
+ * dereferencet::stitch_together_from_byte_array with num_bytes == 0. Its only
+ * guard was an assert, which NDEBUG compiles out of the shipping build, so the
+ * stitching loop read bytes[-1] and ESBMC died with SIGSEGV instead of
+ * producing a verdict. It now fails loudly in every build.
+ *
+ * The refusal is not the end state -- clang runs this program and the assertion
+ * holds -- but a diagnosable error beats an out-of-bounds read inside the
+ * verifier. */
+#include <assert.h>
+#include <stdlib.h>
+
+struct e
+{
+  void *k, *v;
+};
+struct s
+{
+  void *a;
+  struct e slots[0];
+};
+
+int main(void)
+{
+  struct s tmpl;
+  tmpl.a = (void *)0x1234;
+  struct s *p = calloc(1, sizeof(struct s) + 2 * sizeof(struct e));
+  if (!p)
+    return 0;
+  *p = tmpl;
+  assert(((unsigned char *)&p->slots[0])[1] == 0);
+  return 0;
+}

--- a/regression/esbmc/zero_length_array_member_deref/test.desc
+++ b/regression/esbmc/zero_length_array_member_deref/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --64
+^ERROR: dereference: cannot read a zero-width object$

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -2419,8 +2419,8 @@ expr2tc dereferencet::stitch_together_from_byte_array(
 {
   /* A zero-width object has no bytes to stitch. This was guarded by an assert
    * alone, which NDEBUG compiles out of the shipping build, and the loops below
-   * then read bytes[-1] -- an out-of-bounds access in ESBMC itself rather than a
-   * verdict. A struct with a zero-length array member reaches it. */
+   * then read bytes[-1] -- an out-of-bounds access in ESBMC itself rather than
+   * a verdict. A struct with a zero-length array member reaches it. */
   if (num_bytes == 0)
   {
     log_error("dereference: cannot read a zero-width object");

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -2354,7 +2354,14 @@ std::vector<expr2tc> dereferencet::extract_bytes(
   unsigned int num_bytes,
   const expr2tc &offset) const
 {
-  assert(num_bytes != 0);
+  /* A zero-width object has no bytes to extract, and the stitching below reads
+   * bytes[num_bytes - 1] -- an out-of-bounds access in ESBMC itself rather than
+   * a verdict. A struct with a zero-length array member reaches here. */
+  if (num_bytes == 0)
+  {
+    log_error("dereference: cannot read a zero-width object");
+    abort();
+  }
 
   std::vector<expr2tc> bytes;
   bytes.reserve(num_bytes);
@@ -2417,15 +2424,9 @@ expr2tc dereferencet::stitch_together_from_byte_array(
   unsigned int num_bytes,
   const std::vector<expr2tc> &bytes)
 {
-  /* A zero-width object has no bytes to stitch. This was guarded by an assert
-   * alone, which NDEBUG compiles out of the shipping build, and the loops below
-   * then read bytes[-1] -- an out-of-bounds access in ESBMC itself rather than
-   * a verdict. A struct with a zero-length array member reaches it. */
-  if (num_bytes == 0)
-  {
-    log_error("dereference: cannot read a zero-width object");
-    abort();
-  }
+  /* Every caller sources `bytes` from extract_bytes(), which refuses a
+   * zero-width read before we get here. */
+  assert(num_bytes != 0);
 
   // We are composing a larger data type out of bytes -- we must consider
   // what byte order we are going to stitch it together out of.

--- a/src/pointer-analysis/dereference.cpp
+++ b/src/pointer-analysis/dereference.cpp
@@ -2417,7 +2417,15 @@ expr2tc dereferencet::stitch_together_from_byte_array(
   unsigned int num_bytes,
   const std::vector<expr2tc> &bytes)
 {
-  assert(num_bytes != 0);
+  /* A zero-width object has no bytes to stitch. This was guarded by an assert
+   * alone, which NDEBUG compiles out of the shipping build, and the loops below
+   * then read bytes[-1] -- an out-of-bounds access in ESBMC itself rather than a
+   * verdict. A struct with a zero-length array member reaches it. */
+  if (num_bytes == 0)
+  {
+    log_error("dereference: cannot read a zero-width object");
+    abort();
+  }
 
   // We are composing a larger data type out of bytes -- we must consider
   // what byte order we are going to stitch it together out of.


### PR DESCRIPTION
`dereferencet::stitch_together_from_byte_array` guarded `num_bytes == 0` with an
`assert` alone. `NDEBUG` compiles that out of the shipping build, so the
stitching loop evaluated `bytes[num_bytes - 1]` as `bytes[-1]` — an
out-of-bounds read inside ESBMC. A struct with a zero-length array member
reaches it, and the thirteen-line test in this PR made a release build die with
SIGSEGV instead of producing a verdict. It now fails loudly in every build,
matching how the neighbouring unrecognised-type cases in this file report.

The refusal is not the end state: clang runs that program and its assertion
holds, so the right answer is SUCCESSFUL. What this changes is that a
precondition violation is diagnosable rather than a memory-safety bug in the
verifier. Found while reducing #5393, whose flexible-array-member modelling
reaches the same zero-width shape.

Tests: zero_length_array_member_deref pins the diagnostic; it segfaults when
the guard is reverted. 400 regression/esbmc tests pass unchanged.