### PR TITLE
[test] Pin the exception type names ESBMC actually prints

### DIFF
--- a/regression/esbmc-cpp/cpp/ch8_5/test.desc
+++ b/regression/esbmc-cpp/cpp/ch8_5/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 --unwind 40 --no-unwinding-assertions --timeout 900
 ^VERIFICATION FAILED$
-uncaught exception: class std::out_of_range
+uncaught exception: std::out_of_range

--- a/regression/esbmc-cpp/cpp/github_7433/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7433/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 
 ^VERIFICATION SUCCESSFUL$
-^  PASSED       \[maybe_throw\.assertion\.[0-9]+\] +line +10 +uncaught exception: struct my_error$
+^  PASSED       \[maybe_throw\.assertion\.[0-9]+\] +line +10 +uncaught exception: my_error$

--- a/regression/esbmc-cpp/cpp/github_7433_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7433_fail/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 
 ^VERIFICATION FAILED$
-^  FAILED       \[main\.assertion\.[0-9]+\] +line +7 +uncaught exception: struct my_error$
+^  FAILED       \[main\.assertion\.[0-9]+\] +line +7 +uncaught exception: my_error$

--- a/regression/esbmc-cpp/cpp/github_7433_library_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7433_library_fail/test.desc
@@ -2,5 +2,5 @@ CORE
 main.cpp
 --multi-property
 ^VERIFICATION FAILED$
-^  FAILED       \[main\.assertion\.[0-9]+\] +line +5 +uncaught exception: class std::runtime_error$
-^  FAILED       \[main\.assertion\.[0-9]+\] +line +6 +uncaught exception: class std::bad_alloc$
+^  FAILED       \[main\.assertion\.[0-9]+\] +line +5 +uncaught exception: std::runtime_error$
+^  FAILED       \[main\.assertion\.[0-9]+\] +line +6 +uncaught exception: std::bad_alloc$

--- a/regression/esbmc-cpp/cpp/github_7433_throw_site/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7433_throw_site/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 
 ^VERIFICATION SUCCESSFUL$
-^  PASSED       \[maybe_throw\.assertion\.[0-9]+\] +line +11 +uncaught exception: struct my_error$
+^  PASSED       \[maybe_throw\.assertion\.[0-9]+\] +line +11 +uncaught exception: my_error$

--- a/regression/esbmc-cpp/cpp/github_7433_throw_site_fail/test.desc
+++ b/regression/esbmc-cpp/cpp/github_7433_throw_site_fail/test.desc
@@ -2,4 +2,4 @@ CORE
 main.cpp
 
 ^VERIFICATION FAILED$
-^  FAILED       \[maybe_throw\.assertion\.[0-9]+\] +line +11 +uncaught exception: struct my_error$
+^  FAILED       \[maybe_throw\.assertion\.[0-9]+\] +line +11 +uncaught exception: my_error$


### PR DESCRIPTION
Six CORE tests in `regression/esbmc-cpp/cpp` fail on master, all for one
reason: they pin an elaborated type name that ESBMC does not print.

- `ch8_5` and `github_7433_library_fail` expect `class std::out_of_range`,
  `class std::runtime_error`, `class std::bad_alloc`
- `github_7433`, `github_7433_fail`, `github_7433_throw_site` and
  `github_7433_throw_site_fail` expect `struct my_error`

ESBMC prints `std::out_of_range` and `my_error`. Correcting the expectation is
not loosening a check, because none of these has ever gated anything: built at
`d98d88ae96`, the commit that added ch8_5's expectation, ESBMC already printed
the bare name and the test already failed. The other five came from #7417 with
the same mistaken spelling. Nothing else in the suite pins either form.

The bare spelling is the one ESBMC uses elsewhere — the Python frontend reports
`uncaught exception: ValueError`.

Tests: the six above, which pass with this change and fail without it.