### PR TITLE
[docs] Open Phase 8 (solidity) with a measured census

### DIFF
--- a/docs/roadmap/frontends-to-irep2.md
+++ b/docs/roadmap/frontends-to-irep2.md
@@ -431,6 +431,14 @@ are about: a census must show the thing under test executed before its zero
 means anything. Both suites need Linux CI (Solidity) or a build with
 `-DENABLE_JIMPLE_FRONTEND=On` (Jimple).
 
+**Superseded for Solidity (2026-09-11).** With `ENABLE_SOLIDITY_FRONTEND=On` the
+suite runs locally: `ctest -L esbmc-solidity` is 523 of 525, the other two being
+`KNOWNBUG` rows that now pass. Tests ship a pre-generated `contract.solast`, and
+their flags line names it, so `solc` is not needed. Phase 8 is therefore
+measurable and is opened at `scope-solidity-irep2.md`. Jimple's blocker is not
+re-tested here, though the same build has `ENABLE_JIMPLE_FRONTEND=On` and 26
+`jimple` tests.
+
 ### 15.2 Python, re-censused with the §14 fix
 
 The docstring-location fix (#6695) applied, same instrumentation, the five tests

--- a/docs/roadmap/scope-solidity-irep2.md
+++ b/docs/roadmap/scope-solidity-irep2.md
@@ -1,0 +1,173 @@
+# Scope: solidity frontend to IREP2 (Phase 8)
+
+Opened per `frontends-to-irep2.md` §6, which requires each of Phases 5-9 to
+start with its own scope doc: census, phased decomposition, gates, risks. Phase
+5 (jimple) closed at `scope-jimple-irep2.md` §31; Phase 6 (clang-c) is
+`scope-clang-c-irep2.md`; Phase 7 (clang-cpp) is `scope-clang-cpp-irep2.md` and
+is **not** closed, which matters here for the reason §2 gives.
+
+## 1. Census
+
+### 1.1 The blocker the parent records is stale
+
+`frontends-to-irep2.md` §15.1 records Solidity as *blocked, not zero*: a decline
+census got `ERROR: `' is not a goto-binary`, nothing ran, and the note concludes
+the suite needs Linux CI. Re-tested 2026-09-11 and it is measurable here.
+
+```
+$ grep ENABLE_SOLIDITY build/CMakeCache.txt
+ENABLE_SOLIDITY_FRONTEND:BOOL=On
+$ ctest -j24 -L esbmc-solidity
+99% tests passed, 2 tests failed out of 525
+```
+
+The two are not failures: both print `passed but is marked as KNOWNBUG.
+Consider reclassifying it as CORE` (`testing_tool.py` exit 77) —
+`delegate_shadow_3` and `nested_array_deep_1`, each expecting `^VERIFICATION
+SUCCESSFUL$` and getting it, in half a second, so not the timeout that
+`KNOWNBUG` silently accepts. They are master drift, and flipping them wants its
+own change; they are recorded here because a census that reports "2 failures"
+without saying which kind is the §15.1 mistake again.
+
+§15.1's own rule is what makes this census admissible: it must show the thing
+under test executed before a zero means anything.
+
+### 1.2 Surface
+
+`src/solidity-frontend`, 23 599 LOC over 25 files:
+
+| File | LOC | Legacy construction sites |
+|---|---:|---:|
+| `solidity_convert_call.cpp` | 3 682 | 404 |
+| `solidity_convert_expr.cpp` | 3 409 | 250 |
+| `solidity_convert.h` | 1 129 | 221 |
+| `solidity_convert_ref.cpp` | 937 | 89 |
+| `solidity_convert_type.cpp` | 1 588 | 86 |
+| `solidity_convert_constructor.cpp` | 1 055 | 78 |
+| `solidity_convert_stmt.cpp` | 978 | 75 |
+| `solidity_convert_decl.cpp` | 1 526 | 73 |
+| `solidity_convert_mapping.cpp` | 708 | 70 |
+| `solidity_convert_contract.cpp` | 850 | 67 |
+| `solidity_convert_tuple.cpp` | 653 | 59 |
+| `solidity_convert_builtin.cpp` | 524 | 54 |
+| `solidity_convert_modifier.cpp` | 752 | 53 |
+| `solidity_convert.cpp` | 1 266 | 51 |
+| `solidity_convert_util.cpp` | 1 046 | 36 |
+| `solidity_convert_literals.cpp` | 159 | 15 |
+| `solidity_grammar.cpp` | 1 804 | **0** |
+| `pattern_check.cpp` | 153 | **0** |
+| remainder (`typecast`, `language`, headers) | — | 4 |
+| **total** | **23 599** | **1 685** |
+
+"Construction sites" counts lines mentioning `exprt`, `typet`, a `code_*t`,
+`symbol_expr`, `gen_zero` or `from_integer` — the same rough proxy the parent
+used for its 971 and 1 420 figures, not a precise obligation count. The
+parent's 1 420 was measured at `f14cd73ff8`; the surface has grown since.
+
+**IREP2 use today: zero.** `grep -c 'expr2tc\|type2tc' *.cpp *.h` over the
+whole frontend returns 0, so unlike clang-c (49 sites already native) this
+phase has no head start. `solidity_grammar.cpp` is the AST-kind classifier and
+constructs no IR at all — the analogue of `clang_c_lexer.cpp` in Phase 6's
+§1.1, and it needs no migration.
+
+### 1.3 Corpus
+
+| Suite | Tests |
+|---|---|
+| `esbmc-solidity` | 525 |
+
+Tests ship a pre-generated `contract.solast` beside `contract.sol`, and the
+flags line names both (`--sol contract.sol --contract <Name>`), so `solc` is
+not needed to run them. That is why the suite is measurable without the
+toolchain §15.1 assumed was required.
+
+## 2. The finding that sets this phase's shape: there is no Solidity adjust pass
+
+`solidity_languaget::typecheck` (`src/solidity-frontend/solidity_language.cpp`)
+has four phases — intrinsics, the `sol64` operational models, the converter,
+then the adjuster — and the adjuster it runs is **`clang_cpp_adjust`**, Phase
+7's subject, not one of its own:
+
+```cpp
+  clang_cpp_adjust adjuster(new_context);
+  if (adjuster.adjust())
+    return true;
+```
+
+Two consequences, and they pull in opposite directions.
+
+**The adjust half of this phase is inherited, not owed.** Every arm Phase 7
+ports serves Solidity at no extra cost, and none of Solidity's 1 685 sites is
+in an adjust pass. Phase 8's own work is entirely in the *converter*.
+
+**Solidity is therefore exposed to every Phase 7 divergence, and is not
+currently measuring any of them.** `clang_cpp_language.cpp` gates its adjuster
+on `clang-cpp-irep2-adjust-only`; the line above does not, so the flag does not
+reach this path — a Solidity test run with it is byte-identical to one run
+without (checked on `abi_decode_1`; the claim rests on the source, since one
+identical verdict would not distinguish "flag ignored" from "flag made no
+difference here").
+
+That makes the first action of this phase cheap and valuable: wire the existing
+flag through, and the 525-test Solidity corpus becomes a **second, independent
+corpus for Phase 7's pass** — one whose input the C++ frontend never produces,
+over a converter with different habits. Phase 7's divergence census has been run
+on `esbmc-cpp` only.
+
+### 2.1 The save/restore dance is a seam hazard
+
+Phase 4 of that function saves every library symbol's value as an `exprt`
+before adjusting and restores it afterwards, because `clang_cpp_adjust` would
+corrupt bodies that `c2goto`'s `clang_c_adjust` already adjusted.
+`clang_c_adjust_irep2` writes back only values it changed, and writes them back
+through `migrate_expr_back`. So the restore interacts with a different
+write-back discipline than it was written against, and any seam loss on a
+library body would be masked by the restore rather than observed. This wants a
+measurement before the flag is wired, not after.
+
+## 3. Proposed decomposition (not yet executed)
+
+1. **S.1** Wire `clang-cpp-irep2-adjust-only` into
+   `solidity_languaget::typecheck` and report the divergence count over the 525
+   tests. Measured baseline, no porting. Gated on §2.1's measurement.
+2. **S.2** A read-only `migrate` census for the Solidity converter's output, as
+   `--clang-cpp-irep2-migrate-census` is for C++: run every value through
+   `get_value2()` and report what `migrate_expr` cannot represent. This is the
+   only way to price the converter before touching it, and it is the step
+   §15.1's void figure was trying to be.
+3. **S.3** The converter's construction sites, in the order the census ranks
+   them. `solidity_convert_call.cpp` and `solidity_convert_expr.cpp` are 39 %
+   of the surface between them.
+4. **S.4** Remove the legacy path once S.1's divergence count is zero.
+
+Steps S.1 and S.2 are both measurement, and both are cheap. Neither is
+committed to a porting order, deliberately: Phase 6 §60 found the adjuster's
+arms to be one strongly-coupled component that could not move singly, and Phase
+7 §3 found its pass was not extensible in the way Phase 6 assumed. A census
+first is the lesson those two paid for.
+
+## 4. Gates
+
+The parent's §7 gates apply unchanged. Two are worth restating for this phase:
+
+- **A census must show the thing under test executed.** §15.1's "14 tests, 0
+  declines" is void because nothing ran. Any figure this doc reports names the
+  command that produced it.
+- **`KNOWNBUG` and `FUTURE` rows cannot be read as green.** They accept a
+  timeout as satisfying the expectation, so a Solidity divergence count must
+  separate them out; `grep` for `accepted under KNOWNBUG` before reading a run
+  as clean.
+
+## 5. Risks
+
+| # | Risk |
+|---|---|
+| R1 | This phase's adjust half depends on Phase 7 closing. Wiring the flag before Phase 7's divergences are down exposes Solidity to all of them at once, which is why S.1 is a measurement and not a flip. |
+| R2 | The §2.1 restore can mask a seam loss on a library body. A divergence count taken without checking it may be optimistic. |
+| R3 | The `sol64` operational models are a second `c2goto`-compiled artefact, adjusted by `clang_c_adjust` at build time. The `building-c-library` exemptions that protect the C models have no Solidity analogue recorded, and Phase 6's name-matched-builtin section found one such exemption already unreachable from the IREP2 pass. |
+| R4 | 1 685 sites and zero head start make this the second-largest phase after Python. Its ordering before Python is the parent's §215 judgement and this doc does not revisit it. |
+| R5 | The two XPASS rows in §1.1 mean the suite's expectations are drifting from master. A divergence count is only meaningful against a suite whose baseline is green. |
+
+## 6. Next
+
+S.1 and S.2, in that order, each as its own change. Neither ports anything.


### PR DESCRIPTION
`frontends-to-irep2.md` §15.1 recorded Solidity as blocked, not zero: a decline
census got `ERROR: `' is not a goto-binary`, nothing ran, and the note concluded
the suite needed Linux CI. It runs here — `ctest -L esbmc-solidity` is 523 of
525, and the two remaining rows are `KNOWNBUG`s that now pass rather than
failures. Tests ship a pre-generated `contract.solast` and name it on their flags
line, so `solc` is not needed.

So Phase 8 opens with a census it can stand behind: 1685 legacy construction
sites over 23599 lines, and no `expr2tc`/`type2tc` anywhere, so no head start.
The finding that shapes the phase is that there is no Solidity adjust pass —
`solidity_languaget::typecheck` runs `clang_cpp_adjust`. Phase 7 therefore owns
that half, and Solidity's own work is entirely in the converter. It also does not
gate that adjuster on `clang-cpp-irep2-adjust-only`, so the 525 tests are not
measuring Phase 7 at all yet; wiring it through is the first step.

Refs #4715
