### PR TITLE
[test] Pin that a malloc(0) dereference is reported

### DIFF
--- a/regression/esbmc/malloc_zero_deref_fail/main.c
+++ b/regression/esbmc/malloc_zero_deref_fail/main.c
@@ -1,0 +1,35 @@
+/* C17 7.22.3p1: when the requested size is zero the behaviour is
+ * implementation-defined -- either a null pointer is returned, or the behaviour
+ * is as if the size were some nonzero value, "except that the returned pointer
+ * shall not be used to access an object". Reading an object through a
+ * malloc(0) pointer is therefore undefined, and flagging it is correct.
+ *
+ * This shape is why #5397 reports false on
+ * ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil: the
+ * harness calls ldv_xmalloc(0UL), assumes the result non-null, casts it to
+ * struct pm_message * and dereferences it. The task's expected verdict is true,
+ * but the access is undefined by the paragraph above -- so this test exists to
+ * keep the check from being weakened to match that expectation.
+ * See malloc_zero_deref_sized for the same access over a sized allocation. */
+#include <stdlib.h>
+
+struct pm
+{
+  int event;
+};
+
+static void use(struct pm *p)
+{
+  struct pm v = *p;
+  (void)v;
+}
+
+int main(void)
+{
+  void *q = malloc(0);
+  if ((unsigned long)q == 0UL)
+    return 0;
+  use((struct pm *)q);
+  free(q);
+  return 0;
+}

--- a/regression/esbmc/malloc_zero_deref_fail/test.desc
+++ b/regression/esbmc/malloc_zero_deref_fail/test.desc
@@ -1,0 +1,5 @@
+CORE
+main.c
+--force-malloc-success --32 --incremental-bmc
+^VERIFICATION FAILED$
+^  dereference failure: array bounds violated: heap object$

--- a/regression/esbmc/malloc_zero_deref_sized/main.c
+++ b/regression/esbmc/malloc_zero_deref_sized/main.c
@@ -1,0 +1,26 @@
+/* Control for malloc_zero_deref_fail: the same access over an allocation of
+ * the object's size, which is well defined and must verify. It is what
+ * attributes that test's violation to the zero size rather than to the
+ * cast or the dereference. */
+#include <stdlib.h>
+
+struct pm
+{
+  int event;
+};
+
+static void use(struct pm *p)
+{
+  struct pm v = *p;
+  (void)v;
+}
+
+int main(void)
+{
+  void *q = malloc(sizeof(struct pm));
+  if ((unsigned long)q == 0UL)
+    return 0;
+  use((struct pm *)q);
+  free(q);
+  return 0;
+}

--- a/regression/esbmc/malloc_zero_deref_sized/test.desc
+++ b/regression/esbmc/malloc_zero_deref_sized/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--force-malloc-success --32 --incremental-bmc
+^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
#5397 reports a false alarm on
`ldv-linux-3.14-races/linux-3.14--drivers--net--irda--nsc-ircc.ko.cil`, where
ESBMC answers `false(valid-deref)` against an expected verdict of true. It
reduces to eleven lines: the harness calls `ldv_xmalloc(0UL)`, assumes the
result non-null, casts it to `struct pm_message *` and dereferences it.

That access is undefined. C17 7.22.3p1 makes a zero-size allocation
implementation-defined — either a null pointer, or as if the size were nonzero
"except that the returned pointer shall not be used to access an object". So
ESBMC's `array bounds violated: heap object` is standard-conforming, and the
disagreement is with the benchmark's expected verdict rather than with C. It
reproduces with and without `--malloc-zero-is-null`.

This pins the behaviour so #5397 is not closed by weakening the check. Whether
to model the task's expectation instead is a separate decision.

Refs #5397

Tests: malloc_zero_deref_fail and malloc_zero_deref_sized, the same access over
an allocation of the object's size. Swapping the two sizes makes each test fail.