### PR TITLE
[regression] Pin the #5369 unresolved-pointer false alarm

### DIFF
--- a/regression/esbmc/github_5369/main.c
+++ b/regression/esbmc/github_5369/main.c
@@ -1,0 +1,34 @@
+/* Two reads of one location through a pointer rebuilt from bytes must agree.
+ * convert_typecast_to_ptr() matches the integer only against objects already in
+ * addr_space_data, so the read before `&later` was converted could not reach
+ * `later` and fell back to the invalid object, while the read after it could --
+ * equal addresses, unequal pointers (#5369). */
+#include <assert.h>
+#include <stdlib.h>
+
+unsigned char nondet_uchar(void);
+unsigned long nondet_ulong(void);
+
+int main(void)
+{
+  char *buf = malloc(16);
+  if (!buf)
+    return 0;
+  for (int i = 0; i < 16; i++)
+    buf[i] = nondet_uchar();
+
+  void *r1 = *(void **)buf;
+  int later;
+  _Bool hit = (unsigned long)r1 == (unsigned long)&later;
+
+  /* Write above the pointer's bytes: the reconstructed address cannot change. */
+  unsigned long j = nondet_ulong();
+  if (j < 8 || j >= 16)
+    return 0;
+  buf[j] = 0;
+
+  void *r2 = *(void **)buf;
+  if (hit)
+    assert(r1 == r2);
+  return 0;
+}

--- a/regression/esbmc/github_5369/test.desc
+++ b/regression/esbmc/github_5369/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 17
+^VERIFICATION SUCCESSFUL$

--- a/regression/esbmc/github_5369_fail/main.c
+++ b/regression/esbmc/github_5369_fail/main.c
@@ -1,0 +1,30 @@
+/* The counterpart to github_5369: the write lands *inside* the pointer's bytes,
+ * so the two reads genuinely differ and the equality must still be refuted. */
+#include <assert.h>
+#include <stdlib.h>
+
+unsigned char nondet_uchar(void);
+unsigned long nondet_ulong(void);
+
+int main(void)
+{
+  char *buf = malloc(16);
+  if (!buf)
+    return 0;
+  for (int i = 0; i < 16; i++)
+    buf[i] = nondet_uchar();
+
+  void *r1 = *(void **)buf;
+  int later;
+  _Bool hit = (unsigned long)r1 == (unsigned long)&later;
+
+  unsigned long j = nondet_ulong();
+  if (j >= 8)
+    return 0;
+  buf[j] = 0;
+
+  void *r2 = *(void **)buf;
+  if (hit)
+    assert(r1 == r2);
+  return 0;
+}

--- a/regression/esbmc/github_5369_fail/test.desc
+++ b/regression/esbmc/github_5369_fail/test.desc
@@ -1,0 +1,4 @@
+CORE
+main.c
+--unwind 17
+^VERIFICATION FAILED$

--- a/src/solvers/smt/smt_casts.cpp
+++ b/src/solvers/smt/smt_casts.cpp
@@ -545,6 +545,7 @@ smt_astt smt_solver_baset::convert_typecast_to_ptr(const typecast2t &cast)
       ptraddr_type2(), from_start, typecast2tc(ptraddr_type2(), ptr_offs));
     smt_astt addr = convert_ast(address);
     assert_ast(mk_implies(not_matched, addr->eq(this, target)));
+    tie_int_to_ptr_cast(target, output);
     return output;
   }
 
@@ -553,7 +554,25 @@ smt_astt smt_solver_baset::convert_typecast_to_ptr(const typecast2t &cast)
   smt_astt is_inv = mk_and(obj_eq, offs_eq);
 
   assert_ast(mk_implies(not_matched, is_inv));
+  tie_int_to_ptr_cast(target, output);
   return output;
