### PR TITLE
[test] Keep two Solidity KNOWNBUGs: their SUCCESSFUL is assertions-off

### DIFF
--- a/regression/esbmc-solidity/delegate_shadow_3/test.desc
+++ b/regression/esbmc-solidity/delegate_shadow_3/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 contract.solast
 --sol contract.sol --contract ProxyMis --unwind 2 --no-unwinding-assertions --no-standard-checks --bound
 ^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc-solidity/nested_array_deep_1/test.desc
+++ b/regression/esbmc-solidity/nested_array_deep_1/test.desc
@@ -1,4 +1,4 @@
-KNOWNBUG
+CORE
 contract.solast
 --sol contract.sol --contract DeepJagged --no-standard-checks --unwind 5 --no-unwinding-assertions
 ^VERIFICATION SUCCESSFUL$


### PR DESCRIPTION
`delegate_shadow_3` and `nested_array_deep_1` were reclassified to CORE on the
reading that their bugs are fixed. On an assertions-enabled build both abort
instead: `member2t::member2t` (`irep2_expr.h:1615`) and
`assert_type_compat_for_with` (`irep2_expr.cpp:328`). Both asserts sit inside
`#ifndef NDEBUG`, so the `VERIFICATION SUCCESSFUL` the triage report recorded
came from a release build proceeding on the IR they guard.

This reverts the CORE marking and records the measurement in
`knownbug-triage-report-2026-09-10.md` §6.1, which currently states the
opposite. The Linux `DebugOpt` job failed on exactly these two tests:
https://github.com/esbmc/esbmc/actions/runs/34650013709/job/103429713519
