### PR TITLE
[goto-programs] Scan only reachable calls for thread entries

### DIFF
--- a/regression/esbmc-cpp/cpp/github_7644/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7644/main.cpp
@@ -1,0 +1,22 @@
+/* std::thread's operational model hands pthread_create its own `f` parameter,
+ * which is a function-pointer variable rather than a direct &worker. Exception
+ * lowering scanned every function body, so that unreachable constructor made it
+ * report "a thread with an unresolved start routine" and decline any program
+ * that merely included <thread> and used exceptions -- no thread required.
+ * Reported against immer, whose headers pull <thread> in transitively (#7644).
+ * See github_7644_thread_fail for a program that does start a thread, which
+ * must still be declined. */
+#include <thread>
+
+int main()
+{
+  try
+  {
+    throw 1;
+  }
+  catch (int)
+  {
+    return 0;
+  }
+  return 1;
+}

--- a/regression/esbmc-cpp/cpp/github_7644/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7644/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-cpp/cpp/github_7644_thread_fail/main.cpp
+++ b/regression/esbmc-cpp/cpp/github_7644_thread_fail/main.cpp
@@ -1,0 +1,27 @@
+/* Counterpart of github_7644: a genuine std::thread makes the constructor
+ * reachable, so the unresolved start routine is real and the program must still
+ * be declined. This is what keeps the reachability gate from being widened into
+ * skipping the check altogether. */
+#include <thread>
+
+static int x = 0;
+
+static void worker()
+{
+  x = 1;
+}
+
+int main()
+{
+  std::thread t(worker);
+  t.join();
+  try
+  {
+    throw 1;
+  }
+  catch (int)
+  {
+    return 0;
+  }
+  return 1;
+}

--- a/regression/esbmc-cpp/cpp/github_7644_thread_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7644_thread_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.cpp
+--std c++23
+^ERROR: exception lowering: cannot lower a thread with an unresolved start routine$

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -212,7 +212,12 @@ public:
           const code_function_call2t &c = to_code_function_call2t(it->code);
           if (is_symbol2t(c.function))
             direct_call_targets.insert(to_symbol2t(c.function).thename);
-          collect_thread_entry(c);
+          // Only a call the entry can reach starts a thread. std::thread's
+          // operational model hands pthread_create its own `f` parameter, so
+          // scanning unreachable bodies reported an unresolved routine for any
+          // program that merely includes <thread> and uses exceptions (#7644).
+          if (entry_reachable_.count(fn.first))
+            collect_thread_entry(c);
         }
       }
     }

--- a/src/goto-programs/remove_exceptions.cpp
+++ b/src/goto-programs/remove_exceptions.cpp
@@ -212,12 +212,7 @@ public:
           const code_function_call2t &c = to_code_function_call2t(it->code);
           if (is_symbol2t(c.function))
             direct_call_targets.insert(to_symbol2t(c.function).thename);
-          // Only a call the entry can reach starts a thread. std::thread's
-          // operational model hands pthread_create its own `f` parameter, so
-          // scanning unreachable bodies reported an unresolved routine for any
-          // program that merely includes <thread> and uses exceptions (#7644).
-          if (entry_reachable_.count(fn.first))
-            collect_thread_entry(c);
+          collect_thread_entry(fn.first, c);
         }
       }
     }
@@ -610,16 +605,22 @@ private:
     return call;
   }
 
-  /// If @p call is a pthread_create, record its start-routine argument (the 3rd)
-  /// as a thread entry, so lower_ip enforces the uncaught-escape terminate at
-  /// that function's epilogue. The argument is `&worker`, possibly under
+  /// If @p call is a pthread_create, record its start-routine argument (the
+  /// 3rd) as a thread entry, so lower_ip enforces the uncaught-escape terminate
+  /// at that function's epilogue. The argument is `&worker`, possibly under
   /// typecasts; peel them to the underlying function symbol. A computed
   /// (unresolvable) routine sets thread_entry_unresolved so run() declines the
   /// program rather than silently miss its uncaught-escape check.
-  void collect_thread_entry(const code_function_call2t &call)
+  ///
+  /// Only a call the entry can reach starts a thread, so @p caller gates the
+  /// scan: std::thread's operational model hands pthread_create its own `f`
+  /// parameter, and scanning unreachable bodies reported an unresolved routine
+  /// for any program that merely includes <thread> and uses exceptions (#7644).
+  void
+  collect_thread_entry(const irep_idt &caller, const code_function_call2t &call)
   {
     if (
-      !is_symbol2t(call.function) ||
+      !entry_reachable_.count(caller) || !is_symbol2t(call.function) ||
       id2string(to_symbol2t(call.function).thename).find("pthread_create") ==
         std::string::npos ||
       call.operands.size() < 3)


### PR DESCRIPTION
`std::thread`'s operational model passes `pthread_create` its own `f` parameter
(`src/cpp/library/thread:72,77`), a function-pointer variable rather than a
direct `&worker`. Exception lowering scanned every function body for thread
entries, so that constructor — unreachable in a program that never starts a
thread — reported an unresolved start routine and declined the program.

#7644 reports this against immer, whose headers pull `<thread>` in
transitively, but it needs neither immer nor a thread. Two lines reproduce it:

```cpp
#include <thread>
int main() { try { throw 1; } catch (int) { return 0; } return 1; }
```

Dropping either the include or the exception makes it verify. Any C++ program
that reaches `<thread>` transitively and uses exceptions is affected.

`entry_reachable_` is already computed a few lines above for exactly this kind
of question, so gate the scan on it. A program that does start a thread still
declines.

Fixes #7644

Tests: github_7644 (the reduction, which fails without the change) and
github_7644_thread_fail, which pins that a genuine `std::thread` is still
declined — that one is invariant by design and guards the gate from being
widened into skipping the check. 350 esbmc-cpp tests unchanged; the single
failure there, ch8_5, fails identically on master.