### PR TITLE
[python] Treat a bare Callable parameter as Any

### DIFF
--- a/regression/python/github_7672/main.py
+++ b/regression/python/github_7672/main.py
@@ -1,0 +1,18 @@
+# A bare `Callable` parameter resolved to a pointer whose code type returns
+# void, so the call through it carried no value and this assertion folded away.
+from typing import Callable
+
+
+def apply(g: Callable):
+    return g()
+
+
+def five() -> int:
+    return 5
+
+
+def main() -> None:
+    assert apply(five) == 5
+
+
+main()

--- a/regression/python/github_7672/test.desc
+++ b/regression/python/github_7672/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/regression/python/github_7672_fail/main.py
+++ b/regression/python/github_7672_fail/main.py
@@ -1,0 +1,18 @@
+# A bare `Callable` parameter resolved to a pointer whose code type returns
+# void, so the call through it carried no value and this assertion folded away.
+from typing import Callable
+
+
+def apply(g: Callable):
+    return g()
+
+
+def five() -> int:
+    return 5
+
+
+def main() -> None:
+    assert apply(five) == 6
+
+
+main()

--- a/regression/python/github_7672_fail/test.desc
+++ b/regression/python/github_7672_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION FAILED$

--- a/regression/python/github_7672_subscripted/main.py
+++ b/regression/python/github_7672_subscripted/main.py
@@ -1,0 +1,17 @@
+# A subscripted Callable spells its signature out and keeps it.
+from typing import Callable
+
+
+def apply(g: Callable[[], int]) -> int:
+    return g()
+
+
+def five() -> int:
+    return 5
+
+
+def main() -> None:
+    assert apply(five) == 5
+
+
+main()

--- a/regression/python/github_7672_subscripted/test.desc
+++ b/regression/python/github_7672_subscripted/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.py
+
+^VERIFICATION SUCCESSFUL$

--- a/src/python-frontend/converter/converter_funcdef.cpp
+++ b/src/python-frontend/converter/converter_funcdef.cpp
@@ -1396,6 +1396,30 @@ bool python_converter::try_infer_numpy_param_type(
   return false;
 }
 
+/// A `Callable` annotation with no `[[A], R]` signature, spelled either bare or
+/// through `typing`. A subscripted one carries its return type and is usable.
+static bool is_bare_callable_annotation(const nlohmann::json &ann)
+{
+  if (!ann.is_object())
+    return false;
+  const std::string kind = ann.value("_type", "");
+  if (kind == "Name")
+    return ann.value("id", "") == "Callable";
+  if (kind == "Attribute")
+    return ann.value("attr", "") == "Callable";
+  return false;
+}
+
+/// Whether the parameter takes the Any (void*) default: no annotation at all,
+/// or a bare `Callable`, which is worse than none (#7672).
+static bool parameter_defaults_to_any(const nlohmann::json &element)
+{
+  if (!element.contains("annotation") || element["annotation"].is_null())
+    return true;
+  return is_bare_callable_annotation(element["annotation"]);
+}
+
+
 size_t python_converter::register_function_argument(
   const nlohmann::json &element,
   code_typet &type,
@@ -1414,10 +1438,18 @@ size_t python_converter::register_function_argument(
     arg_type = gen_pointer_type(type_handler_.get_typet(current_class_name_));
   else
   {
-    if (!element.contains("annotation") || element["annotation"].is_null())
+    if (parameter_defaults_to_any(element))
     {
       // Python does not require type annotations; treat unannotated parameters
       // as Any (void*) to follow Python semantics.
+      //
+      // A bare `Callable` joins them: it resolves to a pointer whose code type
+      // returns void, so the call through the parameter carries no value and
+      // the caller's use of the result folds away (#7672). Any keeps the
+      // callee's own return type, which the unannotated form already does.
+      // converter_stmt.cpp's variable path defers a bare `Callable` for the
+      // same reason (#6640). A subscripted `Callable[[A], R]` spells its
+      // signature out and is left to get_type_from_annotation.
       arg_type = any_type();
     }
     else


### PR DESCRIPTION
`def apply(g: Callable): return g()` made the call through `g` carry no value,
so `apply(five) == 5` folded to false. Adding `-> int` turned the wrong answer
into `Unexpected type in int/ptr typecast` instead.

A bare `Callable` resolves to a pointer whose code type returns void, which is
worse than no annotation at all — the unannotated form types the parameter Any
and lets the callee's own return type through. `converter_stmt.cpp` already
defers a bare `Callable` on the variable path for this reason (#6640);
parameters now take the same Any default. A subscripted `Callable[[A], R]`
spells its signature out and is untouched.

Fixes #7672

Tests: `github_7672{,_fail}` and `github_7672_subscripted`, the last pinning
that a spelled signature still resolves. 311 callable/lambda/annotation tests
pass, and `scripts/check_python_tests.sh` is clean.