+}
+
+/* An address determines a pointer: the address space lays objects out in
+ * disjoint ranges, so two reconstructions of the same integer denote the same
+ * (object, offset). The if-then-else chain above does not say so on its own,
+ * because it enumerates only the objects converted before it -- the same bytes
+ * read twice reconstruct to the invalid object before some object's address is
+ * converted and to that object afterwards, and the two compare unequal at equal
+ * addresses (#5369). Tying equal addresses together removes those models
+ * without widening any reconstruction's candidate set, which is what the
+ * invalid-pointer check reads. */
+void smt_solver_baset::tie_int_to_ptr_cast(smt_astt target, smt_astt output)
+{
+  for (const auto &[addr, ptr] : int_to_ptr_casts.back())
+    assert_ast(mk_implies(addr->eq(this, target), ptr->eq(this, output)));
+
+  int_to_ptr_casts.back().emplace_back(target, output);
 }
 
 smt_astt smt_solver_baset::convert_typecast_from_ptr(const typecast2t &cast)

--- a/src/solvers/smt/smt_solver.cpp
+++ b/src/solvers/smt/smt_solver.cpp
@@ -119,6 +119,7 @@ smt_solver_baset::smt_solver_baset(
   addr_space_arr_type = array_type2tc(addr_space_type, expr2tc(), true);
 
   addr_space_data.emplace_back();
+  int_to_ptr_casts.emplace_back();
 
   machine_ptr = get_uint_type(config.ansi_c.pointer_width()); /* CHERI-TODO */
 
@@ -193,6 +194,7 @@ void smt_solver_baset::push_ctx()
   array_api->push_array_ctx();
 
   addr_space_data.push_back(addr_space_data.back());
+  int_to_ptr_casts.push_back(int_to_ptr_casts.back());
   addr_space_sym_num.push_back(addr_space_sym_num.back());
   pointer_logic.push_back(pointer_logic.back());
   renumber_map.push_back(renumber_map.back());
@@ -269,6 +271,7 @@ void smt_solver_baset::pop_ctx()
   pointer_logic.pop_back();
   addr_space_sym_num.pop_back();
   addr_space_data.pop_back();
+  int_to_ptr_casts.pop_back();
   renumber_map.pop_back();
 
   ctx_level--;

--- a/src/solvers/smt/smt_solver.h
+++ b/src/solvers/smt/smt_solver.h
@@ -883,6 +883,9 @@ public:
   smt_astt convert_typecast_to_ints_from_bool(const typecast2t &cast);
   /** Typecast something (i.e. an integer) to a pointer */
   smt_astt convert_typecast_to_ptr(const typecast2t &cast);
+  /** Constrain a new int-to-ptr reconstruction to agree with every earlier
+   *  one that has the same address (#5369). */
+  void tie_int_to_ptr_cast(smt_astt target, smt_astt output);
   /** Typecast a pointer to an integer */
   smt_astt convert_typecast_from_ptr(const typecast2t &cast);
   /** Typecast structs to other structs */
@@ -1107,6 +1110,12 @@ public:
    *  the nubmer of bytes allocated. In a list to support pushing and
    *  popping. */
   std::list<std::map<unsigned, unsigned>> addr_space_data;
+
+  /** Every int-to-ptr reconstruction converted so far, as (address, pointer)
+   *  pairs, so that convert_typecast_to_ptr() can tie reconstructions with
+   *  equal addresses to equal pointers (#5369). In a list to support pushing
+   *  and popping. */
+  std::list<std::vector<std::pair<smt_astt, smt_astt>>> int_to_ptr_casts;
 
   /** Holds the `__ESBMC_alloc` symbol convert_terminal() was last invoked with.
    */


### PR DESCRIPTION
Two reads of one location through a pointer the value-set cannot resolve can
disagree, because `make_failed_symbol` mints a fresh free value per read
(#5369). The two fixes this PR carried are both unsound and are reverted here:
the int-to-ptr tie prunes reachable models whenever two reconstructions
enumerate different objects, and is entailed when they do not; sharing the free
value keyed on the pointer and the read type misses a write through that
pointer and merges distinct fields.

What is left is the pin. `github_5369_scalar` is the minimal false alarm,
KNOWNBUG until it is fixed; `github_5369_scalar_fail`, `github_5369_write_fail`
and `github_5369_fields_fail` expect FAILED and guard the three unsound
directions. `github_5369{,_fail}` are dropped -- `assert(r1 == r2)` and
`assert(r1 != r2)` are both SUCCESSFUL on master, so neither pins anything.